### PR TITLE
cycle 57 (UI): Workspace deep-latents tab — add cae_3d_full_4 to dropdown

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2392,6 +2392,7 @@ const DEEP_METHOD_OPTIONS: {
   { key: "cae_3d_8",   label: "CAE-3D K=8 (anchor)",   K: 8,  family: "cae_3d" },
   { key: "cae_3d_16",  label: "CAE-3D K=16 (anchor)",  K: 16, family: "cae_3d" },
   { key: "cae_3d_32",  label: "CAE-3D K=32 (anchor)",  K: 32, family: "cae_3d" },
+  { key: "cae_3d_full_4", label: "CAE-3D K=4 (full-patch)", K: 4, family: "cae_3d_full" },
   { key: "cae_3d_full_8", label: "CAE-3D K=8 (full-patch)", K: 8, family: "cae_3d_full" },
 ];
 


### PR DESCRIPTION
Closes #219. One-line addition: `cae_3d_full_4` joins `cae_3d_full_8` in the Workspace > Deep latents dropdown so users can pick the K=4 full-patch latent shipped in cycle 55.