### PR TITLE
B-12: API endpoint + Benchmarks viz for LLM tea-leaves

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -276,6 +276,9 @@ class Settings(BaseSettings):
     def endmember_baseline_path(self, scene_id: str) -> Path:
         return self.data_path / "derived" / "endmember_baseline" / f"{scene_id}.json"
 
+    def llm_tea_leaves_path(self, scene_id: str) -> Path:
+        return self.data_path / "derived" / "llm_tea_leaves" / f"{scene_id}.json"
+
     @property
     def cross_scene_transfer_path(self) -> Path:
         return self.data_path / "derived" / "cross_scene_transfer" / "transfer_matrix.json"

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -706,6 +706,15 @@ def endmember_baseline(scene_id: str) -> dict:
         raise HTTPException(status_code=404, detail=f"endmember_baseline for '{scene_id}' not generated yet") from exc
 
 
+@router.get("/llm-tea-leaves/{scene_id}")
+def llm_tea_leaves(scene_id: str) -> dict:
+    from app.services.content import get_llm_tea_leaves
+    try:
+        return get_llm_tea_leaves(scene_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"llm_tea_leaves for '{scene_id}' not generated yet (set ANTHROPIC_API_KEY and run build_b12_llm_tea_leaves)") from exc
+
+
 @router.get("/cross-scene-transfer")
 def cross_scene_transfer() -> dict:
     from app.services.content import get_cross_scene_transfer

--- a/app/services/content.py
+++ b/app/services/content.py
@@ -465,6 +465,10 @@ def get_endmember_baseline(scene_id: str) -> dict:
     return _load_or_404(get_settings().endmember_baseline_path(scene_id))
 
 
+def get_llm_tea_leaves(scene_id: str) -> dict:
+    return _load_or_404(get_settings().llm_tea_leaves_path(scene_id))
+
+
 def get_cross_scene_transfer() -> dict:
     return _load_or_404(get_settings().cross_scene_transfer_path)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -298,6 +298,10 @@ export const api = {
     request<MutualInformation>(
       `/api/mutual-information/${encodeURIComponent(sceneId)}`,
     ),
+  llmTeaLeaves: (sceneId: string) =>
+    request<LlmTeaLeaves>(
+      `/api/llm-tea-leaves/${encodeURIComponent(sceneId)}`,
+    ),
   buffer: (path: string) => requestBuffer(path),
 };
 
@@ -516,3 +520,31 @@ export type TopicRoutedClassifier = {
     macro_f1_ci95: [number, number];
   }[];
 };
+
+export type LlmTeaLeavesTopic = {
+  topic_id: number;
+  skipped?: boolean;
+  reason?: string;
+  top_words?: string[];
+  intrusion_candidates?: string[];
+  intruder?: string;
+  llm_chose?: string | null;
+  intrusion_correct?: boolean;
+  llm_label?: string;
+};
+
+export type LlmTeaLeaves = {
+  scene_id: string;
+  topic_count: number;
+  model: string;
+  lambda_used: string;
+  top_n_per_topic: number;
+  n_attempted: number;
+  n_correct_intrusion: number;
+  intrusion_accuracy: number;
+  per_topic: LlmTeaLeavesTopic[];
+  framework_axis: string;
+  generated_at: string;
+  builder_version: string;
+};
+

--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -118,9 +118,131 @@ export default function Benchmarks() {
           <HidsagBenchmarks />
           <HidsagPreprocessing />
           <HidsagCrossPreprocessingStability />
+          <LlmTeaLeavesSection />
         </>
       )}
     </PageShell>
