### PR TITLE
i18n: default language is now English

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -20,7 +20,7 @@ void i18n
       es: { common: esCommon, nav: esNav, pages: esPages },
       en: { common: enCommon, nav: enNav, pages: enPages },
     },
-    fallbackLng: "es",
+    fallbackLng: "en",
     supportedLngs: SUPPORTED_LANGUAGES,
     defaultNS: "common",
     ns: ["common", "nav", "pages"],


### PR DESCRIPTION
Closes #84.

## Summary
- `frontend/src/i18n/config.ts`: `fallbackLng: 'en'`
- `frontend/index.html`: `<html lang="en">`
- LanguageDetector still consults localStorage first, so previously-set `caos.lang=es` is preserved.

## Test plan
- [x] `pnpm build` green
- [ ] Cleared localStorage → app starts in EN