### PR TITLE
[codex] Update LDA HSI production status copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Useful commands:
 
 ## Immediate Next Steps
 
-- Manually review the professional three-panel workbench and clustering
-  diagnostics before any production redeploy
+- Review the deployed professional workbench and clustering diagnostics
+  on `https://lda-hsi.fasl-work.com` before the next iteration
 - Extend the new PCA/KMeans diagnostics into topic stability, seed
   comparison, and representation-comparison reports
 - Add ECOSTRESS and satellite/UAV curated subsets after direct access,
@@ -143,5 +143,5 @@ Useful commands:
   vectors where available
 - Extend real-scene modelling to compare multiple document encodings on
   the downloaded public scenes, not only on the synthetic demo
-- Keep production deploys paused until local build, API smoke tests, and
-  visual checks pass
+- Keep future production deploys gated by local build, API smoke tests,
+  public smoke tests, and visual checks

--- a/docs/technical-roadmap.md
+++ b/docs/technical-roadmap.md
@@ -26,8 +26,8 @@ Problem:
 
 ## Phase 1: Professional Workbench
 
-Status: implemented locally; pending manual visual review before
-production redeploy.
+Status: implemented and deployed on the 2026-04-30 main release; pending
+continued manual product review for the next iteration.
 
 Acceptance criteria:
 
@@ -42,13 +42,14 @@ Acceptance criteria:
 - Light/dark mode works.
 - Public repository link is visible.
 - Backend payload may grow only when the workbench needs a new data
-  surface. The current local pass added `spectral_library`.
+  surface. The current release includes `spectral_library` and
+  `analysis`.
 - A compact help/status modal is available from the header.
 - The spectral-library navigator participates in the main search filter.
 - Scene topic matrices and nearest spectral-library reference comparisons
-  are implemented locally.
-- Compact PCA/KMeans clustering diagnostics are implemented locally for
-  real-scene topic mixtures and spectral-library reference spectra.
+  are implemented and deployed.
+- Compact PCA/KMeans clustering diagnostics are implemented and deployed
+  for real-scene topic mixtures and spectral-library reference spectra.
 
 ## Phase 2: Dataset Expansion
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -107,7 +107,7 @@
   "helpSpectralLibrary": "Compact USGS spectral-library references are available as local derived assets.",
   "helpSceneMatrix": "Real scenes expose topic-mixture matrices and inferred topic-stratum previews when labels are unavailable.",
   "helpClusterDiagnostics": "Topic-space and spectral-library PCA/KMeans diagnostics are generated as compact derived assets.",
-  "helpNoDeploy": "Production has not been redeployed from this branch.",
+  "helpNoDeploy": "Production is deployed from the validated main release.",
   "dataState": "Data state",
   "sceneTopicMatrix": "Scene topic matrix",
   "largestRegimes": "largest regimes",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -107,7 +107,7 @@
   "helpSpectralLibrary": "Referencias compactas de la libreria espectral USGS estan disponibles como activos derivados locales.",
   "helpSceneMatrix": "Las escenas reales exponen matrices de mezcla de topicos y previews de estratos inferidos cuando no hay etiquetas.",
   "helpClusterDiagnostics": "Diagnosticos PCA/KMeans en espacio de topicos y libreria espectral se generan como activos derivados compactos.",
-  "helpNoDeploy": "Produccion no ha sido redesplegada desde esta rama.",
+  "helpNoDeploy": "Produccion esta desplegada desde la release validada en main.",
   "dataState": "Estado de datos",
   "sceneTopicMatrix": "Matriz de topicos de escena",
   "largestRegimes": "regimenes mayores",


### PR DESCRIPTION
﻿## Summary

Post-deploy copy correction after the validated production release:

- updates the help modal so it no longer claims production has not been redeployed
- updates README and roadmap language to reflect that the scientific workbench is live on `main`

## Validation

- `./scripts/local.ps1 build`
- local FastAPI smoke on `http://127.0.0.1:8119`

## Deploy Status

Deploy after merge so the public help modal reflects the current production state.
