### PR TITLE
API + viz: super-topics endpoint + Benchmarks cross-scene cluster table

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -280,6 +280,10 @@ class Settings(BaseSettings):
         return self.data_path / "derived" / "llm_tea_leaves" / f"{scene_id}.json"
 
     @property
+    def super_topics_path(self) -> Path:
+        return self.data_path / "derived" / "super_topics" / "super_topics.json"
+
+    @property
     def cross_scene_transfer_path(self) -> Path:
         return self.data_path / "derived" / "cross_scene_transfer" / "transfer_matrix.json"
 

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -715,6 +715,15 @@ def llm_tea_leaves(scene_id: str) -> dict:
         raise HTTPException(status_code=404, detail=f"llm_tea_leaves for '{scene_id}' not generated yet (set ANTHROPIC_API_KEY and run build_b12_llm_tea_leaves)") from exc
 
 
+@router.get("/super-topics")
+def super_topics() -> dict:
+    from app.services.content import get_super_topics
+    try:
+        return get_super_topics()
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="super_topics not generated yet") from exc
+
+
 @router.get("/cross-scene-transfer")
 def cross_scene_transfer() -> dict:
     from app.services.content import get_cross_scene_transfer

--- a/app/services/content.py
+++ b/app/services/content.py
@@ -469,6 +469,10 @@ def get_llm_tea_leaves(scene_id: str) -> dict:
     return _load_or_404(get_settings().llm_tea_leaves_path(scene_id))
 
 
+def get_super_topics() -> dict:
+    return _load_or_404(get_settings().super_topics_path)
+
+
 def get_cross_scene_transfer() -> dict:
     return _load_or_404(get_settings().cross_scene_transfer_path)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -302,6 +302,7 @@ export const api = {
     request<LlmTeaLeaves>(
       `/api/llm-tea-leaves/${encodeURIComponent(sceneId)}`,
     ),
+  superTopics: () => request<SuperTopics>(`/api/super-topics`),
   buffer: (path: string) => requestBuffer(path),
 };
 
@@ -544,6 +545,41 @@ export type LlmTeaLeaves = {
   intrusion_accuracy: number;
   per_topic: LlmTeaLeavesTopic[];
   framework_axis: string;
+  generated_at: string;
+  builder_version: string;
+};
+
+export type SuperTopicMember = {
+  scene_id: string;
+  topic_k: number;
+  scene_wavelength_coverage: string;
+};
+
+export type SuperTopicCluster = {
+  cluster_id: number;
+  n_members: number;
+  scene_set: string[];
+  members: SuperTopicMember[];
+  centroid_profile_round6: number[];
+};
+
+export type SuperTopicCut = {
+  cut_level: number;
+  n_clusters: number;
+  clusters: SuperTopicCluster[];
+};
+
+export type SuperTopics = {
+  n_topics_total: number;
+  n_scenes: number;
+  scenes: string[];
+  common_grid: { low_nm: number; high_nm: number; n_bands: number };
+  linkage_method: string;
+  distance: string;
+  linkage_matrix_round6: number[][];
+  cuts: SuperTopicCut[];
+  scene_pair_super_topic_overlap_at_cut8: Record<string, Record<string, number>>;
+  members: SuperTopicMember[];
   generated_at: string;
   builder_version: string;
 };

--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -119,6 +119,7 @@ export default function Benchmarks() {
           <HidsagPreprocessing />
           <HidsagCrossPreprocessingStability />
           <LlmTeaLeavesSection />
+          <SuperTopicsSection />
         </>
       )}
     </PageShell>
@@ -133,6 +134,75 @@ const LABELLED_SCENES = [
   "kennedy-space-center",
   "botswana",
 ];
