### PR TITLE
cycle 53 (UI): Benchmarks DeepGateSection — surface topic-routed-deep-gate 5-method comparison

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -266,6 +266,10 @@ export const api = {
     request<TopicRoutedClassifier>(
       `/api/topic-routed-classifier/${encodeURIComponent(sceneId)}`,
     ),
+  topicRoutedDeepGate: (sceneId: string) =>
+    request<TopicRoutedDeepGate>(
+      `/api/topic-routed-deep-gate/${encodeURIComponent(sceneId)}`,
+    ),
   hidsagMethodStatistics: (subsetCode: string) =>
     request<HidsagMethodStatistics>(
       `/api/method-statistics-hidsag/${encodeURIComponent(subsetCode)}`,
@@ -572,6 +576,20 @@ export type TopicRoutedClassifier = {
     macro_f1_mean: number;
     macro_f1_ci95: [number, number];
   }[];
+};
+
+export type TopicRoutedDeepGate = {
+  scene_id: string;
+  n_documents: number;
+  n_classes: number;
+  gate_methods: string[];
+  method_metrics: Record<string, RoutedMethodMetrics>;
+  ranked_by_macro_f1_mean: {
+    method: string;
+    macro_f1_mean: number;
+    macro_f1_ci95: [number, number];
+  }[];
+  framework_axis?: string;
 };
 
 export type LlmTeaLeavesTopic = {

--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -117,6 +117,7 @@ export default function Benchmarks() {
           </Section>
 
           <MultiAxisBatterySection />
+          <DeepGateSection />
           <BayesianHdiSection />
           <DeepKCurveSection />
           <BetaVaeCollapseSection />
@@ -1153,6 +1154,141 @@ function BetaVaeCollapseSection() {
         signal; encoder maps every input to N(0, I)). Salinas-A resists collapse and even gains
         with β (compact 6-class signal dominates the regulariser). Pavia U degrades monotonically
         with β. The β=4 default sits at the inflection point.
+      </p>
+    </Section>
+  );
+}
+
+function DeepGateSection() {
+  const queries = useQueries({
+    queries: LABELLED_SCENES.map((sc) => ({
+      queryKey: ["topic-routed-deep-gate", sc],
+      queryFn: () => api.topicRoutedDeepGate(sc),
+      retry: false,
+    })),
+  });
+  const ready = queries.every((q) => q.data !== undefined || q.error);
+  if (!ready) {
+    return (
+      <Section
+        title="B-3 follow-up — any encoder as gate? raw vs θ-routed vs deep gates"
+        lead="Loading deep-gate payloads from /api/topic-routed-deep-gate/{scene}…"
+      >
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+      </Section>
+    );
+  }
+
+  const METHODS = [
+    { key: "raw_logistic", label: "raw" },
+    { key: "theta_routed", label: "θ_routed" },
+    { key: "pca_8_routed", label: "PCA-8" },
+    { key: "cae_1d_8_routed", label: "CAE-1D-8" },
+    { key: "beta_vae_8_routed", label: "β-VAE-8" },
+  ];
+
+  type Cell = { mean: number; std: number };
+  type Row = { scene: string; cells: Record<string, Cell | null>; winner: string };
+
+  const rows: Row[] = LABELLED_SCENES.map((sc, i) => {
+    const data = queries[i]?.data;
+    const cells: Record<string, Cell | null> = {};
+    let winner = "";
+    let bestMean = -Infinity;
+    for (const m of METHODS) {
+      const block = data?.method_metrics?.[m.key];
+      const f1 = block?.macro_f1;
+      if (f1 && Number.isFinite(f1.mean)) {
+        cells[m.key] = { mean: f1.mean, std: f1.std };
+        if (f1.mean > bestMean) {
+          bestMean = f1.mean;
+          winner = m.key;
+        }
+      } else {
+        cells[m.key] = null;
+      }
+    }
+    return { scene: sc, cells, winner };
+  });
+
+  const wins: Record<string, number> = {};
+  for (const m of METHODS) wins[m.key] = 0;
+  for (const r of rows) if (r.winner) wins[r.winner] = (wins[r.winner] ?? 0) + 1;
+
+  return (
+    <Section
+      title="B-3 follow-up — any encoder as gate? raw vs θ-routed vs deep gates"
+      lead="Five candidate gates compete on per-fold macro F1 across labelled scenes: raw_logistic (no gating), θ_routed (LDA topic mixture, natural Dirichlet simplex), and three deep gates (PCA-8, CAE-1D-8, β-VAE-8) projected onto the simplex via softmax. Tests whether any deep encoder recovers θ's gating advantage. Source: /api/topic-routed-deep-gate/{scene}."
+    >
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
+          <thead>
+            <tr style={{ color: "var(--color-text-muted)" }}>
+              <th className="text-left font-mono text-[12px] pb-2 pr-3">scene</th>
+              {METHODS.map((m) => (
+                <th key={m.key} className="text-right font-mono text-[12px] pb-2 pr-3">
+                  {m.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.scene} style={{ borderTop: "1px solid var(--color-border)" }}>
+                <td className="py-1.5 pr-3 font-mono">{r.scene}</td>
+                {METHODS.map((m) => {
+                  const c = r.cells[m.key];
+                  const isWinner = r.winner === m.key;
+                  return (
+                    <td
+                      key={m.key}
+                      className="py-1.5 pr-3 text-right font-mono"
+                      style={{
+                        color: isWinner ? "var(--color-accent)" : "var(--color-text)",
+                        fontWeight: isWinner ? 600 : 400,
+                      }}
+                    >
+                      {c ? c.mean.toFixed(3) : "—"}
+                      {c ? (
+                        <span
+                          className="ml-1 text-[10px]"
+                          style={{ color: "var(--color-text-muted)", fontWeight: 400 }}
+                        >
+                          ±{c.std.toFixed(3)}
+                        </span>
+                      ) : null}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+            <tr style={{ borderTop: "2px solid var(--color-border)" }}>
+              <td
+                className="py-1.5 pr-3 font-mono text-[11px]"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                wins (best per scene)
+              </td>
+              {METHODS.map((m) => (
+                <td
+                  key={m.key}
+                  className="py-1.5 pr-3 text-right font-mono text-[11px]"
+                  style={{ color: "var(--color-text-muted)" }}
+                >
+                  {wins[m.key]}/{LABELLED_SCENES.length}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
+        Honest finding: deep gates with naive softmax-to-simplex projection do <em>not</em>{" "}
+        outperform raw_logistic or θ_routed. raw_logistic wins on most scenes; θ_routed
+        ties or wins where Dirichlet-simplex structure aligns with class topology
+        (e.g. Salinas). The advantage of θ comes from the natural simplex constraint
+        of Dirichlet-distributed topic mixtures, not merely from compressing to K
+        dimensions — softmaxed deep latents fail to recover the gating mechanism.
       </p>
     </Section>
   );


### PR DESCRIPTION
Closes #208.

Surfaces cycle 51's \`/api/topic-routed-deep-gate/{scene}\` payload as a Benchmarks section. Previously the API was deployed but invisible.

## Section content
- Row × column table: 6 labelled scenes × 5 gate methods (raw, θ_routed, PCA-8, CAE-1D-8, β-VAE-8)
- Per-row winner in accent colour
- Wins-per-method footer
- Honest commentary: deep gates with naive softmax-to-simplex projection do NOT outperform raw or θ — θ's advantage comes from the natural Dirichlet simplex, not merely from K-dim compression

## Files
- \`frontend/src/api/client.ts\` — adds \`topicRoutedDeepGate\` fn + \`TopicRoutedDeepGate\` type
- \`frontend/src/pages/Benchmarks.tsx\` — adds \`DeepGateSection\` between MultiAxisBattery and BayesianHdi

Type-check clean, build clean.