### PR TITLE
Wrap heavy builders with MLflow (closes #14)

### DIFF
--- a/data-pipeline/build_external_validation.py
+++ b/data-pipeline/build_external_validation.py
@@ -30,7 +30,12 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
 from research_core.paths import DATA_DIR, DERIVED_DIR
+from _mlflow_helper import mlflow_run
 
 
 METHOD_STATS_DIR = DERIVED_DIR / "method_statistics_hidsag"
@@ -221,57 +226,78 @@ def main() -> int:
         library_samples = json.load(LIBRARY_PATH.open("r", encoding="utf-8")).get("samples", [])
         for scene_id in LABELLED_SCENES:
             print(f"[external_validation] {scene_id} (literature) ...", flush=True)
-            try:
-                payload = topic_to_literature_for_scene(scene_id, library_samples)
-            except Exception as exc:
-                print(f"  FAILED: {exc}", flush=True)
-                continue
-            if payload is None:
-                print("  skipped", flush=True)
-                continue
-            out_path = OUTPUT_DIR / f"{scene_id}_literature.json"
-            with out_path.open("w", encoding="utf-8") as h:
-                json.dump(payload, h, separators=(",", ":"))
-            best = max(
-                payload["per_topic_alignment"],
-                key=lambda e: e["best_cosine"] if e.get("best_cosine") else 0.0,
-            )
-            print(
-                f"  K={payload['topic_count']} best topic={best['topic_k']} "
-                f"-> {best['best_literature_category']} ({best['best_cosine']:.3f})",
-                flush=True,
-            )
-            written += 1
+            with mlflow_run(
+                "build_external_validation",
+                scene_id=scene_id,
+                tags={"phase": "literature"},
+            ) as run:
+                try:
+                    payload = topic_to_literature_for_scene(scene_id, library_samples)
+                except Exception as exc:
+                    print(f"  FAILED: {exc}", flush=True)
+                    continue
+                if payload is None:
+                    print("  skipped", flush=True)
+                    continue
+                out_path = OUTPUT_DIR / f"{scene_id}_literature.json"
+                with out_path.open("w", encoding="utf-8") as h:
+                    json.dump(payload, h, separators=(",", ":"))
+                best = max(
+                    payload["per_topic_alignment"],
+                    key=lambda e: e["best_cosine"] if e.get("best_cosine") else 0.0,
+                )
+                run.log_metric("topic_count", float(payload["topic_count"]))
+                run.log_metric(
+                    "best_topic_cosine", float(best.get("best_cosine") or 0.0)
+                )
+                run.log_artifact(str(out_path))
+                print(
+                    f"  K={payload['topic_count']} best topic={best['topic_k']} "
+                    f"-> {best['best_literature_category']} ({best['best_cosine']:.3f})",
+                    flush=True,
+                )
+                written += 1
 
     # HIDSAG method comparison summary (Friedman + Nemenyi)
     for subset_code in HIDSAG_SUBSETS:
         print(f"[external_validation] {subset_code} (HIDSAG methods) ...", flush=True)
-        try:
-            payload = hidsag_method_summary(subset_code)
-        except Exception as exc:
-            print(f"  FAILED: {exc}", flush=True)
-            continue
-        if payload is None:
-            print("  skipped (no method_statistics_hidsag yet)", flush=True)
-            continue
-        out_path = OUTPUT_DIR / f"{subset_code}_methods.json"
-        with out_path.open("w", encoding="utf-8") as h:
-            json.dump(payload, h, separators=(",", ":"))
-        if payload.get("regression"):
-            r = payload["regression"]
-            print(
-                f"  REG  best={r['best_method']} R2={r['best_r2_mean']:.3f} "
-                f"CI95={r['best_r2_ci95']}",
-                flush=True,
-            )
-        if payload.get("classification"):
-            c = payload["classification"]
-            print(
-                f"  CLS  best={c['best_method']} F1={c['best_macro_f1_mean']:.3f} "
-                f"CI95={c['best_macro_f1_ci95']}",
-                flush=True,
-            )
-        written += 1
+        with mlflow_run(
+            "build_external_validation",
+            scene_id=subset_code,
+            tags={"phase": "hidsag_methods"},
+        ) as run:
+            try:
+                payload = hidsag_method_summary(subset_code)
+            except Exception as exc:
+                print(f"  FAILED: {exc}", flush=True)
+                continue
+            if payload is None:
+                print("  skipped (no method_statistics_hidsag yet)", flush=True)
+                continue
+            out_path = OUTPUT_DIR / f"{subset_code}_methods.json"
+            with out_path.open("w", encoding="utf-8") as h:
+                json.dump(payload, h, separators=(",", ":"))
+            if payload.get("regression"):
+                r = payload["regression"]
+                run.log_metric("regression_best_r2_mean", float(r["best_r2_mean"]))
+                print(
+                    f"  REG  best={r['best_method']} R2={r['best_r2_mean']:.3f} "
+                    f"CI95={r['best_r2_ci95']}",
+                    flush=True,
+                )
+            if payload.get("classification"):
+                c = payload["classification"]
+                run.log_metric(
+                    "classification_best_macro_f1_mean",
+                    float(c["best_macro_f1_mean"]),
+                )
+                print(
+                    f"  CLS  best={c['best_method']} F1={c['best_macro_f1_mean']:.3f} "
+                    f"CI95={c['best_macro_f1_ci95']}",
+                    flush=True,
+                )
+            run.log_artifact(str(out_path))
+            written += 1
 
     print(f"[external_validation] done — {written} payloads written.", flush=True)
     return 0

--- a/data-pipeline/build_lda_sweep.py
+++ b/data-pipeline/build_lda_sweep.py
@@ -28,6 +28,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
 from research_core.class_catalog import has_labels
 from research_core.paths import DATA_DIR, DERIVED_DIR
 from research_core.raw_scenes import (
@@ -36,6 +40,7 @@ from research_core.raw_scenes import (
     stratified_sample_indices,
     valid_spectra_mask,
 )
+from _mlflow_helper import mlflow_run
 
 
 DERIVED_OUT_DIR = DERIVED_DIR / "lda_sweep"
@@ -245,28 +250,56 @@ def main() -> int:
     written = 0
     for scene_id in LABELLED_SCENES:
         print(f"[lda_sweep] {scene_id} ...", flush=True)
-        try:
-            payload = build_for_scene(scene_id)
-        except Exception as exc:
-            print(f"  FAILED: {exc}", flush=True)
-            import traceback
-            traceback.print_exc()
-            continue
-        if payload is None:
-            print("  skipped", flush=True)
-            continue
-        out_path = DERIVED_OUT_DIR / f"{scene_id}.json"
-        with out_path.open("w", encoding="utf-8") as handle:
-            json.dump(payload, handle, separators=(",", ":"))
-        # Show brief grid
-        for r in payload["grid"]:
-            print(
-                f"  K={r['K']:2d}  perp_test={r['perplexity_test_mean']:.2f} "
-                f"NPMI={r['npmi_mean']:+.3f}  stability={r['matched_cosine_mean']:.3f}",
-                flush=True,
-            )
-        print(f"  -> recommended K = {payload['recommended_K']}", flush=True)
-        written += 1
+        with mlflow_run(
+            "build_lda_sweep",
+            scene_id=scene_id,
+            params={
+                "K_grid": ",".join(str(k) for k in K_GRID),
+                "n_seeds": len(SEEDS),
+                "samples_per_class": SAMPLES_PER_CLASS,
+                "wordification": "band-frequency",
+                "quantization_scale": SCALE,
+                "train_fraction": TRAIN_FRAC,
+            },
+        ) as run:
+            try:
+                payload = build_for_scene(scene_id)
+            except Exception as exc:
+                print(f"  FAILED: {exc}", flush=True)
+                import traceback
+                traceback.print_exc()
+                continue
+            if payload is None:
+                print("  skipped", flush=True)
+                continue
+            out_path = DERIVED_OUT_DIR / f"{scene_id}.json"
+            with out_path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, separators=(",", ":"))
+            # Log headline metrics: best K and per-K aggregates
+            run.log_metric("recommended_K", float(payload["recommended_K"]))
+            for r in payload["grid"]:
+                K = r["K"]
+                if r["perplexity_test_mean"] is not None:
+                    run.log_metric(
+                        "perplexity_test_mean", r["perplexity_test_mean"], step=K
+                    )
+                run.log_metric("npmi_mean", r["npmi_mean"], step=K)
+                run.log_metric(
+                    "matched_cosine_mean", r["matched_cosine_mean"], step=K
+                )
+                run.log_metric(
+                    "topic_diversity_mean", r["topic_diversity_mean"], step=K
+                )
+            run.log_artifact(str(out_path))
+            # Show brief grid
+            for r in payload["grid"]:
+                print(
+                    f"  K={r['K']:2d}  perp_test={r['perplexity_test_mean']:.2f} "
+                    f"NPMI={r['npmi_mean']:+.3f}  stability={r['matched_cosine_mean']:.3f}",
+                    flush=True,
+                )
+            print(f"  -> recommended K = {payload['recommended_K']}", flush=True)
+            written += 1
     print(f"[lda_sweep] done — {written} scenes written.", flush=True)
     return 0
 

--- a/data-pipeline/build_method_statistics_hidsag.py
+++ b/data-pipeline/build_method_statistics_hidsag.py
@@ -44,7 +44,12 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
 from research_core.paths import DERIVED_DIR
+from _mlflow_helper import mlflow_run
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -298,50 +303,66 @@ def main() -> int:
     core = json.load(CORE_BENCHMARKS_PATH.open("r", encoding="utf-8"))
     runs = core.get("measured_target_runs", []) or []
     written = 0
-    for run in runs:
-        code = run.get("subset_code")
+    for run_record in runs:
+        code = run_record.get("subset_code")
         if not code:
             continue
         print(f"[method_stats_hidsag] {code} ...", flush=True)
-        try:
-            payload = aggregate_subset(run)
-        except Exception as exc:
-            print(f"  FAILED: {exc}", flush=True)
-            import traceback
-            traceback.print_exc()
-            continue
-        out_path = DERIVED_OUT_DIR / f"{code}.json"
-        with out_path.open("w", encoding="utf-8") as h:
-            json.dump(payload, h, separators=(",", ":"))
+        with mlflow_run("build_method_statistics_hidsag", scene_id=code) as mlrun:
+            try:
+                payload = aggregate_subset(run_record)
+            except Exception as exc:
+                print(f"  FAILED: {exc}", flush=True)
+                import traceback
+                traceback.print_exc()
+                continue
+            out_path = DERIVED_OUT_DIR / f"{code}.json"
+            with out_path.open("w", encoding="utf-8") as h:
+                json.dump(payload, h, separators=(",", ":"))
 
-        # Brief headline
-        if payload["regression"]:
-            block = payload["regression"]
-            best_method = max(
-                block["method_aggregates"].items(),
-                key=lambda kv: (kv[1]["r2_distribution"]["mean"]
-                                if kv[1]["r2_distribution"]["mean"] is not None else -np.inf),
-            )
-            f = block["friedman_nemenyi"].get("friedman") if block.get("friedman_nemenyi") else None
-            print(
-                f"  REG  best={best_method[0]} (R2 mean={best_method[1]['r2_distribution']['mean']:.3f}); "
-                f"Friedman p={f['p_value'] if f else 'NA'}",
-                flush=True,
-            )
-        if payload["classification"]:
-            block = payload["classification"]
-            best_method = max(
-                block["method_aggregates"].items(),
-                key=lambda kv: (kv[1]["macro_f1_distribution"]["mean"]
-                                if kv[1]["macro_f1_distribution"]["mean"] is not None else -np.inf),
-            )
-            f = block["friedman_nemenyi"].get("friedman") if block.get("friedman_nemenyi") else None
-            print(
-                f"  CLS  best={best_method[0]} (F1 mean={best_method[1]['macro_f1_distribution']['mean']:.3f}); "
-                f"Friedman p={f['p_value'] if f else 'NA'}",
-                flush=True,
-            )
-        written += 1
+            # Brief headline + MLflow metrics
+            if payload["regression"]:
+                block = payload["regression"]
+                best_method = max(
+                    block["method_aggregates"].items(),
+                    key=lambda kv: (kv[1]["r2_distribution"]["mean"]
+                                    if kv[1]["r2_distribution"]["mean"] is not None else -np.inf),
+                )
+                f = block["friedman_nemenyi"].get("friedman") if block.get("friedman_nemenyi") else None
+                if best_method[1]["r2_distribution"]["mean"] is not None:
+                    mlrun.log_metric(
+                        "regression_best_r2_mean",
+                        float(best_method[1]["r2_distribution"]["mean"]),
+                    )
+                if f and f.get("p_value") is not None:
+                    mlrun.log_metric("regression_friedman_p", float(f["p_value"]))
+                print(
+                    f"  REG  best={best_method[0]} (R2 mean={best_method[1]['r2_distribution']['mean']:.3f}); "
+                    f"Friedman p={f['p_value'] if f else 'NA'}",
+                    flush=True,
+                )
+            if payload["classification"]:
+                block = payload["classification"]
+                best_method = max(
+                    block["method_aggregates"].items(),
+                    key=lambda kv: (kv[1]["macro_f1_distribution"]["mean"]
+                                    if kv[1]["macro_f1_distribution"]["mean"] is not None else -np.inf),
+                )
+                f = block["friedman_nemenyi"].get("friedman") if block.get("friedman_nemenyi") else None
+                if best_method[1]["macro_f1_distribution"]["mean"] is not None:
+                    mlrun.log_metric(
+                        "classification_best_macro_f1_mean",
+                        float(best_method[1]["macro_f1_distribution"]["mean"]),
+                    )
+                if f and f.get("p_value") is not None:
+                    mlrun.log_metric("classification_friedman_p", float(f["p_value"]))
+                print(
+                    f"  CLS  best={best_method[0]} (F1 mean={best_method[1]['macro_f1_distribution']['mean']:.3f}); "
+                    f"Friedman p={f['p_value'] if f else 'NA'}",
+                    flush=True,
+                )
+            mlrun.log_artifact(str(out_path))
+            written += 1
     print(f"[method_stats_hidsag] done — {written} subsets written.", flush=True)
     return 0
 

--- a/data-pipeline/build_optuna_hyperparam_search.py
+++ b/data-pipeline/build_optuna_hyperparam_search.py
@@ -33,6 +33,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
 from research_core.class_catalog import has_labels
 from research_core.paths import DATA_DIR, DERIVED_DIR
 from research_core.raw_scenes import (
@@ -42,6 +46,7 @@ from research_core.raw_scenes import (
     stratified_sample_indices,
     valid_spectra_mask,
 )
+from _mlflow_helper import mlflow_run
 
 warnings.filterwarnings("ignore")
 optuna.logging.set_verbosity(optuna.logging.WARNING)
@@ -200,26 +205,42 @@ def main() -> int:
     written = 0
     for scene_id in LABELLED_SCENES:
         print(f"[optuna] {scene_id} ...", flush=True)
-        try:
-            payload = build_for_scene(scene_id)
-        except Exception as exc:
-            print(f"  FAILED: {exc}", flush=True)
-            import traceback
-            traceback.print_exc()
-            continue
-        if payload is None:
-            print("  skipped", flush=True)
-            continue
-        out_path = DERIVED_OUT_DIR / f"{scene_id}.json"
-        with out_path.open("w", encoding="utf-8") as h:
-            json.dump(payload, h, separators=(",", ":"))
-        bp = payload["best_params"]
-        print(
-            f"  best K={bp['K']} alpha={bp['alpha']:.3f} eta={bp['eta']:.3f} "
-            f"objective={payload['best_value']:.4f}",
-            flush=True,
-        )
-        written += 1
+        with mlflow_run(
+            "build_optuna_hyperparam_search",
+            scene_id=scene_id,
+            params={
+                "n_trials": N_TRIALS,
+                "samples_per_class": SAMPLES_PER_CLASS,
+                "scale": SCALE,
+                "train_fraction": TRAIN_FRAC,
+                "random_state": RANDOM_STATE,
+            },
+        ) as run:
+            try:
+                payload = build_for_scene(scene_id)
+            except Exception as exc:
+                print(f"  FAILED: {exc}", flush=True)
+                import traceback
+                traceback.print_exc()
+                continue
+            if payload is None:
+                print("  skipped", flush=True)
+                continue
+            out_path = DERIVED_OUT_DIR / f"{scene_id}.json"
+            with out_path.open("w", encoding="utf-8") as h:
+                json.dump(payload, h, separators=(",", ":"))
+            bp = payload["best_params"]
+            run.log_metric("best_value", float(payload["best_value"]))
+            run.log_metric("best_K", float(bp["K"]))
+            run.log_metric("best_alpha", float(bp["alpha"]))
+            run.log_metric("best_eta", float(bp["eta"]))
+            run.log_artifact(str(out_path))
+            print(
+                f"  best K={bp['K']} alpha={bp['alpha']:.3f} eta={bp['eta']:.3f} "
+                f"objective={payload['best_value']:.4f}",
+                flush=True,
+            )
+            written += 1
     print(f"[optuna] done — {written} scenes written.", flush=True)
     return 0
 

--- a/data-pipeline/build_topic_model_variants.py
+++ b/data-pipeline/build_topic_model_variants.py
@@ -52,6 +52,10 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
 from research_core.class_catalog import has_labels
 from research_core.paths import DATA_DIR, DERIVED_DIR
 from research_core.raw_scenes import (
@@ -61,6 +65,7 @@ from research_core.raw_scenes import (
     stratified_sample_indices,
     valid_spectra_mask,
 )
+from _mlflow_helper import mlflow_run
 
 
 LOCAL_OUT_ROOT = DATA_DIR / "local" / "topic_variants"
@@ -525,14 +530,39 @@ def main() -> int:
     written_total = 0
     for scene_id in LABELLED_SCENES:
         print(f"[topic_variants] {scene_id} ...", flush=True)
-        try:
-            summaries = build_for_scene(scene_id)
-        except Exception as exc:
-            print(f"  FAILED: {exc}", flush=True)
-            import traceback
-            traceback.print_exc()
-            continue
-        written_total += len(summaries)
+        with mlflow_run(
+            "build_topic_model_variants",
+            scene_id=scene_id,
+            params={
+                "samples_per_class": SAMPLES_PER_CLASS,
+                "scale": SCALE,
+                "top_n_words": TOP_N_WORDS,
+                "top_n_npmi": TOP_N_NPMI,
+                "random_state": RANDOM_STATE,
+            },
+        ) as run:
+            try:
+                summaries = build_for_scene(scene_id)
+            except Exception as exc:
+                print(f"  FAILED: {exc}", flush=True)
+                import traceback
+                traceback.print_exc()
+                continue
+            for summary in summaries:
+                variant = summary.get("variant_id") or summary.get("variant") or "?"
+                cv = summary.get("coherence_c_v")
+                um = summary.get("coherence_u_mass")
+                npmi = summary.get("coherence_npmi")
+                perp = summary.get("perplexity")
+                if cv is not None:
+                    run.log_metric(f"{variant}_c_v", float(cv))
+                if um is not None:
+                    run.log_metric(f"{variant}_u_mass", float(um))
+                if npmi is not None:
+                    run.log_metric(f"{variant}_npmi", float(npmi))
+                if perp is not None:
+                    run.log_metric(f"{variant}_perplexity", float(perp))
+            written_total += len(summaries)
     print(
         f"[topic_variants] done — {written_total} (variant x scene) outputs.",
         flush=True,


### PR DESCRIPTION
Closes #14.

## Summary
Wraps each per-scene / per-subset run of the five heavy builders with the existing `_mlflow_helper.mlflow_run()` context manager. No-op when mlflow is not importable, so fully backwards-compatible. Default tracking URI: `data/local/mlruns/` (gitignored). Experiment: `caos-lda-hsi`. Both overridable via env vars.

## Coverage

| Builder | Run unit | Headline metrics |
|---|---|---|
| `build_lda_sweep` | per scene | `recommended_K`, per-K `perplexity_test_mean` / `npmi_mean` / `matched_cosine_mean` / `topic_diversity_mean` (step=K) |
| `build_optuna_hyperparam_search` | per scene | `best_value`, `best_K`, `best_alpha`, `best_eta` |
| `build_external_validation` | per scene (literature) + per subset (HIDSAG) | `best_topic_cosine`, `regression_best_r2_mean`, `classification_best_macro_f1_mean` |
| `build_method_statistics_hidsag` | per subset | `regression_best_r2_mean`, `classification_best_macro_f1_mean`, Friedman p-values |
| `build_topic_model_variants` | per scene | per-variant `c_v` / `u_mass` / `npmi` / `perplexity` |

Output JSONs are uploaded as run artifacts (except for `build_topic_model_variants` whose per-variant outputs are too granular for run-level artifact upload).

## Test plan
- [x] `ast.parse` clean across all 5 modified files
- [x] `from _mlflow_helper import mlflow_run` resolves in each builder under the pipeline venv (verified by importing each module)
- [x] `mlflow_run` returns the no-op stub if `mlflow` import fails — existing builders that don't import this stay backwards-compatible per the helper's docstring