+
+function SuperTopicsSection() {
+  const { data, error } = useQuery({
+    queryKey: ["super-topics"],
+    queryFn: () => api.superTopics(),
+    retry: false,
+  });
+  if (error || !data) {
+    return (
+      <Section
+        title="Cross-scene super-topics (master plan §12)"
+        lead="Hierarchical clustering of every topic across all six labelled scenes on the common 400–2500 nm grid (average linkage on cosine). Reveals which topics group across scenes vs. stay scene-local."
+      >
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
+          super_topics payload not available yet.
+        </p>
+      </Section>
+    );
+  }
+  const cut8 =
+    data.cuts.find((c) => c.cut_level === 8) ?? data.cuts[data.cuts.length - 1]!;
+  const sortedClusters = [...cut8.clusters].sort(
+    (a, b) => b.scene_set.length - a.scene_set.length || b.n_members - a.n_members,
+  );
+  return (
+    <Section
+      title="Cross-scene super-topics (master plan §12)"
+      lead={`Hierarchical clustering of all ${data.n_topics_total} topics across ${data.n_scenes} labelled scenes on the common 400–2500 nm grid (average linkage on cosine). Cut level shown: ${cut8.cut_level} → ${cut8.n_clusters} super-topic clusters. Multi-scene clusters identify topics that recur across data sets — what "unites" the scenes.`}
+    >
+      <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
+        <thead>
+          <tr style={{ color: "var(--color-text-muted)" }}>
+            <th className="text-left font-mono text-[12px] pb-2">cluster</th>
+            <th className="text-left font-mono text-[12px] pb-2">members</th>
+            <th className="text-left font-mono text-[12px] pb-2">scenes</th>
+            <th className="text-left font-mono text-[12px] pb-2">topic ids</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedClusters.map((c) => (
+            <tr
+              key={c.cluster_id}
+              style={{ borderTop: "1px solid var(--color-border)" }}
+            >
+              <td className="py-1.5 font-mono">#{c.cluster_id}</td>
+              <td className="py-1.5">{c.n_members}</td>
+              <td
+                className="py-1.5 text-[12.5px]"
+                style={{
+                  color:
+                    c.scene_set.length > 1
+                      ? "var(--color-accent)"
+                      : "var(--color-text-muted)",
+                }}
+              >
+                {c.scene_set.join(", ")}
+              </td>
+              <td className="py-1.5 font-mono text-[12px]">
+                {c.members
+                  .map((m) => `${m.scene_id.split("-")[0]}:${m.topic_k}`)
+                  .join(" · ")}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Section>
+  );
+}
 
 function LlmTeaLeavesSection() {
   const queries = useQueries({

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -88,6 +88,7 @@ $paths = @(
     "/api/topic-spatial-full/indian-pines-corrected",
     "/api/endmember-baseline/indian-pines-corrected",
     "/api/cross-scene-transfer",
+    "/api/super-topics",
     "/api/bayesian-comparison/classification-labelled",
     "/generated/groupings/felzenszwalb/indian-pines-corrected.json",
     "/generated/cross_method_agreement/indian-pines-corrected.json",

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -85,6 +85,7 @@ paths=(
   "/api/topic-spatial-full/indian-pines-corrected"
   "/api/endmember-baseline/indian-pines-corrected"
   "/api/cross-scene-transfer"
+  "/api/super-topics"
   "/api/bayesian-comparison/classification-labelled"
   "/generated/groupings/felzenszwalb/indian-pines-corrected.json"
   "/generated/cross_method_agreement/indian-pines-corrected.json"


### PR DESCRIPTION
Closes #86. Fills the audit gap: builder shipped (PR #23) but API + frontend never wired.

## Summary
- `/api/super-topics` route, service, settings path
- `api.superTopics()` typed client + full type coverage
- New `SuperTopicsSection` in Benchmarks: cluster table at cut level 8 with multi-scene clusters highlighted in accent color
- Smoke harness extended with `/api/super-topics`

## Test plan
- [x] `pnpm build` green
- [ ] `/api/super-topics` returns 200 on production after deploy
- [ ] Section renders 8 clusters; multi-scene ones highlighted