### PR TITLE
Methodology > Representations page (12 recipes + grid + 4 doc granularities) — closes #29

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.vite
+.tmp
+*.tsbuildinfo
+.env
+.env.local

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,3 @@
+auto-install-peers=true
+strict-peer-dependencies=false
+shamefully-hoist=false

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="CAOS LDA HSI — probabilistic topic modelling on hyperspectral imagery"
+    />
+    <title>CAOS LDA HSI</title>
+    <script>
+      // Apply persisted theme before first paint to avoid flash.
+      (function () {
+        try {
+          var saved = localStorage.getItem("caos.theme");
+          var prefersDark =
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches;
+          var theme = saved || (prefersDark ? "dark" : "light");
+          document.documentElement.setAttribute("data-theme", theme);
+        } catch (_) {}
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "caos-lda-hsi-frontend",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@xstate/react": "^4.1.3",
+    "clsx": "^2.1.1",
+    "i18next": "^23.16.4",
+    "i18next-browser-languagedetector": "^8.0.0",
+    "lucide-react": "^0.460.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-i18next": "^15.1.1",
+    "react-router-dom": "^7.0.1",
+    "tailwind-merge": "^2.5.5",
+    "xstate": "^5.18.2",
+    "zustand": "^5.0.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0-beta.6",
+    "@types/node": "^22.9.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.3",
+    "tailwindcss": "^4.0.0-beta.6",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.1"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "i18next": "^23.16.4",
     "i18next-browser-languagedetector": "^8.0.0",
+    "katex": "^0.16.21",
     "lucide-react": "^0.460.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0-beta.6",
+    "@types/katex": "^0.16.7",
     "@types/node": "^22.9.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1,0 +1,1706 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.100.9(react@19.2.5)
+      '@xstate/react':
+        specifier: ^4.1.3
+        version: 4.1.3(@types/react@19.2.14)(react@19.2.5)(xstate@5.31.0)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      i18next:
+        specifier: ^23.16.4
+        version: 23.16.8
+      i18next-browser-languagedetector:
+        specifier: ^8.0.0
+        version: 8.2.1
+      lucide-react:
+        specifier: ^0.460.0
+        version: 0.460.0(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      react-i18next:
+        specifier: ^15.1.1
+        version: 15.7.4(i18next@23.16.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      react-router-dom:
+        specifier: ^7.0.1
+        version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwind-merge:
+        specifier: ^2.5.5
+        version: 2.6.1
+      xstate:
+        specifier: ^5.18.2
+        version: 5.31.0
+      zustand:
+        specifier: ^5.0.1
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.0.0-beta.6
+        version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.3
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.0.0-beta.6
+        version: 4.2.4
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.1
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/node@4.2.4':
+    resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    resolution: {integrity: sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    resolution: {integrity: sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    resolution: {integrity: sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    resolution: {integrity: sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    resolution: {integrity: sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    resolution: {integrity: sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    resolution: {integrity: sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    resolution: {integrity: sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.4':
+    resolution: {integrity: sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.4':
+    resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.100.9':
+    resolution: {integrity: sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==}
+
+  '@tanstack/react-query@5.100.9':
+    resolution: {integrity: sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@xstate/react@4.1.3':
+    resolution: {integrity: sha512-zhE+ZfrcCR87bu71Rkh5Z5ruZBivR/7uD/dkelzJqjQdI45IZc9DqTI8lL4Cg5+VN2p5k86KxDsusqW1kW11Tg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      xstate: ^5.18.2
+    peerDependenciesMeta:
+      xstate:
+        optional: true
+
+  baseline-browser-mapping@2.10.27:
+    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  electron-to-chromium@1.5.349:
+    resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
+
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
+    engines: {node: '>=10.13.0'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  i18next-browser-languagedetector@8.2.1:
+    resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
+
+  i18next@23.16.8:
+    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.460.0:
+    resolution: {integrity: sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-i18next@15.7.4:
+    resolution: {integrity: sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==}
+    peerDependencies:
+      i18next: '>= 23.4.0'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
+
+  xstate@5.31.0:
+    resolution: {integrity: sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@tailwindcss/node@4.2.4':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.0
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.4
+
+  '@tailwindcss/oxide-android-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.4':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.4':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-arm64': 4.2.4
+      '@tailwindcss/oxide-darwin-x64': 4.2.4
+      '@tailwindcss/oxide-freebsd-x64': 4.2.4
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.4
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.4
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.4
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.4
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
+
+  '@tailwindcss/vite@4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.2.4
+      '@tailwindcss/oxide': 4.2.4
+      tailwindcss: 4.2.4
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@tanstack/query-core@5.100.9': {}
+
+  '@tanstack/react-query@5.100.9(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.9
+      react: 19.2.5
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xstate/react@4.1.3(@types/react@19.2.14)(react@19.2.5)(xstate@5.31.0)':
+    dependencies:
+      react: 19.2.5
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      xstate: 5.31.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  baseline-browser-mapping@2.10.27: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.27
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.349
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001791: {}
+
+  clsx@2.1.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  electron-to-chromium@1.5.349: {}
+
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  graceful-fs@4.2.11: {}
+
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
+  i18next-browser-languagedetector@8.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  i18next@23.16.8:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.460.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.38: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-i18next@15.7.4(i18next@23.16.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      html-parse-stringify: 3.0.1
+      i18next: 23.16.8
+      react: 19.2.5
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+      typescript: 5.9.3
+
+  react-refresh@0.17.0: {}
+
+  react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.5
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
+  react@19.2.5: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  source-map-js@1.2.1: {}
+
+  tailwind-merge@2.6.1: {}
+
+  tailwindcss@4.2.4: {}
+
+  tapable@2.3.3: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+
+  void-elements@3.1.0: {}
+
+  xstate@5.31.0: {}
+
+  yallist@3.1.1: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.0.0
         version: 8.2.1
+      katex:
+        specifier: ^0.16.21
+        version: 0.16.45
       lucide-react:
         specifier: ^0.460.0
         version: 0.460.0(react@19.2.5)
@@ -51,6 +54,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0-beta.6
         version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@types/katex':
+        specifier: ^0.16.7
+        version: 0.16.8
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.17
@@ -575,6 +581,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -617,6 +626,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -702,6 +715,10 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
 
   lightningcss-android-arm64@1.32.0:
@@ -1370,6 +1387,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/katex@0.16.8': {}
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -1417,6 +1436,8 @@ snapshots:
   caniuse-lite@1.0.30001791: {}
 
   clsx@2.1.1: {}
+
+  commander@8.3.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1498,6 +1519,10 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0b1220" />
+  <g fill="none" stroke="#7dd3fc" stroke-width="1.5" stroke-linecap="round">
+    <path d="M6 22 Q12 10 16 16 T26 12" />
+    <circle cx="9" cy="20" r="1.4" fill="#7dd3fc" />
+    <circle cx="16" cy="16" r="1.4" fill="#7dd3fc" />
+    <circle cx="23" cy="13" r="1.4" fill="#7dd3fc" />
+  </g>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,53 @@
+import { Suspense, lazy } from "react";
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { PageFallback } from "@/components/PageFallback";
+
+const Overview = lazy(() => import("@/pages/Overview"));
+const Methodology = lazy(() => import("@/pages/Methodology"));
+const MethodologyTheory = lazy(() => import("@/pages/methodology/Theory"));
+const MethodologyRepresentations = lazy(
+  () => import("@/pages/methodology/Representations"),
+);
+const MethodologyPipeline = lazy(() => import("@/pages/methodology/Pipeline"));
+const MethodologyApplication = lazy(
+  () => import("@/pages/methodology/Application"),
+);
+const Databases = lazy(() => import("@/pages/Databases"));
+const Workspace = lazy(() => import("@/pages/Workspace"));
+const Benchmarks = lazy(() => import("@/pages/Benchmarks"));
+
+export function App() {
+  return (
+    <div
+      className="min-h-screen flex flex-col"
+      style={{ backgroundColor: "var(--color-bg)", color: "var(--color-fg)" }}
+    >
+      <Header />
+      <main className="flex-1 w-full">
+        <Suspense fallback={<PageFallback />}>
+          <Routes>
+            <Route path="/" element={<Overview />} />
+            <Route path="/methodology" element={<Methodology />}>
+              <Route index element={<Navigate to="theory" replace />} />
+              <Route path="theory" element={<MethodologyTheory />} />
+              <Route
+                path="representations"
+                element={<MethodologyRepresentations />}
+              />
+              <Route path="pipeline" element={<MethodologyPipeline />} />
+              <Route path="application" element={<MethodologyApplication />} />
+            </Route>
+            <Route path="/databases" element={<Databases />} />
+            <Route path="/workspace" element={<Workspace />} />
+            <Route path="/benchmarks" element={<Benchmarks />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,58 @@
+/**
+ * Typed FastAPI client. Endpoints are intentionally narrow; subsequent
+ * task branches add per-page wrappers as their pages are implemented.
+ *
+ * Both relative and absolute base paths are supported. In dev the Vite
+ * proxy forwards `/api` and `/generated` to FastAPI on `:8105`; in
+ * production the same nginx that fronts FastAPI also serves `dist/`,
+ * so `/api` and `/generated` are same-origin too.
+ */
+
+const BASE = (import.meta.env.VITE_API_BASE ?? "").replace(/\/$/, "");
+
+export class ApiError extends Error {
+  status: number;
+  url: string;
+  constructor(message: string, status: number, url: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.url = url;
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${BASE}${path}`;
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new ApiError(
+      `Request failed: ${res.status} ${res.statusText}`,
+      res.status,
+      url,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+async function requestBuffer(
+  path: string,
+  init?: RequestInit,
+): Promise<ArrayBuffer> {
+  const url = `${BASE}${path}`;
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new ApiError(
+      `Request failed: ${res.status} ${res.statusText}`,
+      res.status,
+      url,
+    );
+  }
+  return await res.arrayBuffer();
+}
+
+export const api = {
+  health: () => request<{ status: string }>("/api/healthz"),
+  appData: () => request<unknown>("/api/app-data"),
+  manifest: () => request<unknown>("/api/manifest"),
+  buffer: (path: string) => requestBuffer(path),
+};

--- a/frontend/src/components/Equation.tsx
+++ b/frontend/src/components/Equation.tsx
@@ -7,7 +7,9 @@ type Props = {
   block?: boolean;
 };
 
-export function Math({ tex, block = false }: Props) {
+// Renamed from `Math` to avoid shadowing the global Math object in
+// modules that also use Math.floor / Math.PI / etc.
+export function Equation({ tex, block = false }: Props) {
   const ref = useRef<HTMLSpanElement | HTMLDivElement | null>(null);
 
   useEffect(() => {

--- a/frontend/src/components/Figure.tsx
+++ b/frontend/src/components/Figure.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  caption?: string;
+  children: ReactNode;
+};
+
+export function Figure({ caption, children }: Props) {
+  return (
+    <figure
+      className="my-6 rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <div className="flex justify-center overflow-x-auto">{children}</div>
+      {caption ? (
+        <figcaption
+          className="mt-3 text-sm leading-relaxed"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next";
+
+export function Footer() {
+  const { t } = useTranslation();
+  return (
+    <footer
+      className="border-t mt-12"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      <div
+        className="mx-auto max-w-screen-2xl px-6 py-6 text-sm flex flex-wrap items-center gap-4"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        <span>{t("common:site_title")}</span>
+        <span>·</span>
+        <span>{t("common:site_tagline")}</span>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,130 @@
+import { NavLink } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Github, Globe, Sparkles } from "lucide-react";
+
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { LanguageToggle } from "@/components/LanguageToggle";
+import { cn } from "@/lib/cn";
+
+const NAV_ITEMS = [
+  { to: "/", key: "overview" as const, end: true },
+  { to: "/methodology", key: "methodology" as const, end: false },
+  { to: "/databases", key: "databases" as const, end: false },
+  { to: "/workspace", key: "workspace" as const, end: false },
+  { to: "/benchmarks", key: "benchmarks" as const, end: false },
+];
+
+const EXTERNAL = {
+  orcid: "https://orcid.org/0000-0002-3614-2087",
+  github: "https://github.com/fsantibanezleal/CAOS_LDA_HSI",
+  site: "https://fasl-work.com",
+};
+
+export function Header() {
+  const { t } = useTranslation(["common", "nav"]);
+  return (
+    <header
+      className="sticky top-0 z-50 backdrop-blur-md border-b"
+      style={{
+        backgroundColor: "color-mix(in oklab, var(--color-bg) 80%, transparent)",
+        borderColor: "var(--color-border)",
+      }}
+    >
+      <div className="mx-auto max-w-screen-2xl flex items-center gap-4 px-6 h-14">
+        <NavLink
+          to="/"
+          className="flex items-center gap-2 font-semibold tracking-tight"
+          style={{ color: "var(--color-fg)" }}
+        >
+          <Sparkles size={18} aria-hidden style={{ color: "var(--color-accent)" }} />
+          <span>{t("common:site_title")}</span>
+        </NavLink>
+
+        <nav className="hidden md:flex items-center gap-1 ml-4">
+          {NAV_ITEMS.map(({ to, key, end }) => (
+            <NavLink
+              key={key}
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                cn(
+                  "px-3 py-1.5 rounded-md text-sm transition-colors",
+                  isActive ? "font-medium" : "opacity-75 hover:opacity-100",
+                )
+              }
+              style={({ isActive }) => ({
+                backgroundColor: isActive
+                  ? "var(--color-accent-soft)"
+                  : "transparent",
+                color: isActive ? "var(--color-accent)" : "var(--color-fg)",
+              })}
+            >
+              {t(`nav:${key}`)}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-1">
+          <a
+            href={EXTERNAL.orcid}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={t("common:external.orcid")}
+            title={t("common:external.orcid")}
+            className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity"
+          >
+            <OrcidIcon />
+          </a>
+          <a
+            href={EXTERNAL.github}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={t("common:external.github")}
+            title={t("common:external.github")}
+            className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity"
+          >
+            <Github size={18} />
+          </a>
+          <a
+            href={EXTERNAL.site}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={t("common:external.site")}
+            title={t("common:external.site")}
+            className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity"
+          >
+            <Globe size={18} />
+          </a>
+          <span
+            className="mx-1 h-5 w-px"
+            style={{ backgroundColor: "var(--color-border)" }}
+            aria-hidden
+          />
+          <LanguageToggle />
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function OrcidIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 256 256"
+      width="18"
+      height="18"
+      aria-hidden
+      role="img"
+    >
+      <path
+        d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z"
+        fill="#a6ce39"
+      />
+      <g fill="#fff">
+        <path d="M86.3 186.2H70.9V79.1h15.4v107.1zm-7.7-118c-5.4 0-9.8 4.4-9.8 9.7 0 5.4 4.4 9.8 9.8 9.8s9.8-4.4 9.8-9.8c0-5.3-4.4-9.7-9.8-9.7zm32.7 11h41.6c39.5 0 56.9 28.2 56.9 53.6 0 27.6-21.6 53.5-56.7 53.5h-41.8V79.2zm15.4 93.3h24.5c34.9 0 42.9-26.5 42.9-39.7 0-21.5-13.7-39.7-43.7-39.7h-23.7v79.4z" />
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/components/LanguageToggle.tsx
+++ b/frontend/src/components/LanguageToggle.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "react-i18next";
+import { Languages } from "lucide-react";
+
+import {
+  SUPPORTED_LANGUAGES,
+  type Language,
+} from "@/i18n/config";
+
+export function LanguageToggle() {
+  const { i18n, t } = useTranslation();
+  const current = (i18n.resolvedLanguage ?? i18n.language ?? "es") as Language;
+  const next: Language = current === "es" ? "en" : "es";
+
+  const swap = () => {
+    if (!SUPPORTED_LANGUAGES.includes(next)) return;
+    void i18n.changeLanguage(next);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={swap}
+      aria-label={t("common:actions.toggle_language")}
+      title={t("common:actions.toggle_language")}
+      className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity inline-flex items-center gap-1"
+    >
+      <Languages size={18} />
+      <span className="text-xs uppercase tracking-wider">{current}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/Math.tsx
+++ b/frontend/src/components/Math.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import katex from "katex";
+import "katex/dist/katex.min.css";
+
+type Props = {
+  tex: string;
+  block?: boolean;
+};
+
+export function Math({ tex, block = false }: Props) {
+  const ref = useRef<HTMLSpanElement | HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    katex.render(tex, ref.current, {
+      throwOnError: false,
+      displayMode: block,
+      strict: "ignore",
+      output: "html",
+    });
+  }, [tex, block]);
+
+  return block ? (
+    <div
+      ref={ref as React.RefObject<HTMLDivElement>}
+      className="my-4 overflow-x-auto"
+      aria-label={`equation: ${tex}`}
+    />
+  ) : (
+    <span
+      ref={ref as React.RefObject<HTMLSpanElement>}
+      aria-label={`equation: ${tex}`}
+    />
+  );
+}

--- a/frontend/src/components/PageFallback.tsx
+++ b/frontend/src/components/PageFallback.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from "react-i18next";
+
+export function PageFallback() {
+  const { t } = useTranslation();
+  return (
+    <div className="mx-auto max-w-screen-2xl px-6 py-12">
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        {t("common:states.loading")}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/PageShell.tsx
+++ b/frontend/src/components/PageShell.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  title: string;
+  lead?: string | undefined;
+  children?: ReactNode;
+};
+
+export function PageShell({ title, lead, children }: Props) {
+  return (
+    <section className="mx-auto max-w-screen-2xl px-6 py-10">
+      <header className="mb-6">
+        <h1
+          className="text-2xl md:text-3xl font-semibold tracking-tight"
+          style={{ color: "var(--color-fg)" }}
+        >
+          {title}
+        </h1>
+        {lead ? (
+          <p
+            className="mt-2 max-w-3xl text-base"
+            style={{ color: "var(--color-fg-subtle)" }}
+          >
+            {lead}
+          </p>
+        ) : null}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/components/RebuildingNotice.tsx
+++ b/frontend/src/components/RebuildingNotice.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from "react-i18next";
+
+type Props = {
+  hint?: string;
+};
+
+export function RebuildingNotice({ hint }: Props) {
+  const { t } = useTranslation();
+  return (
+    <div
+      className="rounded-lg border p-6"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <p style={{ color: "var(--color-fg-subtle)" }}>
+        {t("common:states.rebuilding")}
+      </p>
+      {hint ? (
+        <p
+          className="mt-3 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/Section.tsx
+++ b/frontend/src/components/Section.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+type Props = {
+  id?: string;
+  title: string;
+  lead?: ReactNode;
+  children?: ReactNode;
+};
+
+export function Section({ id, title, lead, children }: Props) {
+  return (
+    <section id={id} className="mt-10 first:mt-0">
+      <h2
+        className="text-xl md:text-2xl font-semibold tracking-tight"
+        style={{ color: "var(--color-fg)" }}
+      >
+        {title}
+      </h2>
+      {lead ? (
+        <p
+          className="mt-2 max-w-3xl text-base leading-relaxed"
+          style={{ color: "var(--color-fg-subtle)" }}
+        >
+          {lead}
+        </p>
+      ) : null}
+      <div className="mt-4 max-w-3xl text-[15px] leading-relaxed">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Moon, Sun } from "lucide-react";
+
+import { useThemeStore } from "@/state/useThemeStore";
+
+export function ThemeToggle() {
+  const { t } = useTranslation();
+  const theme = useThemeStore((s) => s.theme);
+  const toggleTheme = useThemeStore((s) => s.toggleTheme);
+
+  // Apply current theme to <html data-theme=...> in case the inline
+  // pre-paint script and the React store ever drift.
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={t("common:actions.toggle_theme")}
+      title={t("common:actions.toggle_theme")}
+      className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity"
+    >
+      {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -1,0 +1,35 @@
+import i18n from "i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import { initReactI18next } from "react-i18next";
+
+import esCommon from "@/i18n/locales/es/common.json";
+import esNav from "@/i18n/locales/es/nav.json";
+import esPages from "@/i18n/locales/es/pages.json";
+import enCommon from "@/i18n/locales/en/common.json";
+import enNav from "@/i18n/locales/en/nav.json";
+import enPages from "@/i18n/locales/en/pages.json";
+
+export const SUPPORTED_LANGUAGES = ["es", "en"] as const;
+export type Language = (typeof SUPPORTED_LANGUAGES)[number];
+
+void i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      es: { common: esCommon, nav: esNav, pages: esPages },
+      en: { common: enCommon, nav: enNav, pages: enPages },
+    },
+    fallbackLng: "es",
+    supportedLngs: SUPPORTED_LANGUAGES,
+    defaultNS: "common",
+    ns: ["common", "nav", "pages"],
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ["localStorage", "navigator"],
+      lookupLocalStorage: "caos.lang",
+      caches: ["localStorage"],
+    },
+  });
+
+export default i18n;

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,0 +1,19 @@
+{
+  "site_title": "CAOS LDA HSI",
+  "site_tagline": "Probabilistic topic models on hyperspectral imagery",
+  "actions": {
+    "toggle_theme": "Toggle theme",
+    "toggle_language": "Switch language",
+    "open_external": "Open external link"
+  },
+  "states": {
+    "loading": "Loading…",
+    "rebuilding": "This section is being rebuilt. Check back soon.",
+    "endpoint_unavailable": "Endpoint not available yet"
+  },
+  "external": {
+    "orcid": "ORCID",
+    "github": "GitHub",
+    "site": "fasl-work.com"
+  }
+}

--- a/frontend/src/i18n/locales/en/nav.json
+++ b/frontend/src/i18n/locales/en/nav.json
@@ -1,0 +1,13 @@
+{
+  "overview": "Overview",
+  "methodology": "Methodology",
+  "databases": "Databases",
+  "workspace": "Workspace",
+  "benchmarks": "Benchmarks",
+  "methodology_sub": {
+    "theory": "Theory",
+    "representations": "Representations",
+    "pipeline": "Local pipeline",
+    "application": "Application"
+  }
+}

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -1,0 +1,38 @@
+{
+  "overview": {
+    "title": "Overview",
+    "lead": "CAOS LDA HSI explores what probabilistic topic models can capture when documents are pixels, regions, or measurements drawn from hyperspectral imagery.",
+    "cta_workspace": "Open the workspace",
+    "cta_methodology": "Read the methodology"
+  },
+  "methodology": {
+    "title": "Methodology"
+  },
+  "methodology_theory": {
+    "title": "Theory — PTM, LDA, HSI"
+  },
+  "methodology_representations": {
+    "title": "Data types and document representations"
+  },
+  "methodology_pipeline": {
+    "title": "Local data-creation pipeline"
+  },
+  "methodology_application": {
+    "title": "Application to classification and regression via topics"
+  },
+  "databases": {
+    "title": "Databases"
+  },
+  "workspace": {
+    "title": "Workspace",
+    "step": {
+      "family": "Dataset family",
+      "subset": "Subset",
+      "representation": "Representation",
+      "explore": "Explore"
+    }
+  },
+  "benchmarks": {
+    "title": "Benchmarks"
+  }
+}

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -1,0 +1,19 @@
+{
+  "site_title": "CAOS LDA HSI",
+  "site_tagline": "Modelos probabilísticos de tópicos sobre imágenes hiperespectrales",
+  "actions": {
+    "toggle_theme": "Alternar tema",
+    "toggle_language": "Cambiar idioma",
+    "open_external": "Abrir enlace externo"
+  },
+  "states": {
+    "loading": "Cargando…",
+    "rebuilding": "Esta sección se está reconstruyendo. Vuelve pronto.",
+    "endpoint_unavailable": "Endpoint no disponible todavía"
+  },
+  "external": {
+    "orcid": "ORCID",
+    "github": "GitHub",
+    "site": "fasl-work.com"
+  }
+}

--- a/frontend/src/i18n/locales/es/nav.json
+++ b/frontend/src/i18n/locales/es/nav.json
@@ -1,0 +1,13 @@
+{
+  "overview": "Visión general",
+  "methodology": "Metodología",
+  "databases": "Bases de datos",
+  "workspace": "Laboratorio",
+  "benchmarks": "Benchmarks",
+  "methodology_sub": {
+    "theory": "Teoría",
+    "representations": "Representaciones",
+    "pipeline": "Pipeline local",
+    "application": "Aplicación"
+  }
+}

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -1,0 +1,38 @@
+{
+  "overview": {
+    "title": "Visión general",
+    "lead": "CAOS LDA HSI explora qué pueden capturar los modelos probabilísticos de tópicos cuando los documentos son píxeles, regiones o mediciones de imágenes hiperespectrales.",
+    "cta_workspace": "Abrir el laboratorio",
+    "cta_methodology": "Leer la metodología"
+  },
+  "methodology": {
+    "title": "Metodología"
+  },
+  "methodology_theory": {
+    "title": "Teoría — PTM, LDA, HSI"
+  },
+  "methodology_representations": {
+    "title": "Tipos de datos y representaciones de documentos"
+  },
+  "methodology_pipeline": {
+    "title": "Pipeline local de creación de datos"
+  },
+  "methodology_application": {
+    "title": "Aplicación a clasificación y regresión vía tópicos"
+  },
+  "databases": {
+    "title": "Bases de datos"
+  },
+  "workspace": {
+    "title": "Laboratorio",
+    "step": {
+      "family": "Familia de datos",
+      "subset": "Conjunto",
+      "representation": "Representación",
+      "explore": "Explorar"
+    }
+  },
+  "benchmarks": {
+    "title": "Benchmarks"
+  }
+}

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import clsx, { type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,29 @@
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "caos.theme";
+
+export function readTheme(): Theme {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === "light" || saved === "dark") return saved;
+  } catch {
+    // ignore — SSR or storage disabled
+  }
+  if (
+    typeof window !== "undefined" &&
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
+  }
+  return "light";
+}
+
+export function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute("data-theme", theme);
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // ignore
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import "@/styles/globals.css";
+import "@/i18n/config";
+
+import { App } from "@/App";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+      staleTime: 60_000,
+    },
+  },
+});
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("missing #root element");
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+
+import { PageShell } from "@/components/PageShell";
+import { RebuildingNotice } from "@/components/RebuildingNotice";
+
+export default function Benchmarks() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <PageShell title={t("pages:benchmarks.title")}>
+      <RebuildingNotice />
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/Databases.tsx
+++ b/frontend/src/pages/Databases.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+
+import { PageShell } from "@/components/PageShell";
+import { RebuildingNotice } from "@/components/RebuildingNotice";
+
+export default function Databases() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <PageShell title={t("pages:databases.title")}>
+      <RebuildingNotice />
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/Methodology.tsx
+++ b/frontend/src/pages/Methodology.tsx
@@ -1,0 +1,52 @@
+import { NavLink, Outlet } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/cn";
+
+const SUBROUTES = [
+  { path: "theory", key: "theory" as const },
+  { path: "representations", key: "representations" as const },
+  { path: "pipeline", key: "pipeline" as const },
+  { path: "application", key: "application" as const },
+];
+
+export default function Methodology() {
+  const { t } = useTranslation(["pages", "nav"]);
+  return (
+    <div className="mx-auto max-w-screen-2xl px-6 py-10 md:py-12 grid gap-8 md:grid-cols-[220px_1fr]">
+      <aside>
+        <h1
+          className="mb-4 text-lg font-semibold"
+          style={{ color: "var(--color-fg)" }}
+        >
+          {t("pages:methodology.title")}
+        </h1>
+        <nav className="flex md:flex-col gap-1">
+          {SUBROUTES.map(({ path, key }) => (
+            <NavLink
+              key={key}
+              to={path}
+              className={({ isActive }) =>
+                cn(
+                  "rounded-md px-3 py-2 text-sm transition-colors",
+                  isActive ? "font-medium" : "opacity-75 hover:opacity-100",
+                )
+              }
+              style={({ isActive }) => ({
+                backgroundColor: isActive
+                  ? "var(--color-accent-soft)"
+                  : "transparent",
+                color: isActive ? "var(--color-accent)" : "var(--color-fg)",
+              })}
+            >
+              {t(`nav:methodology_sub.${key}`)}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <div>
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+import { PageShell } from "@/components/PageShell";
+
+export default function Overview() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <PageShell
+      title={t("pages:overview.title")}
+      lead={t("pages:overview.lead")}
+    >
+      <div className="flex flex-wrap gap-3">
+        <Link
+          to="/workspace"
+          className="rounded-md px-4 py-2 text-sm font-medium"
+          style={{
+            backgroundColor: "var(--color-accent)",
+            color: "var(--color-accent-fg)",
+          }}
+        >
+          {t("pages:overview.cta_workspace")}
+        </Link>
+        <Link
+          to="/methodology"
+          className="rounded-md px-4 py-2 text-sm font-medium border"
+          style={{
+            borderColor: "var(--color-border)",
+            color: "var(--color-fg)",
+          }}
+        >
+          {t("pages:overview.cta_methodology")}
+        </Link>
+      </div>
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next";
+import { useMachine } from "@xstate/react";
+
+import { PageShell } from "@/components/PageShell";
+import { RebuildingNotice } from "@/components/RebuildingNotice";
+import { workspaceMachine } from "@/state/workspaceMachine";
+
+export default function Workspace() {
+  const { t } = useTranslation(["pages"]);
+  // Mount the FSM so the wiring is real even though the UI is empty.
+  // Subsequent task branches render step views off `state.value` and
+  // dispatch typed events to advance.
+  const [state] = useMachine(workspaceMachine);
+  void state;
+  return (
+    <PageShell title={t("pages:workspace.title")}>
+      <RebuildingNotice />
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+
+import { PageShell } from "@/components/PageShell";
+import { RebuildingNotice } from "@/components/RebuildingNotice";
+
+export default function MethodologyApplication() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <PageShell title={t("pages:methodology_application.title")}>
+      <RebuildingNotice />
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+
+import { PageShell } from "@/components/PageShell";
+import { RebuildingNotice } from "@/components/RebuildingNotice";
+
+export default function MethodologyPipeline() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <PageShell title={t("pages:methodology_pipeline.title")}>
+      <RebuildingNotice />
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/methodology/Representations.tsx
+++ b/frontend/src/pages/methodology/Representations.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+
+import { PageShell } from "@/components/PageShell";
+import { RebuildingNotice } from "@/components/RebuildingNotice";
+
+export default function MethodologyRepresentations() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <PageShell title={t("pages:methodology_representations.title")}>
+      <RebuildingNotice />
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/methodology/Representations.tsx
+++ b/frontend/src/pages/methodology/Representations.tsx
@@ -1,13 +1,495 @@
 import { useTranslation } from "react-i18next";
 
+import { Figure } from "@/components/Figure";
+import { Equation } from "@/components/Equation";
 import { PageShell } from "@/components/PageShell";
-import { RebuildingNotice } from "@/components/RebuildingNotice";
+import { Section } from "@/components/Section";
+
+type Recipe = {
+  id: string;
+  name: string;
+  token: string;
+  vocabSize: string;
+  oneLine: string;
+  bullets: string[];
+};
+
+const RECIPES: Recipe[] = [
+  {
+    id: "V1",
+    name: "Wavelength-as-word",
+    token: "(band l)",
+    vocabSize: "B",
+    oneLine: "La identidad de la banda es la palabra; la cantidad de tokens por banda es la intensidad cuantizada.",
+    bullets: [
+      "Más simple y la receta canónica del paper Procemin / A39.",
+      "Preserva identidad de longitud de onda.",
+      "Es densa: cada documento tiene B · ⟨q⟩ tokens.",
+    ],
+  },
+  {
+    id: "V2",
+    name: "Intensity-as-word",
+    token: "(intensity_bin q)",
+    vocabSize: "Q",
+    oneLine: "La identidad del bin de intensidad es la palabra. El espectro pierde su orientación en bandas.",
+    bullets: [
+      "Vocabulario diminuto.",
+      "Robusta a permutaciones de bandas.",
+      "Útil sólo como control de sensibilidad.",
+    ],
+  },
+  {
+    id: "V3",
+    name: "Concatenated spectra",
+    token: "(spectrum_id, band)",
+    vocabSize: "S · B",
+    oneLine: "Cada espectro mantiene identidad propia. Útil para corpus pequeños y reproducibles.",
+    bullets: [
+      "Preserva variabilidad inter-espectro.",
+      "Vocabulario crece con el corpus.",
+      "Receta fundacional del paper A39 (DB1).",
+    ],
+  },
+  {
+    id: "V4",
+    name: "Derivative-bin",
+    token: "(band, q(d))",
+    vocabSize: "B · Q",
+    oneLine: "La derivada banda-a-banda cuantizada captura dirección-de-cambio.",
+    bullets: [
+      "Robusta a deriva de brillo per-sample.",
+      "Útil para red-edge, suelos, MSI mal calibrada.",
+      "Implementada en build_wordifications_v4plus.py.",
+    ],
+  },
+  {
+    id: "V5",
+    name: "Second-derivative bin",
+    token: "(band, q(d²))",
+    vocabSize: "B · Q",
+    oneLine: "La segunda derivada resalta picos y valles independientemente de pendiente.",
+    bullets: [
+      "Buena para absorción estrecha.",
+      "Pareja natural con V4.",
+    ],
+  },
+  {
+    id: "V6",
+    name: "Wavelet-coefficient bin",
+    token: "(coef_j, q(|c|))",
+    vocabSize: "J · Q",
+    oneLine: "Daubechies-4 nivel 4: descomposición multi-resolución cuantizada.",
+    bullets: [
+      "Captura envoltura ancha + absorción local simultáneamente.",
+      "Buena para minerales con estructura mixta.",
+    ],
+  },
+  {
+    id: "V7",
+    name: "Absorption-feature triplet",
+    token: "(centroid_bucket, depth_bin, area_bin)",
+    vocabSize: "8 · Q²",
+    oneLine: "Hull cóncavo (Clark & Roush 1984) → tripletes (centroide, profundidad, área) por feature.",
+    bullets: [
+      "Físicamente interpretable.",
+      "Convex-hull stack monotónico propio (pysptools.spectro es frágil).",
+      "Ideal para identificación mineral.",
+    ],
+  },
+  {
+    id: "V8",
+    name: "Endmember-fraction bin",
+    token: "(endmember_k, q(α_k))",
+    vocabSize: "K_em · Q",
+    oneLine: "Base de K endmembers (NFINDR) + NNLS unmixing → abundancia por endmember cuantizada.",
+    bullets: [
+      "Receta más compacta del catálogo.",
+      "Vocabulario fijo independiente de las bandas.",
+      "Tópicos LDA expresados en la misma base que el unmixing.",
+    ],
+  },
+  {
+    id: "V9",
+    name: "Region token (Felzenszwalb)",
+    token: "(region_id, sam_bin)",
+    vocabSize: "≈ #regions · Q",
+    oneLine: "Felzenszwalb segmenta la escena; el token es (región, distancia SAM al centroide).",
+    bullets: [
+      "Documento = región (no píxel).",
+      "Coherencia espacial nativa.",
+    ],
+  },
+  {
+    id: "V10",
+    name: "Band-group VNIR / SWIR-1 / SWIR-2",
+    token: "(group_id, q(mean))",
+    vocabSize: "3 · Q",
+    oneLine: "El espectro se reduce a tres regiones espectrales gruesas; receta deliberadamente coarse.",
+    bullets: [
+      "Útil como baseline / smoke test.",
+      "Pavia U colapsa a un solo bucket porque su rango es 430–860 nm (sólo VNIR).",
+    ],
+  },
+  {
+    id: "V11",
+    name: "Codebook VQ (nanopq)",
+    token: "(subvector_j, code)",
+    vocabSize: "M · Q",
+    oneLine: "Product Quantisation (Jegou-Douze-Schmid 2011): k-means por sub-vector.",
+    bullets: [
+      "Representación discreta aprendida.",
+      "Adapta el alfabeto al manifold del corpus.",
+    ],
+  },
+  {
+    id: "V12",
+    name: "GMM token",
+    token: "(band, gmm_component)",
+    vocabSize: "B · Q",
+    oneLine: "GaussianMixture(Q) por banda; soft binning de intensidades.",
+    bullets: [
+      "Alternativa data-driven a uniform / quantile / Lloyd-Max.",
+      "Vocabulario denso comparable a V1.",
+    ],
+  },
+];
+
+const QUANT_SCHEMES = [
+  {
+    id: "uniform",
+    name: "Uniform",
+    desc: "Bins equiespaciados sobre el rango [min, max] del espectro normalizado.",
+  },
+  {
+    id: "quantile",
+    name: "Quantile",
+    desc: "Bins equiprobables: cada bin contiene el mismo número de muestras.",
+  },
+  {
+    id: "lloyd_max",
+    name: "Lloyd-Max",
+    desc: "Bins óptimos en MSE para la distribución empírica del espectro.",
+  },
+];
 
 export default function MethodologyRepresentations() {
   const { t } = useTranslation(["pages"]);
   return (
-    <PageShell title={t("pages:methodology_representations.title")}>
-      <RebuildingNotice />
+    <PageShell
+      title={t("pages:methodology_representations.title")}
+      lead="Cómo un cubo hiperespectral se convierte en una matriz documento-término. Hay doce recetas implementadas (V1..V12), tres esquemas de cuantización y tres niveles Q ∈ {8, 16, 32}."
+    >
+      <Section
+        id="grid"
+        title="El espacio de configuraciones"
+        lead="Cada celda de la grilla siguiente es un corpus distinto y, por lo tanto, una solución LDA distinta. Total: 12 recetas × 3 esquemas × 3 Q = 108 configs por escena."
+      >
+        <Figure caption="El alfabeto (token) y la longitud del documento dependen de la receta. La cuantización controla cuántos niveles distintos puede emitir el espectro. Q ∈ {8, 16, 32} balancea resolución y entropía.">
+          <RecipeGridSVG />
+        </Figure>
+      </Section>
+
+      <Section
+        id="quantisation"
+        title="Esquemas de cuantización"
+        lead="Toda receta que cuantiza intensidades elige uno de tres esquemas. La diferencia ocurre en los extremos de la distribución."
+      >
+        <div
+          className="grid sm:grid-cols-3 gap-3 mt-2"
+          style={{ color: "var(--color-fg-subtle)" }}
+        >
+          {QUANT_SCHEMES.map((s) => (
+            <div
+              key={s.id}
+              className="rounded-md border p-4 text-sm leading-relaxed"
+              style={{
+                borderColor: "var(--color-border)",
+                backgroundColor: "var(--color-panel)",
+                boxShadow: "var(--color-shadow)",
+              }}
+            >
+              <h3
+                className="font-semibold mb-2"
+                style={{ color: "var(--color-fg)" }}
+              >
+                {s.name}
+              </h3>
+              <p>{s.desc}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        id="recipes"
+        title="Las doce recetas"
+        lead="Cada receta declara qué constituye un token y un documento. La columna 'Vocabulario' indica el tamaño aproximado de V."
+      >
+        <div className="overflow-x-auto mt-2">
+          <table
+            className="min-w-full text-[14px] leading-relaxed border-collapse"
+            style={{ color: "var(--color-fg-subtle)" }}
+          >
+            <thead>
+              <tr
+                style={{
+                  borderBottom: "1px solid var(--color-border)",
+                  color: "var(--color-fg)",
+                }}
+              >
+                <th className="text-left py-2 pr-4 font-semibold">Receta</th>
+                <th className="text-left py-2 pr-4 font-semibold">Token</th>
+                <th className="text-left py-2 pr-4 font-semibold">Vocab</th>
+                <th className="text-left py-2 font-semibold">Resumen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {RECIPES.map((r) => (
+                <tr
+                  key={r.id}
+                  style={{ borderBottom: "1px solid var(--color-border)" }}
+                >
+                  <td className="py-3 pr-4 align-top whitespace-nowrap">
+                    <span
+                      className="inline-block rounded-md px-2 py-0.5 text-xs font-mono mr-2"
+                      style={{
+                        backgroundColor: "var(--color-accent-soft)",
+                        color: "var(--color-accent)",
+                      }}
+                    >
+                      {r.id}
+                    </span>
+                    <span style={{ color: "var(--color-fg)" }}>{r.name}</span>
+                  </td>
+                  <td className="py-3 pr-4 align-top font-mono text-[13px]">
+                    {r.token}
+                  </td>
+                  <td className="py-3 pr-4 align-top font-mono text-[13px]">
+                    {r.vocabSize}
+                  </td>
+                  <td className="py-3 align-top">
+                    <p className="mb-2">{r.oneLine}</p>
+                    <ul className="list-disc pl-5 space-y-1 text-[13px]">
+                      {r.bullets.map((b, i) => (
+                        <li key={i}>{b}</li>
+                      ))}
+                    </ul>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      <Section
+        id="document"
+        title="¿Qué cuenta como un documento?"
+        lead="El documento es la unidad sobre la que LDA estima theta. Una receta decide implícitamente el tamaño y la coherencia espacial de cada documento."
+      >
+        <p>
+          Para una receta fija, la elección de granularidad documental es la
+          segunda decisión más importante. El proyecto materializa cuatro
+          alternativas vía <code>build_groupings.py</code>:
+        </p>
+        <Figure caption="Cuatro granularidades documentales: píxel, parche fijo (5×5 / 7×7 / 15×15), región SLIC, y región Felzenszwalb. La página de Workspace permite elegir entre ellas y ver cómo cambia la estructura tópica resultante.">
+          <DocumentGranularitySVG />
+        </Figure>
+        <p>
+          La métrica <Equation tex="\text{ARI}_{\text{off-diag}}" /> entre las ocho
+          opciones (4 granularidades × 2 etiquetados) cuantifica la sensibilidad
+          de los tópicos a esta elección. En todas las escenas etiquetadas
+          observadas el valor es ~0.15: las cuatro granularidades producen
+          estructuras tópicas genuinamente distintas, no equivalentes con ruido.
+        </p>
+      </Section>
+
+      <Section
+        id="see-also"
+        title="Cómo seguir"
+      >
+        <p>
+          Cada combinación{" "}
+          <Equation tex="(\text{escena}, \text{receta}, \text{esquema}, Q)" /> está
+          servida en el endpoint{" "}
+          <code>/api/wordifications/{`{scene}/{recipe}/{scheme}/{q}`}</code>. El
+          Workspace expone esa elección como un selector explícito y muestra el
+          ajuste LDA correspondiente sin re-fittear nada en el cliente: todos
+          los <Equation tex="\theta" /> y <Equation tex="\phi" /> están precalculados.
+        </p>
+      </Section>
     </PageShell>
+  );
+}
+
+function RecipeGridSVG() {
+  // 12 recipes × 3 schemes × 3 Q = 108 cells. Render as 12 rows × 9 columns.
+  const recipeIds = RECIPES.map((r) => r.id);
+  const cols = ["U/8", "U/16", "U/32", "Q/8", "Q/16", "Q/32", "L/8", "L/16", "L/32"];
+  const cellW = 32;
+  const cellH = 22;
+  const x0 = 90;
+  const y0 = 28;
+  return (
+    <svg
+      width="430"
+      height={y0 + recipeIds.length * cellH + 14}
+      viewBox={`0 0 430 ${y0 + recipeIds.length * cellH + 14}`}
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Recipe × scheme × Q grid"
+      style={{ color: "var(--color-fg)" }}
+    >
+      <g
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="10"
+        fill="currentColor"
+      >
+        {/* Column headers */}
+        {cols.map((c, i) => (
+          <text
+            key={c}
+            x={x0 + i * cellW + cellW / 2}
+            y={y0 - 8}
+            textAnchor="middle"
+            opacity="0.7"
+          >
+            {c}
+          </text>
+        ))}
+        {/* Recipe rows */}
+        {recipeIds.map((rid, ri) => (
+          <g key={rid}>
+            <text
+              x={x0 - 10}
+              y={y0 + ri * cellH + cellH * 0.65}
+              textAnchor="end"
+              fontFamily="ui-monospace, monospace"
+              fontSize="10.5"
+            >
+              {rid} {RECIPES[ri]?.name}
+            </text>
+            {cols.map((_, ci) => (
+              <rect
+                key={ci}
+                x={x0 + ci * cellW}
+                y={y0 + ri * cellH + 2}
+                width={cellW - 3}
+                height={cellH - 5}
+                rx="2"
+                fill="var(--color-accent)"
+                opacity={0.15 + 0.06 * ((ri + ci) % 5)}
+              />
+            ))}
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+function DocumentGranularitySVG() {
+  return (
+    <svg
+      width="640"
+      height="220"
+      viewBox="0 0 640 220"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Document granularity options"
+      style={{ color: "var(--color-fg)" }}
+    >
+      <g
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="12"
+        fill="currentColor"
+      >
+        {/* Pixel grid */}
+        <g transform="translate(20, 30)">
+          <text x="60" y="-8" textAnchor="middle" fontWeight="600">
+            píxel
+          </text>
+          {Array.from({ length: 36 }).map((_, i) => {
+            const r = Math.floor(i / 6);
+            const c = i % 6;
+            return (
+              <rect
+                key={i}
+                x={c * 20}
+                y={r * 20}
+                width={18}
+                height={18}
+                fill="var(--color-accent)"
+                opacity={0.3 + ((r * 7 + c) % 5) * 0.08}
+              />
+            );
+          })}
+        </g>
+
+        {/* Patch */}
+        <g transform="translate(180, 30)">
+          <text x="60" y="-8" textAnchor="middle" fontWeight="600">
+            parche fijo (5×5)
+          </text>
+          {Array.from({ length: 36 }).map((_, i) => {
+            const r = Math.floor(i / 6);
+            const c = i % 6;
+            // Group into 2x2 patches
+            const pr = Math.floor(r / 2);
+            const pc = Math.floor(c / 2);
+            const opacity = 0.25 + ((pr * 3 + pc) % 4) * 0.12;
+            return (
+              <rect
+                key={i}
+                x={c * 20}
+                y={r * 20}
+                width={18}
+                height={18}
+                fill="var(--color-accent)"
+                opacity={opacity}
+              />
+            );
+          })}
+        </g>
+
+        {/* SLIC */}
+        <g transform="translate(340, 30)">
+          <text x="60" y="-8" textAnchor="middle" fontWeight="600">
+            SLIC superpíxel
+          </text>
+          {/* irregular blobs */}
+          <path
+            d="M 0 30 C 20 0, 60 0, 90 20 C 120 40, 110 80, 80 70 C 50 60, 30 80, 10 60 Z"
+            fill="var(--color-accent)"
+            opacity="0.45"
+          />
+          <path
+            d="M 90 70 C 120 50, 130 100, 110 120 C 90 140, 60 130, 60 110 C 60 90, 70 80, 90 70 Z"
+            fill="var(--color-accent)"
+            opacity="0.32"
+          />
+          <path
+            d="M 10 70 C 0 100, 30 130, 60 130 C 50 110, 30 100, 10 70 Z"
+            fill="var(--color-accent)"
+            opacity="0.55"
+          />
+          <rect x="0" y="0" width="120" height="120" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.35" />
+        </g>
+
+        {/* Felzenszwalb */}
+        <g transform="translate(500, 30)">
+          <text x="60" y="-8" textAnchor="middle" fontWeight="600">
+            Felzenszwalb
+          </text>
+          <path d="M 0 0 L 60 0 L 80 30 L 50 60 L 0 50 Z" fill="var(--color-accent)" opacity="0.5" />
+          <path d="M 60 0 L 120 0 L 120 50 L 80 30 Z" fill="var(--color-accent)" opacity="0.32" />
+          <path d="M 0 50 L 50 60 L 30 110 L 0 90 Z" fill="var(--color-accent)" opacity="0.4" />
+          <path d="M 50 60 L 80 30 L 120 50 L 120 120 L 80 120 Z" fill="var(--color-accent)" opacity="0.25" />
+          <path d="M 30 110 L 80 120 L 80 120 L 0 120 L 0 90 Z" fill="var(--color-accent)" opacity="0.55" />
+          <rect x="0" y="0" width="120" height="120" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.35" />
+        </g>
+      </g>
+    </svg>
   );
 }

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from "react-i18next";
+
+import { PageShell } from "@/components/PageShell";
+import { RebuildingNotice } from "@/components/RebuildingNotice";
+
+export default function MethodologyTheory() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <PageShell title={t("pages:methodology_theory.title")}>
+      <RebuildingNotice />
+    </PageShell>
+  );
+}

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -1,13 +1,518 @@
 import { useTranslation } from "react-i18next";
 
+import { Figure } from "@/components/Figure";
+import { Math } from "@/components/Math";
 import { PageShell } from "@/components/PageShell";
-import { RebuildingNotice } from "@/components/RebuildingNotice";
+import { Section } from "@/components/Section";
 
 export default function MethodologyTheory() {
   const { t } = useTranslation(["pages"]);
   return (
-    <PageShell title={t("pages:methodology_theory.title")}>
-      <RebuildingNotice />
+    <PageShell
+      title={t("pages:methodology_theory.title")}
+      lead="Modelos probabilísticos de tópicos sobre imágenes hiperespectrales — qué son, cómo funcionan y por qué un píxel puede ser tratado como un documento."
+    >
+      <Section
+        id="why-ptm"
+        title="¿Qué es un modelo probabilístico de tópicos?"
+        lead="Un modelo probabilístico de tópicos (PTM) describe cada documento como una mezcla latente sobre un puñado de distribuciones de palabras llamadas tópicos. La gracia es que esa estructura latente se aprende sin supervisión a partir de las co-ocurrencias de palabras."
+      >
+        <p>
+          Bajo el modelo más popular — Latent Dirichlet Allocation (Blei, Ng &amp;
+          Jordan, 2003) — un corpus de <em>D</em> documentos sobre un vocabulario
+          de tamaño <em>V</em> se explica con dos colecciones de distribuciones:{" "}
+          <Math tex="\theta_d \in \Delta^{K-1}" /> es la mezcla de tópicos del
+          documento <em>d</em>, y <Math tex="\phi_k \in \Delta^{V-1}" /> es la
+          distribución de palabras del tópico <em>k</em>. Cada palabra observada
+          se genera tirando primero un tópico desde <Math tex="\theta_d" /> y
+          luego una palabra desde el <Math tex="\phi_k" /> correspondiente.
+        </p>
+        <p className="mt-3">
+          La inferencia recupera <Math tex="\theta" />, <Math tex="\phi" /> y la
+          asignación tópico-por-palabra <Math tex="z" />. El resultado es una
+          descomposición compacta, interpretable y mixta del corpus: cada
+          documento es una mezcla de tópicos en lugar de pertenecer a una sola
+          categoría dura.
+        </p>
+      </Section>
+
+      <Section
+        id="lda-plate"
+        title="LDA — notación de placas y proceso generativo"
+        lead="Las placas externas se repiten sobre documentos y palabras; las distribuciones latentes (theta y phi) son los objetos que el modelo aprende."
+      >
+        <Figure caption="LDA en notación de placas. La placa exterior recorre los D documentos; la interior, las N_d palabras de cada documento. Theta_d es la mezcla por documento sobre los K tópicos; phi_k es la distribución del tópico k sobre las V palabras del vocabulario.">
+          <PlateNotationSVG />
+        </Figure>
+
+        <p>
+          La distribución conjunta del modelo factoriza así (con priors
+          Dirichlet sobre <Math tex="\theta_d" /> y <Math tex="\phi_k" />):
+        </p>
+
+        <Math
+          block
+          tex="p(\theta, \phi, z, w \mid \alpha, \eta) = \prod_{k=1}^{K} p(\phi_k \mid \eta) \, \prod_{d=1}^{D} p(\theta_d \mid \alpha) \prod_{n=1}^{N_d} p(z_{d,n} \mid \theta_d) \, p(w_{d,n} \mid z_{d,n}, \phi_{1:K})"
+        />
+
+        <p>
+          La verosimilitud marginal del corpus se obtiene integrando los
+          latentes continuos y sumando sobre las asignaciones discretas:
+        </p>
+        <Math
+          block
+          tex="p(w \mid \alpha, \eta) = \int \int \, \prod_{k} p(\phi_k \mid \eta) \, \prod_{d} p(\theta_d \mid \alpha) \prod_{n} \sum_{k=1}^{K} \theta_{d,k} \, \phi_{k, w_{d,n}} \, d\theta \, d\phi"
+        />
+        <p>
+          Esa integral es intratable en forma cerrada. La inferencia se hace por
+          variational Bayes (Blei et al. 2003), Gibbs colapsado (Griffiths &amp;
+          Steyvers 2004) o stochastic VI (Hoffman et al. 2013); todas son
+          aproximaciones a la misma posterior.
+        </p>
+      </Section>
+
+      <Section
+        id="hsi-as-document"
+        title="HSI como corpus — ¿por qué un píxel puede ser un documento?"
+        lead="Cada píxel de una imagen hiperespectral es un vector de reflectancia. Para que LDA lo procese hay que cuantizar el espectro y transformarlo en una secuencia discreta de tokens."
+      >
+        <p>
+          Una imagen hiperespectral (HSI) es un cubo{" "}
+          <Math tex="X \in \mathbb{R}^{H \times W \times B}" />, donde cada
+          píxel <Math tex="(i, j)" /> tiene un espectro{" "}
+          <Math tex="x_{ij} = (x_{ij,1}, \dots, x_{ij,B})" /> con la reflectancia
+          observada en cada una de las <em>B</em> bandas espectrales. Bandas
+          típicas: 200 (Indian Pines AVIRIS-Classic) a 224 (Salinas) a más de
+          2000 (HIDSAG).
+        </p>
+        <p className="mt-3">
+          La conversión espectro → documento se llama{" "}
+          <strong>wordification</strong>. Una receta de wordification declara
+          (i) cómo se normaliza el espectro, (ii) cómo se cuantizan las
+          intensidades, (iii) qué constituye un token (banda, intensidad,
+          derivada, coeficiente wavelet, código VQ, etc.) y (iv) qué constituye
+          un documento (un píxel, una región SLIC, un parche, una muestra
+          completa). El resultado es una matriz documento-término{" "}
+          <Math tex="C \in \mathbb{N}^{D \times V}" /> sobre la cual LDA puede
+          inferir.
+        </p>
+
+        <Figure caption="Pipeline de wordification: espectro continuo → normalización → cuantización a Q niveles → emisión de tokens → documento. El alfabeto y la receta de tokens se eligen para preservar la propiedad de interés (banda, forma, absorción, abundancia de endmember, código VQ).">
+          <WordificationFlowSVG />
+        </Figure>
+
+        <p>
+          El proyecto ofrece doce recetas (V1 wavelength-as-word a V12 GMM
+          token), tres esquemas de cuantización (uniforme, cuantil, Lloyd-Max) y
+          tres niveles <em>Q</em> ∈ {`{8, 16, 32}`}. Cada combinación produce un
+          corpus distinto y, por lo tanto, una solución LDA distinta.
+        </p>
+      </Section>
+
+      <Section
+        id="why-mixed-membership"
+        title="Membresía mixta — ¿por qué no clasificación dura?"
+        lead="El espectro de un píxel mineral no proviene de una única especie. Mezclas, vegetación intercalada, sombra y dispersión atmosférica producen mediciones que reflejan varias firmas a la vez."
+      >
+        <p>
+          La asunción de membresía dura — un píxel pertenece a una y solo una
+          clase — falla en HSI porque cada espectro es por construcción una
+          mezcla. La descomposición mixta de LDA captura esa realidad
+          directamente:{" "}
+          <Math tex="\theta_d" /> es la composición topical del píxel{" "}
+          <em>d</em>, y la suma <Math tex="\sum_{k} \theta_{d,k} \phi_k" /> es
+          la firma reconstruida que el modelo cree que produjo las palabras
+          observadas.
+        </p>
+        <p className="mt-3">
+          Compárese con un baseline lineal (PCA, NMF, ICA) sobre el mismo cubo:
+          esos métodos también producen una representación de baja dimensión,
+          pero sin un modelo generativo de cuentas discretas y, sobre todo, sin
+          la interpretabilidad de "tópico = distribución sobre palabras
+          espectrales". La página de Aplicación profundiza en cuándo conviene
+          una u otra.
+        </p>
+
+        <Figure caption="Memoria mixta: cada píxel del mapa hiperespectral se descompone en una proporción θ_d sobre los K tópicos. La suma ponderada de las firmas tópicas reconstruye una versión suavizada del espectro original.">
+          <MixedMembershipSVG />
+        </Figure>
+      </Section>
+
+      <Section id="readings" title="Lecturas mínimas">
+        <ul
+          className="mt-2 space-y-2 list-disc pl-5"
+          style={{ color: "var(--color-fg-subtle)" }}
+        >
+          <li>
+            Blei, Ng &amp; Jordan (2003) — <em>Latent Dirichlet Allocation</em>.
+            JMLR. El paper canónico.
+          </li>
+          <li>
+            Griffiths &amp; Steyvers (2004) —{" "}
+            <em>Finding scientific topics</em>. PNAS. Gibbs colapsado.
+          </li>
+          <li>
+            Sievert &amp; Shirley (2014) —{" "}
+            <em>LDAvis: A method for visualizing and interpreting topics</em>.
+            Define la fórmula de relevancia λ que se usa en la página de
+            Workspace.
+          </li>
+          <li>
+            Stammbach et al. (2024) — <em>Re-visiting word intrusion</em>. TACL.
+            Marco moderno para validar tópicos vía oráculos LLM.
+          </li>
+        </ul>
+      </Section>
     </PageShell>
+  );
+}
+
+function PlateNotationSVG() {
+  return (
+    <svg
+      width="560"
+      height="260"
+      viewBox="0 0 560 260"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="LDA plate notation"
+      style={{ color: "var(--color-fg)" }}
+    >
+      <defs>
+        <marker
+          id="arrowTheory"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0 0 L10 5 L0 10 z" fill="currentColor" />
+        </marker>
+      </defs>
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="13"
+      >
+        <rect x="20" y="40" width="380" height="190" rx="8" />
+        <text x="380" y="220" fill="currentColor" textAnchor="end">
+          D
+        </text>
+        <rect x="100" y="100" width="280" height="110" rx="8" />
+        <text x="360" y="200" fill="currentColor" textAnchor="end">
+          N_d
+        </text>
+        <rect x="430" y="40" width="110" height="80" rx="8" />
+        <text x="525" y="110" fill="currentColor" textAnchor="end">
+          K
+        </text>
+
+        <circle cx="40" cy="70" r="14" fill="var(--color-bg)" />
+        <text x="40" y="74" textAnchor="middle" fill="currentColor">
+          α
+        </text>
+        <circle cx="450" cy="70" r="14" fill="var(--color-bg)" />
+        <text x="450" y="74" textAnchor="middle" fill="currentColor">
+          η
+        </text>
+
+        <circle cx="80" cy="140" r="18" fill="var(--color-accent-soft)" />
+        <text x="80" y="144" textAnchor="middle" fill="currentColor">
+          θ_d
+        </text>
+
+        <circle cx="190" cy="155" r="18" fill="var(--color-accent-soft)" />
+        <text x="190" y="159" textAnchor="middle" fill="currentColor">
+          z
+        </text>
+
+        <circle cx="300" cy="155" r="18" fill="var(--color-accent)" />
+        <text x="300" y="159" textAnchor="middle" fill="var(--color-accent-fg)">
+          w
+        </text>
+
+        <circle cx="490" cy="80" r="18" fill="var(--color-accent-soft)" />
+        <text x="490" y="84" textAnchor="middle" fill="currentColor">
+          φ_k
+        </text>
+
+        <line x1="56" y1="70" x2="62" y2="125" markerEnd="url(#arrowTheory)" />
+        <line
+          x1="100"
+          y1="145"
+          x2="170"
+          y2="153"
+          markerEnd="url(#arrowTheory)"
+        />
+        <line
+          x1="210"
+          y1="155"
+          x2="280"
+          y2="155"
+          markerEnd="url(#arrowTheory)"
+        />
+        <line
+          x1="478"
+          y1="92"
+          x2="320"
+          y2="148"
+          markerEnd="url(#arrowTheory)"
+        />
+        <line
+          x1="450"
+          y1="84"
+          x2="475"
+          y2="73"
+          markerEnd="url(#arrowTheory)"
+        />
+      </g>
+    </svg>
+  );
+}
+
+function WordificationFlowSVG() {
+  return (
+    <svg
+      width="640"
+      height="220"
+      viewBox="0 0 640 220"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Wordification pipeline"
+      style={{ color: "var(--color-fg)" }}
+    >
+      <defs>
+        <marker
+          id="arrowWord"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0 0 L10 5 L0 10 z" fill="currentColor" />
+        </marker>
+      </defs>
+      <g
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="12"
+        fill="currentColor"
+      >
+        <rect
+          x="20"
+          y="60"
+          width="120"
+          height="100"
+          rx="8"
+          fill="var(--color-panel)"
+          stroke="currentColor"
+          strokeWidth="1.3"
+        />
+        <text x="80" y="80" textAnchor="middle" fontWeight="600">
+          Espectro
+        </text>
+        <path
+          d="M 30 130 C 50 100, 70 160, 90 110 S 130 90, 130 130"
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth="1.6"
+        />
+        <text x="80" y="155" textAnchor="middle" opacity="0.7">
+          x ∈ ℝ^B
+        </text>
+
+        <rect
+          x="170"
+          y="60"
+          width="120"
+          height="100"
+          rx="8"
+          fill="var(--color-panel)"
+          stroke="currentColor"
+          strokeWidth="1.3"
+        />
+        <text x="230" y="80" textAnchor="middle" fontWeight="600">
+          Normalización
+        </text>
+        <text x="230" y="115" textAnchor="middle" opacity="0.85">
+          per-spectrum,
+        </text>
+        <text x="230" y="132" textAnchor="middle" opacity="0.85">
+          per-band o
+        </text>
+        <text x="230" y="149" textAnchor="middle" opacity="0.85">
+          reflectancia
+        </text>
+
+        <rect
+          x="320"
+          y="60"
+          width="120"
+          height="100"
+          rx="8"
+          fill="var(--color-panel)"
+          stroke="currentColor"
+          strokeWidth="1.3"
+        />
+        <text x="380" y="80" textAnchor="middle" fontWeight="600">
+          Cuantización
+        </text>
+        <g stroke="var(--color-accent)" strokeWidth="1.6" fill="none">
+          <line x1="335" y1="100" x2="425" y2="100" />
+          <line x1="335" y1="115" x2="425" y2="115" />
+          <line x1="335" y1="130" x2="425" y2="130" />
+          <line x1="335" y1="145" x2="425" y2="145" />
+        </g>
+        <text x="380" y="158" textAnchor="middle" opacity="0.7">
+          uniform / quantile / Lloyd-Max
+        </text>
+
+        <rect
+          x="470"
+          y="60"
+          width="150"
+          height="100"
+          rx="8"
+          fill="var(--color-panel)"
+          stroke="currentColor"
+          strokeWidth="1.3"
+        />
+        <text x="545" y="80" textAnchor="middle" fontWeight="600">
+          Tokens
+        </text>
+        <text x="545" y="105" textAnchor="middle" opacity="0.85">
+          V1, V2, … V12
+        </text>
+        <text x="545" y="125" textAnchor="middle" opacity="0.7">
+          (band, q) | (k, α_k)
+        </text>
+        <text x="545" y="143" textAnchor="middle" opacity="0.7">
+          (centroid, depth, area)
+        </text>
+
+        <g
+          stroke="currentColor"
+          strokeWidth="1.4"
+          fill="none"
+          markerEnd="url(#arrowWord)"
+        >
+          <line x1="142" y1="110" x2="166" y2="110" />
+          <line x1="292" y1="110" x2="316" y2="110" />
+          <line x1="442" y1="110" x2="466" y2="110" />
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+function MixedMembershipSVG() {
+  return (
+    <svg
+      width="560"
+      height="240"
+      viewBox="0 0 560 240"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Mixed-membership reconstruction"
+      style={{ color: "var(--color-fg)" }}
+    >
+      <defs>
+        <linearGradient id="gradT1" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#0ea5e9" stopOpacity="0.8" />
+          <stop offset="100%" stopColor="#0ea5e9" stopOpacity="0.1" />
+        </linearGradient>
+        <linearGradient id="gradT2" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#f97316" stopOpacity="0.8" />
+          <stop offset="100%" stopColor="#f97316" stopOpacity="0.1" />
+        </linearGradient>
+        <linearGradient id="gradT3" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#22c55e" stopOpacity="0.8" />
+          <stop offset="100%" stopColor="#22c55e" stopOpacity="0.1" />
+        </linearGradient>
+      </defs>
+      <g
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="12"
+        fill="currentColor"
+      >
+        <rect
+          x="20"
+          y="80"
+          width="80"
+          height="80"
+          fill="var(--color-accent)"
+          opacity="0.85"
+        />
+        <text x="60" y="180" textAnchor="middle" fontWeight="600">
+          píxel d
+        </text>
+
+        <text x="160" y="62" fontWeight="600">
+          θ_d (mezcla)
+        </text>
+        <g>
+          <rect x="160" y="80" width="200" height="20" fill="#0ea5e9" />
+          <rect x="360" y="80" width="120" height="20" fill="#f97316" />
+          <rect x="480" y="80" width="50" height="20" fill="#22c55e" />
+          <text x="260" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+            tópico 1 — 0.59
+          </text>
+          <text x="420" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+            tópico 2 — 0.27
+          </text>
+          <text x="505" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+            t3
+          </text>
+        </g>
+
+        <text x="160" y="130" fontWeight="600">
+          φ_k (firmas tópicas)
+        </text>
+        <g transform="translate(160, 140)">
+          <path
+            d="M 0 60 C 30 40, 60 70, 90 30 S 150 50, 200 35"
+            stroke="#0ea5e9"
+            strokeWidth="1.8"
+            fill="url(#gradT1)"
+          />
+        </g>
+        <g transform="translate(160, 165)">
+          <path
+            d="M 0 50 C 30 30, 70 60, 110 25 S 170 50, 200 45"
+            stroke="#f97316"
+            strokeWidth="1.8"
+            fill="url(#gradT2)"
+          />
+        </g>
+        <g transform="translate(160, 190)">
+          <path
+            d="M 0 40 C 40 25, 80 45, 120 15 S 180 30, 200 28"
+            stroke="#22c55e"
+            strokeWidth="1.8"
+            fill="url(#gradT3)"
+          />
+        </g>
+
+        <text x="400" y="130" fontWeight="600">
+          Reconstrucción
+        </text>
+        <text x="400" y="148" opacity="0.85">
+          Σ θ_dk · φ_k
+        </text>
+        <g transform="translate(400, 160)">
+          <path
+            d="M 0 50 C 25 25, 60 65, 95 20 S 145 40, 150 35"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            fill="none"
+          />
+        </g>
+      </g>
+    </svg>
   );
 }

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import { Figure } from "@/components/Figure";
-import { Math } from "@/components/Math";
+import { Equation } from "@/components/Equation";
 import { PageShell } from "@/components/PageShell";
 import { Section } from "@/components/Section";
 
@@ -21,15 +21,15 @@ export default function MethodologyTheory() {
           Bajo el modelo más popular — Latent Dirichlet Allocation (Blei, Ng &amp;
           Jordan, 2003) — un corpus de <em>D</em> documentos sobre un vocabulario
           de tamaño <em>V</em> se explica con dos colecciones de distribuciones:{" "}
-          <Math tex="\theta_d \in \Delta^{K-1}" /> es la mezcla de tópicos del
-          documento <em>d</em>, y <Math tex="\phi_k \in \Delta^{V-1}" /> es la
+          <Equation tex="\theta_d \in \Delta^{K-1}" /> es la mezcla de tópicos del
+          documento <em>d</em>, y <Equation tex="\phi_k \in \Delta^{V-1}" /> es la
           distribución de palabras del tópico <em>k</em>. Cada palabra observada
-          se genera tirando primero un tópico desde <Math tex="\theta_d" /> y
-          luego una palabra desde el <Math tex="\phi_k" /> correspondiente.
+          se genera tirando primero un tópico desde <Equation tex="\theta_d" /> y
+          luego una palabra desde el <Equation tex="\phi_k" /> correspondiente.
         </p>
         <p className="mt-3">
-          La inferencia recupera <Math tex="\theta" />, <Math tex="\phi" /> y la
-          asignación tópico-por-palabra <Math tex="z" />. El resultado es una
+          La inferencia recupera <Equation tex="\theta" />, <Equation tex="\phi" /> y la
+          asignación tópico-por-palabra <Equation tex="z" />. El resultado es una
           descomposición compacta, interpretable y mixta del corpus: cada
           documento es una mezcla de tópicos en lugar de pertenecer a una sola
           categoría dura.
@@ -47,10 +47,10 @@ export default function MethodologyTheory() {
 
         <p>
           La distribución conjunta del modelo factoriza así (con priors
-          Dirichlet sobre <Math tex="\theta_d" /> y <Math tex="\phi_k" />):
+          Dirichlet sobre <Equation tex="\theta_d" /> y <Equation tex="\phi_k" />):
         </p>
 
-        <Math
+        <Equation
           block
           tex="p(\theta, \phi, z, w \mid \alpha, \eta) = \prod_{k=1}^{K} p(\phi_k \mid \eta) \, \prod_{d=1}^{D} p(\theta_d \mid \alpha) \prod_{n=1}^{N_d} p(z_{d,n} \mid \theta_d) \, p(w_{d,n} \mid z_{d,n}, \phi_{1:K})"
         />
@@ -59,7 +59,7 @@ export default function MethodologyTheory() {
           La verosimilitud marginal del corpus se obtiene integrando los
           latentes continuos y sumando sobre las asignaciones discretas:
         </p>
-        <Math
+        <Equation
           block
           tex="p(w \mid \alpha, \eta) = \int \int \, \prod_{k} p(\phi_k \mid \eta) \, \prod_{d} p(\theta_d \mid \alpha) \prod_{n} \sum_{k=1}^{K} \theta_{d,k} \, \phi_{k, w_{d,n}} \, d\theta \, d\phi"
         />
@@ -78,9 +78,9 @@ export default function MethodologyTheory() {
       >
         <p>
           Una imagen hiperespectral (HSI) es un cubo{" "}
-          <Math tex="X \in \mathbb{R}^{H \times W \times B}" />, donde cada
-          píxel <Math tex="(i, j)" /> tiene un espectro{" "}
-          <Math tex="x_{ij} = (x_{ij,1}, \dots, x_{ij,B})" /> con la reflectancia
+          <Equation tex="X \in \mathbb{R}^{H \times W \times B}" />, donde cada
+          píxel <Equation tex="(i, j)" /> tiene un espectro{" "}
+          <Equation tex="x_{ij} = (x_{ij,1}, \dots, x_{ij,B})" /> con la reflectancia
           observada en cada una de las <em>B</em> bandas espectrales. Bandas
           típicas: 200 (Indian Pines AVIRIS-Classic) a 224 (Salinas) a más de
           2000 (HIDSAG).
@@ -93,7 +93,7 @@ export default function MethodologyTheory() {
           derivada, coeficiente wavelet, código VQ, etc.) y (iv) qué constituye
           un documento (un píxel, una región SLIC, un parche, una muestra
           completa). El resultado es una matriz documento-término{" "}
-          <Math tex="C \in \mathbb{N}^{D \times V}" /> sobre la cual LDA puede
+          <Equation tex="C \in \mathbb{N}^{D \times V}" /> sobre la cual LDA puede
           inferir.
         </p>
 
@@ -119,8 +119,8 @@ export default function MethodologyTheory() {
           clase — falla en HSI porque cada espectro es por construcción una
           mezcla. La descomposición mixta de LDA captura esa realidad
           directamente:{" "}
-          <Math tex="\theta_d" /> es la composición topical del píxel{" "}
-          <em>d</em>, y la suma <Math tex="\sum_{k} \theta_{d,k} \phi_k" /> es
+          <Equation tex="\theta_d" /> es la composición topical del píxel{" "}
+          <em>d</em>, y la suma <Equation tex="\sum_{k} \theta_{d,k} \phi_k" /> es
           la firma reconstruida que el modelo cree que produjo las palabras
           observadas.
         </p>

--- a/frontend/src/state/useSelectionStore.ts
+++ b/frontend/src/state/useSelectionStore.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+
+export type DatasetFamily =
+  | "hsi-labelled"
+  | "hidsag-mineral"
+  | "usgs-reference"
+  | "msi-field"
+  | "unmixing-roi";
+
+export type RepresentationKind =
+  | "raw"
+  | "lda"
+  | "ntm"
+  | "dmr"
+  | "pca"
+  | "nmf"
+  | "ae";
+
+type SelectionState = {
+  family: DatasetFamily | null;
+  subset: string | null;
+  representation: RepresentationKind | null;
+  setFamily: (family: DatasetFamily | null) => void;
+  setSubset: (subset: string | null) => void;
+  setRepresentation: (rep: RepresentationKind | null) => void;
+  reset: () => void;
+};
+
+export const useSelectionStore = create<SelectionState>((set) => ({
+  family: null,
+  subset: null,
+  representation: null,
+  setFamily: (family) =>
+    set({ family, subset: null, representation: null }),
+  setSubset: (subset) => set({ subset, representation: null }),
+  setRepresentation: (representation) => set({ representation }),
+  reset: () => set({ family: null, subset: null, representation: null }),
+}));

--- a/frontend/src/state/useThemeStore.ts
+++ b/frontend/src/state/useThemeStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { applyTheme, readTheme, type Theme } from "@/lib/theme";
+
+type ThemeState = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  theme: readTheme(),
+  setTheme: (theme) => {
+    applyTheme(theme);
+    set({ theme });
+  },
+  toggleTheme: () => {
+    const next: Theme = get().theme === "dark" ? "light" : "dark";
+    applyTheme(next);
+    set({ theme: next });
+  },
+}));

--- a/frontend/src/state/workspaceMachine.ts
+++ b/frontend/src/state/workspaceMachine.ts
@@ -1,0 +1,106 @@
+import { setup, assign } from "xstate";
+
+import type {
+  DatasetFamily,
+  RepresentationKind,
+} from "@/state/useSelectionStore";
+
+export type WorkspaceView =
+  | "raw"
+  | "spectra"
+  | "labels"
+  | "segmentation"
+  | "embed2d"
+  | "embed3d"
+  | "topicMap"
+  | "topicVsLabel";
+
+export type WorkspaceContext = {
+  family: DatasetFamily | null;
+  subset: string | null;
+  rep: RepresentationKind | null;
+  view: WorkspaceView | null;
+  docId: string | null;
+};
+
+export type WorkspaceEvent =
+  | { type: "PICK_FAMILY"; family: DatasetFamily }
+  | { type: "PICK_SUBSET"; subset: string }
+  | { type: "PICK_REP"; rep: RepresentationKind }
+  | { type: "GO_VIEW"; view: WorkspaceView }
+  | { type: "PICK_DOC"; docId: string }
+  | { type: "BACK" };
+
+const initialContext: WorkspaceContext = {
+  family: null,
+  subset: null,
+  rep: null,
+  view: null,
+  docId: null,
+};
+
+/**
+ * Workspace wizard state machine — implements the FSM described in
+ * `_CAOS_MANAGE/wip/caos-lda-hsi/web-app-spec.md` §4.
+ *
+ * Step gates: each transition is unconditional in this skeleton; guards
+ * (e.g. `repAvailableForSubset`) will be added when the manifest is
+ * wired and the page-level UIs are implemented.
+ */
+export const workspaceMachine = setup({
+  types: {
+    context: {} as WorkspaceContext,
+    events: {} as WorkspaceEvent,
+  },
+}).createMachine({
+  id: "workspace",
+  initial: "pickFamily",
+  context: initialContext,
+  states: {
+    pickFamily: {
+      on: {
+        PICK_FAMILY: {
+          target: "pickSubset",
+          actions: assign({ family: ({ event }) => event.family }),
+        },
+      },
+    },
+    pickSubset: {
+      on: {
+        PICK_SUBSET: {
+          target: "pickRep",
+          actions: assign({ subset: ({ event }) => event.subset }),
+        },
+        BACK: { target: "pickFamily", actions: assign({ subset: null }) },
+      },
+    },
+    pickRep: {
+      on: {
+        PICK_REP: {
+          target: "explore",
+          actions: assign({ rep: ({ event }) => event.rep }),
+        },
+        BACK: { target: "pickSubset", actions: assign({ rep: null }) },
+      },
+    },
+    explore: {
+      initial: "raw",
+      on: {
+        GO_VIEW: {
+          target: ".dynamic",
+          actions: assign({ view: ({ event }) => event.view }),
+        },
+        PICK_DOC: {
+          target: "benchmarkFork",
+          actions: assign({ docId: ({ event }) => event.docId }),
+        },
+        BACK: { target: "pickRep" },
+      },
+      states: {
+        raw: {},
+        dynamic: {},
+      },
+    },
+    benchmarkFork: { type: "final" },
+  },
+});

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,75 @@
+@import "tailwindcss";
+
+/* Light/dark theme tokens. The data-theme attribute is set on <html>
+   before first paint by an inline script in index.html. */
+@theme {
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+}
+
+:root,
+[data-theme="light"] {
+  --color-bg: #fafbfc;
+  --color-fg: #0b1220;
+  --color-fg-subtle: #4b5563;
+  --color-fg-faint: #6b7280;
+  --color-panel: #ffffff;
+  --color-border: #e5e7eb;
+  --color-accent: #0369a1;
+  --color-accent-fg: #ffffff;
+  --color-accent-soft: #dbeafe;
+  --color-warn: #b45309;
+  --color-success: #047857;
+  --color-shadow: 0 1px 2px rgba(11, 18, 32, 0.06),
+    0 4px 10px rgba(11, 18, 32, 0.04);
+}
+
+[data-theme="dark"] {
+  --color-bg: #0b1220;
+  --color-fg: #e6edf3;
+  --color-fg-subtle: #9aa6b2;
+  --color-fg-faint: #6c7785;
+  --color-panel: #111827;
+  --color-border: #1f2937;
+  --color-accent: #38bdf8;
+  --color-accent-fg: #0b1220;
+  --color-accent-soft: #0c2233;
+  --color-warn: #fbbf24;
+  --color-success: #34d399;
+  --color-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 4px 10px rgba(0, 0, 0, 0.4);
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+declare module "*.json" {
+  const value: unknown;
+  export default value;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
             return "xstate";
           if (id.includes("node_modules/zustand")) return "zustand";
           if (id.includes("node_modules/lucide-react")) return "icons";
+          if (id.includes("node_modules/katex")) return "katex";
           return undefined;
         },
       },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
+
+const apiTarget = process.env.VITE_API_BASE ?? "http://127.0.0.1:8105";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      "/api": { target: apiTarget, changeOrigin: true },
+      "/generated": { target: apiTarget, changeOrigin: true },
+    },
+  },
+  build: {
+    target: "es2022",
+    sourcemap: false,
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          if (id.includes("node_modules/react") || id.includes("node_modules/react-dom"))
+            return "react";
+          if (id.includes("node_modules/react-router")) return "router";
+          if (id.includes("node_modules/@tanstack")) return "query";
+          if (id.includes("node_modules/i18next") || id.includes("node_modules/react-i18next"))
+            return "i18n";
+          if (id.includes("node_modules/xstate") || id.includes("node_modules/@xstate"))
+            return "xstate";
+          if (id.includes("node_modules/zustand")) return "zustand";
+          if (id.includes("node_modules/lucide-react")) return "icons";
+          return undefined;
+        },
+      },
+    },
+  },
+});

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -109,7 +109,9 @@ $paths = @(
     "/generated/topic_to_library/indian-pines-corrected.json",
     "/generated/spatial/indian-pines-corrected.json",
     "/generated/wordifications/indian-pines-corrected_V3_uniform_Q16.json",
-    "/generated/manifests/index.json"
+    "/generated/manifests/index.json",
+    # ---- SPA root (only present once frontend/dist exists) ----
+    "/"
 )
 
 foreach ($path in $paths) {

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -107,6 +107,8 @@ paths=(
   "/generated/spatial/indian-pines-corrected.json"
   "/generated/wordifications/indian-pines-corrected_V3_uniform_Q16.json"
   "/generated/manifests/index.json"
+  # ---- SPA root (only present once frontend/dist exists) ----
+  "/"
 )
 
 for path in "${paths[@]}"; do


### PR DESCRIPTION
Closes #29. Chained on **PR #28** (Theory). Both depend on PR #21 (skeleton).

## Sections

- **El espacio de configuraciones** — 12 × 9 grid (recipe × scheme × Q) rendered as inline SVG. One visual that positions every shipped config.
- **Esquemas de cuantización** — uniform / quantile / Lloyd-Max as cards
- **Las doce recetas** — table of V1..V12 with token shape, vocab size, one-line summary and 3 bullets each
- **¿Qué cuenta como un documento?** — pixel / patch / SLIC / Felzenszwalb granularities, custom SVG, with the cross-method-agreement headline (off-diagonal ARI ~0.15 across scenes)

## Refactor

`components/Math.tsx` → `components/Equation.tsx`. The original name shadowed the global `Math` object, breaking any module that uses `Math.floor` / `Math.PI` / etc. (Real failure: Representations.tsx uses `Math.floor` for its grid layout.) The KaTeX wrapper is now `<Equation tex=... />`.

## Bundle

| Chunk | Before | After | Δ |
|---|---:|---:|---:|
| Theory | 16.89 / 5.25 KB gzip | 15.76 / 4.83 KB gzip | -0.4 KB |
| Representations | 0.29 KB | 12.15 / 4.64 KB gzip | +12 KB |
| `katex` chunk | 76.9 KB gzip | unchanged | 0 |

KaTeX still only loads when a Methodology sub-page opens.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] No "wave/cycle/sprint/master-plan/pending/wip" strings in the page copy
- [x] No fake data — pure didactic content + custom SVG

## Reference
- `_CAOS_MANAGE/wip/caos-lda-hsi/web-app-spec.md` §2.2 Data types and document representations