+  );
+}
+
+const LABELLED_SCENES = [
+  "indian-pines-corrected",
+  "salinas-corrected",
+  "salinas-a-corrected",
+  "pavia-university",
+  "kennedy-space-center",
+  "botswana",
+];
+
+function LlmTeaLeavesSection() {
+  const queries = useQueries({
+    queries: LABELLED_SCENES.map((sceneId) => ({
+      queryKey: ["llm-tea-leaves", sceneId],
+      queryFn: () => api.llmTeaLeaves(sceneId),
+      retry: false,
+    })),
+  });
+  const ready = queries
+    .map((q, i) => ({ sceneId: LABELLED_SCENES[i]!, data: q.data }))
+    .filter((row) => row.data);
+
+  if (ready.length === 0) {
+    return (
+      <Section
+        title="B-12 — LLM tea-leaves (Stammbach et al. TACL 2024)"
+        lead="Word-intrusion + coherent-label probes via Anthropic Claude. Builder is gated by ANTHROPIC_API_KEY; outputs land in data/derived/llm_tea_leaves once the env var is set and the builder is run."
+      >
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
+          No scenes evaluated yet. Set <code className="font-mono">ANTHROPIC_API_KEY</code>{" "}
+          and run <code className="font-mono">build-b12-llm-tea-leaves</code> to populate.
+        </p>
+      </Section>
+    );
+  }
+
+  return (
+    <Section
+      title="B-12 — LLM tea-leaves (Stammbach et al. TACL 2024)"
+      lead="Per-scene word-intrusion accuracy + per-topic LLM labels. Higher intrusion accuracy means the LLM correctly identifies the foreign word slipped into each topic's top-10 — a coherence signal that correlates with NPMI in prior work."
+    >
+      <div className="space-y-6">
+        <table
+          className="w-full text-sm"
+          style={{ color: "var(--color-text)" }}
+        >
+          <thead>
+            <tr style={{ color: "var(--color-text-muted)" }}>
+              <th className="text-left font-mono text-[12px] pb-2">scene</th>
+              <th className="text-left font-mono text-[12px] pb-2">topics</th>
+              <th className="text-left font-mono text-[12px] pb-2">
+                intrusion accuracy
+              </th>
+              <th className="text-left font-mono text-[12px] pb-2">model</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ready.map(({ sceneId, data }) => (
+              <tr
+                key={sceneId}
+                style={{ borderTop: "1px solid var(--color-border)" }}
+              >
+                <td className="py-1.5 font-mono">{sceneId}</td>
+                <td className="py-1.5">{data!.topic_count}</td>
+                <td className="py-1.5">
+                  <span style={{ color: "var(--color-accent)" }}>
+                    {(data!.intrusion_accuracy * 100).toFixed(1)}%
+                  </span>{" "}
+                  ({data!.n_correct_intrusion}/{data!.n_attempted})
+                </td>
+                <td className="py-1.5 font-mono text-[12px]">{data!.model}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {ready.map(({ sceneId, data }) => (
+          <details
+            key={sceneId}
+            className="rounded-md border p-3"
+            style={{
+              borderColor: "var(--color-border)",
+              backgroundColor: "var(--color-panel)",
+            }}
+          >
+            <summary className="cursor-pointer font-mono text-[13px]">
+              {sceneId} — per-topic LLM labels
+            </summary>
+            <ul className="mt-2 space-y-1 text-sm">
+              {data!.per_topic.map((tt) => (
+                <li key={tt.topic_id} className="font-mono text-[12.5px]">
+                  <span style={{ color: "var(--color-text-muted)" }}>
+                    topic {tt.topic_id}
+                  </span>{" "}
+                  {tt.skipped ? (
+                    <span style={{ color: "var(--color-text-muted)" }}>
+                      — skipped ({tt.reason})
+                    </span>
+                  ) : (
+                    <>
+                      <span
+                        style={{
+                          color: tt.intrusion_correct
+                            ? "var(--color-accent)"
+                            : "var(--color-text-muted)",
+                        }}
+                      >
+                        [{tt.intrusion_correct ? "✓" : "✗"}]
+                      </span>{" "}
+                      {tt.llm_label || "(no label)"}
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </details>
+        ))}
+      </div>
+    </Section>
   );
 }
 


### PR DESCRIPTION
Closes #81. Follow-up to PR #80.

## Summary

- New `/api/llm-tea-leaves/{scene_id}` route + service helper + settings path.
- `frontend/src/api/client.ts`: `LlmTeaLeaves` + `LlmTeaLeavesTopic` types and `api.llmTeaLeaves` method.
- `frontend/src/pages/Benchmarks.tsx`: new `LlmTeaLeavesSection` rendered after the HIDSAG cross-preprocessing block. Graceful empty-state when no scene has been evaluated (six 404s); populated state shows a 6-row intrusion-accuracy table plus per-scene `<details>` blocks listing each topic's LLM label with a ✓/✗ on intrusion correctness.

## Test plan

- [x] `pnpm tsc --noEmit` green.
- [x] `pnpm build` green; Benchmarks chunk 21.4 KB → 5.91 KB gzip.
- [x] Verified locally that the section renders the empty-state hint when no llm_tea_leaves data exists.