### PR TITLE
cycle 69 (i18n): wire t() across new visual components + comprehensive en/es entries

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -2,11 +2,136 @@
   "overview": {
     "title": "Overview",
     "lead": "CAOS LDA HSI explores what probabilistic topic models can capture when documents are pixels, regions, or measurements drawn from hyperspectral imagery.",
-    "cta_workspace": "Open the workspace",
-    "cta_methodology": "Read the methodology"
+    "cta_workspace": "Open the Workspace",
+    "cta_methodology": "Read the Methodology",
+    "hero": {
+      "spectral_signature": "Live spectral signature",
+      "indian_pines_caption": "Indian Pines · 16 classes · {{bands}} bands · 400–2500 nm",
+      "indian_pines_caption_loading": "Indian Pines · live data loading…",
+      "title": "We treat every hyperspectral pixel as a document.",
+      "caption": "Each curve is the mean signature of one agronomic class in the Indian Pines cube. The inter-class diversity at 1100 / 1400 / 1900 nm — water and feldspar absorptions — is what the textual corpus has to recover discretely. That signature is a document; the project's question is which topics (shared latent structure) live in it.",
+      "datacube_anatomy": "Datacube anatomy",
+      "datacube_caption": "An HSI cube is (H × W × B). Each pixel x[i, j] is a B-band spectral vector. The project walks it as a corpus, discretises it into tokens, fits topics θ ∈ Δ^(K-1) and compares them against K-dim baselines."
+    },
+    "headlines": {
+      "datasets_label": "Datasets",
+      "datasets_sub": "across 4 families",
+      "recipes_label": "Wordification recipes",
+      "recipes_sub": "V1 (band) → V12 (GMM)",
+      "builders_label": "Builders",
+      "builders_sub": "data-pipeline modules",
+      "artifacts_label": "Derived artifacts",
+      "artifacts_sub": "live in production",
+      "endpoints_label": "API endpoints",
+      "endpoints_sub": "smoke 87/87 green",
+      "variants_label": "Topic-model variants",
+      "variants_sub": "LDA · ProdLDA · ETM · …"
+    },
+    "findings": {
+      "section_badge": "Featured finding · {{idx}} / {{total}}"
+    },
+    "pipeline_anatomy": {
+      "tag": "Pipeline anatomy",
+      "title": "From the HSI cube to θ ∈ Δ^(K-1)",
+      "lead": "Four steps that the app serves pre-computed behind every /api/topic-views/{scene} endpoint: define document, discretise to tokens, fit the model, inspect the per-pixel θ mixture.",
+      "stage1_title": "1 · Document",
+      "stage1_sub": "build_groupings",
+      "stage1_note": "x ∈ ℝᴮ per pixel · region · sample",
+      "stage1_pixel": "pixel",
+      "stage1_pixel_label": "x[i,j] ∈ ℝᴮ",
+      "stage1_pixel_caption": "one pixel = one document",
+      "stage2_title": "2 · Discretisation",
+      "stage2_sub": "build_wordifications · V1..V12",
+      "stage2_note1": "band-frequency · band-magnitude · …",
+      "stage2_note2": "12 recipes × 3 schemes × Q ∈ {8, 16, 32}",
+      "stage2_note3": "vocab V ∈ [103, 220]",
+      "stage3_title": "3 · Topic model",
+      "stage3_sub": "LDA · ProdLDA · ETM · CAE-{1D,2D,3D} · β-VAE",
+      "stage3_note1": "φ ∈ ℝ^{K×V}, θ ∈ Δ^(K-1)",
+      "stage3_note2": "K ∈ [4, 32]",
+      "stage4_title": "4 · θ inference",
+      "stage4_sub": "topic_routed · evaluation",
+      "stage4_topic1": "topic 1",
+      "stage4_topic2": "topic 2",
+      "stage4_topic3": "topic 3"
+    },
+    "scenes": {
+      "tag": "Six labelled scenes",
+      "title": "Each scene with its class distribution",
+      "lead": "Each bar is one agronomic / urban / mineral class with its real relative frequency. KSC and Botswana are tough benchmarks (diluted majority class, low SNR).",
+      "open_catalogue": "Open the full catalogue →",
+      "loading_stat": "Loading scene stats…",
+      "n_classes_short": "classes",
+      "n_pixels_short": "labelled pixels",
+      "n_bands_short": "bands",
+      "more_classes": "+{{count}} more"
+    },
+    "pillars": {
+      "tag": "Three levers",
+      "title": "Any topic result is attributable to these three levers",
+      "lever_label": "Lever {{idx}}",
+      "documents_title": "Documents",
+      "documents_body": "How to build a document: by pixel, by region (SLIC, Felzenszwalb), by patch or by full sample. Four alternatives materialised in build_groupings; they change the statistical unit upstream.",
+      "discretisation_title": "Discretisation",
+      "discretisation_body": "How a continuous spectrum becomes a discrete token: twelve recipes V1..V12, three quantisation schemes (uniform, quantile, equalised), three levels Q ∈ {8, 16, 32}.",
+      "model_title": "Model",
+      "model_body": "Canonical LDA (collapsed Gibbs, variational Bayes, online), HDP, CTM, ProdLDA, ETM, NMF, PCA, ICA, dense-AE, CAE-1D/2D/3D, β-VAE — all at the same K for a fair comparison."
+    },
+    "coverage": {
+      "tag": "Method coverage",
+      "title": "11 + 5 + 4 + 12 axes — all evaluated on the same scene when applicable",
+      "lda_family": "LDA-family · 9 variants",
+      "neural_topic": "Neural topic · 2 variants",
+      "deep_repr": "Deep representations · 5",
+      "k_baselines": "K-dim baselines · 4",
+      "axes": "12-axis Addendum-B battery"
+    },
+    "reading_path": {
+      "tag": "How to read this site",
+      "title": "Suggested path — 7 stops",
+      "step1_tag": "Methodology",
+      "step1_title": "Theory",
+      "step1_body": "The PTM/LDA model and why an HSI pixel can be treated as a document.",
+      "step2_tag": "Methodology",
+      "step2_title": "Representations",
+      "step2_body": "The V1..V12 × schemes × Q grid plus 5 deep encoders.",
+      "step3_tag": "Methodology",
+      "step3_title": "Pipeline",
+      "step3_body": "Which scripts run locally to produce the material this app serves.",
+      "step4_tag": "Methodology",
+      "step4_title": "Application",
+      "step4_body": "How topics are applied to classification and regression: direct / routed / embedded.",
+      "step5_tag": "Data",
+      "step5_title": "Databases",
+      "step5_body": "The 21 datasets with their access path, local root and source files.",
+      "step6_tag": "Lab",
+      "step6_title": "Workspace",
+      "step6_body": "Guided flow family → subset → representation → 11 tabs per labelled scene.",
+      "step7_tag": "Eval",
+      "step7_title": "Benchmarks",
+      "step7_body": "16 cards: multi-axis battery, Bayesian HDI, K-curve, β-collapse, neural-topic head-to-head, …"
+    },
+    "manifest_loaded": "Live data layer — manifest loaded correctly.",
+    "manifest_static": "Numbers are from the repo manifest — the app serves pre-computed material, no in-browser fitting."
   },
   "methodology": {
-    "title": "Methodology"
+    "title": "Methodology",
+    "index": {
+      "lead": "Four entries: the theory behind the model, the representations the corpus accepts, the pipeline that produces the data, and how topics are applied to downstream tasks.",
+      "reading": "Suggested reading: Theory → Representations → Pipeline → Application. The Bayesian Method Comparison and Multi-Axis Addendum B wiki pages close the methodological loop.",
+      "theory_tag": "PTM · LDA",
+      "theory_title": "Theory",
+      "theory_body": "The probabilistic topic model (PTM) and why an HSI pixel can be treated as a document. LDA in plate notation, variational inference, generalisations to HDP and CTM.",
+      "repr_tag": "V1..V12 + Deep",
+      "repr_title": "Representations",
+      "repr_body": "Twelve wordification recipes (V1 band → V12 GMM-token), three schemes (uniform/quantile/equalised), Q ∈ {8, 16, 32}. Plus five deep encoders: CAE-1D / CAE-2D / CAE-3D anchor and full-patch / β-VAE. PCA, NMF, ICA as fair K-dim baselines.",
+      "pipe_tag": "57 builders",
+      "pipe_title": "Pipeline",
+      "pipe_body": "Diagram of the 12 stages of the data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Five torch builders detect GPU automatically with CPU fallback.",
+      "app_tag": "direct · routed · embedded",
+      "app_title": "Application",
+      "app_body": "How topics are applied to downstream tasks: flat feature (theta_logistic, dominated by raw), gating (topic_routed_soft = soft mixture of per-topic specialists, matches or beats raw 6/6), embedded (concat [θ | pca_K], small effect on IP). The B-3 follow-up closes: the Dirichlet simplex matters, not K-dim compression."
+    }
   },
   "methodology_theory": {
     "title": "Theory — PTM, LDA, HSI"
@@ -21,18 +146,75 @@
     "title": "Application to classification and regression via topics"
   },
   "databases": {
-    "title": "Databases"
+    "title": "Databases",
+    "lead": "21 datasets grouped in 4 families. Each declares modality, domains, supervision status, and whether it has local roots available for the pipeline. Raw data is not served from the web app — only the publishable derived artifacts.",
+    "family_a_tagline": "USGS / ECOSTRESS curves — reference spectra with label or measurement.",
+    "family_b_tagline": "AVIRIS / ROSIS / Hyperion cubes with pixel-level labels — Indian Pines, Salinas, Pavia U, KSC, Botswana.",
+    "family_cd_tagline": "HIDSAG geo-mining + MicaSense MSI — regions with physical or geochemical measurements.",
+    "family_e_tagline": "Cubes without reliable labels — Borsoi unmixing benchmarks (Samson, Jasper Ridge, Urban) with manual endmembers.",
+    "datasets_count": "{{count}} datasets · {{local}} with local root",
+    "summary": {
+      "cataloged": "Cataloged datasets",
+      "local_avail": "With local download",
+      "raw_volume": "Raw volume",
+      "sources": "Sources"
+    }
   },
   "workspace": {
     "title": "Workspace",
+    "lead": "Guided flow in four steps: family → subset → representation → explore. Each step depends on the previous; you can go back at any time.",
     "step": {
       "family": "Dataset family",
       "subset": "Subset",
       "representation": "Representation",
       "explore": "Explore"
+    },
+    "briefing": {
+      "envelope_caption": "spectral envelope per class",
+      "envelope_unavailable": "envelope unavailable",
+      "loading_scene_context": "Loading scene context…",
+      "stat_dim": "dim",
+      "stat_bands": "bands",
+      "stat_wavelength": "wl",
+      "stat_classes": "classes",
+      "stat_labelled": "labelled",
+      "stat_k_topics": "K topics",
+      "more_classes": "+{{count}} more"
+    },
+    "tabs": {
+      "raw": "Raw · classes",
+      "browser": "Browser · 8000 spectra",
+      "topics": "Topics · LDAvis",
+      "topiclabel": "Topic vs label",
+      "routed": "Routed · ranking",
+      "raster": "Spatial map",
+      "embed3d": "Embedding 3D · θ-PCA",
+      "stability": "Stability · 7-seed",
+      "deep": "Deep latents",
+      "usgs": "USGS · library v7",
+      "metrics": "Reconstruction + MI",
+      "group_raw": "Raw data",
+      "group_topics": "Topic model",
+      "group_spatial": "Spatial geometry",
+      "group_diagnostics": "Diagnostics"
     }
   },
   "benchmarks": {
-    "title": "Benchmarks"
+    "title": "Benchmarks",
+    "lead": "16+ panels organised by Addendum B axis. Use the tabs to jump to the group you want. URL #hash allows sharing a specific tab.",
+    "tabs": {
+      "summary": "Summary",
+      "summary_tag": "Multi-axis battery + baselines",
+      "gating": "B-3 gating",
+      "gating_tag": "Topic-routed · deep gate · neural topic · Bayesian",
+      "deep": "Deep representations",
+      "deep_tag": "K-curve · anchor vs full · β-collapse · anomaly",
+      "axes": "Other axes",
+      "axes_tag": "Cross-scene · rate-distortion · MI · endmember · spatial · super-topics",
+      "hidsag": "HIDSAG",
+      "hidsag_tag": "Family-D geochemistry regression",
+      "llm": "B-12 LLM",
+      "llm_tag": "Tea-leaves word intrusion (gated)"
+    }
   }
 }

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -1,12 +1,137 @@
 {
   "overview": {
     "title": "Visión general",
-    "lead": "CAOS LDA HSI explora qué pueden capturar los modelos probabilísticos de tópicos cuando los documentos son píxeles, regiones o mediciones de imágenes hiperespectrales.",
-    "cta_workspace": "Abrir el laboratorio",
-    "cta_methodology": "Leer la metodología"
+    "lead": "CAOS LDA HSI explora qué pueden capturar los modelos probabilísticos de tópicos cuando los documentos son píxeles, regiones o mediciones extraídas de imágenes hiperespectrales.",
+    "cta_workspace": "Abrir el Laboratorio",
+    "cta_methodology": "Leer la metodología",
+    "hero": {
+      "spectral_signature": "Firma espectral en vivo",
+      "indian_pines_caption": "Indian Pines · 16 clases · {{bands}} bandas · 400–2500 nm",
+      "indian_pines_caption_loading": "Indian Pines · cargando datos en vivo…",
+      "title": "Tratamos cada píxel hiperespectral como un documento.",
+      "caption": "Cada curva es la firma media de una clase agronómica del cubo Indian Pines. La diversidad inter-clase a 1100 / 1400 / 1900 nm — absorciones de agua y feldespatos — es lo que el corpus textual tiene que recuperar discretamente. Esa firma es un documento; la pregunta del proyecto es qué tópicos (estructura latente compartida) viven en él.",
+      "datacube_anatomy": "Anatomía del datacube",
+      "datacube_caption": "Un cubo HSI es (H × W × B). Cada píxel x[i, j] es un vector espectral de B bandas. El proyecto lo recorre como un corpus, lo discretiza en tokens, ajusta tópicos θ ∈ Δ^(K-1) y los compara contra baselines K-dim."
+    },
+    "headlines": {
+      "datasets_label": "Datasets",
+      "datasets_sub": "en 4 familias",
+      "recipes_label": "Recetas de wordificación",
+      "recipes_sub": "V1 (banda) → V12 (GMM)",
+      "builders_label": "Builders",
+      "builders_sub": "módulos del data-pipeline",
+      "artifacts_label": "Artefactos derivados",
+      "artifacts_sub": "vivos en producción",
+      "endpoints_label": "Endpoints API",
+      "endpoints_sub": "smoke 87/87 verde",
+      "variants_label": "Variantes de tópicos",
+      "variants_sub": "LDA · ProdLDA · ETM · …"
+    },
+    "findings": {
+      "section_badge": "Hallazgo destacado · {{idx}} / {{total}}"
+    },
+    "pipeline_anatomy": {
+      "tag": "Pipeline anatómico",
+      "title": "Del cubo HSI a θ ∈ Δ^(K-1)",
+      "lead": "Cuatro pasos que la app sirve precalculados detrás de cada endpoint /api/topic-views/{scene}: definir documento, discretizar a tokens, ajustar el modelo, inspeccionar la mezcla θ por píxel.",
+      "stage1_title": "1 · Documento",
+      "stage1_sub": "build_groupings",
+      "stage1_note": "x ∈ ℝᴮ por píxel · región · muestra",
+      "stage1_pixel": "pixel",
+      "stage1_pixel_label": "x[i,j] ∈ ℝᴮ",
+      "stage1_pixel_caption": "un píxel = un documento",
+      "stage2_title": "2 · Discretización",
+      "stage2_sub": "build_wordifications · V1..V12",
+      "stage2_note1": "band-frequency · band-magnitude · …",
+      "stage2_note2": "12 recetas × 3 esquemas × Q ∈ {8, 16, 32}",
+      "stage2_note3": "vocab V ∈ [103, 220]",
+      "stage3_title": "3 · Modelo de tópicos",
+      "stage3_sub": "LDA · ProdLDA · ETM · CAE-{1D,2D,3D} · β-VAE",
+      "stage3_note1": "φ ∈ ℝ^{K×V}, θ ∈ Δ^(K-1)",
+      "stage3_note2": "K ∈ [4, 32]",
+      "stage4_title": "4 · Inferencia θ",
+      "stage4_sub": "topic_routed · evaluación",
+      "stage4_topic1": "tópico 1",
+      "stage4_topic2": "tópico 2",
+      "stage4_topic3": "tópico 3"
+    },
+    "scenes": {
+      "tag": "Seis escenas etiquetadas",
+      "title": "Cada escena con su distribución de clases",
+      "lead": "Cada barra es una clase agronómica/urbana/mineral con su frecuencia relativa real. KSC y Botswana son benchmarks difíciles (clase mayoritaria diluida, baja SNR).",
+      "open_catalogue": "Ir al catálogo completo →",
+      "loading_stat": "Cargando estadística…",
+      "n_classes_short": "clases",
+      "n_pixels_short": "píxeles etiquetados",
+      "n_bands_short": "bandas",
+      "more_classes": "+{{count}} más"
+    },
+    "pillars": {
+      "tag": "Tres palancas",
+      "title": "Cualquier resultado tópico es atribuible a estas tres palancas",
+      "lever_label": "Pilar {{idx}}",
+      "documents_title": "Documentos",
+      "documents_body": "Cómo construir un documento: por píxel, por región (SLIC, Felzenszwalb), por parche o por muestra completa. Cuatro alternativas materializadas en build_groupings; cambian la unidad estadística aguas arriba.",
+      "discretisation_title": "Discretización",
+      "discretisation_body": "Cómo el espectro continuo se vuelve token discreto: doce recetas V1..V12, tres esquemas de cuantización (uniform, quantile, equalised), tres niveles Q ∈ {8, 16, 32}.",
+      "model_title": "Modelo",
+      "model_body": "LDA canónico (collapsed Gibbs, variational Bayes, online), HDP, CTM, ProdLDA, ETM, NMF, PCA, ICA, dense-AE, CAE-1D/2D/3D, β-VAE — todos a la misma K para comparación justa."
+    },
+    "coverage": {
+      "tag": "Method coverage",
+      "title": "11 + 5 + 4 + 12 ejes — todo evaluado en la misma escena cuando aplica",
+      "lda_family": "Familia LDA · 9 variantes",
+      "neural_topic": "Tópico neural · 2 variantes",
+      "deep_repr": "Representaciones profundas · 5",
+      "k_baselines": "Baselines K-dim · 4",
+      "axes": "Batería Addendum-B 12 ejes"
+    },
+    "reading_path": {
+      "tag": "Cómo leer este sitio",
+      "title": "Camino sugerido — 7 paradas",
+      "step1_tag": "Metodología",
+      "step1_title": "Teoría",
+      "step1_body": "El modelo PTM/LDA y por qué un píxel HSI puede tratarse como documento.",
+      "step2_tag": "Metodología",
+      "step2_title": "Representaciones",
+      "step2_body": "La grilla V1..V12 × esquemas × Q + 5 deep encoders.",
+      "step3_tag": "Metodología",
+      "step3_title": "Pipeline",
+      "step3_body": "Qué scripts corren localmente para producir el material que la app sirve.",
+      "step4_tag": "Metodología",
+      "step4_title": "Aplicación",
+      "step4_body": "Cómo se aplican los tópicos a clasificación y regresión: directo / routed / embedded.",
+      "step5_tag": "Datos",
+      "step5_title": "Bases de datos",
+      "step5_body": "Los 21 datasets con su acceso, raíz local y archivos fuente.",
+      "step6_tag": "Lab",
+      "step6_title": "Workspace",
+      "step6_body": "Flujo guiado familia → conjunto → representación → 11 tabs por escena etiquetada.",
+      "step7_tag": "Eval",
+      "step7_title": "Benchmarks",
+      "step7_body": "16 cards: multi-axis battery, Bayesian HDI, K-curve, β-collapse, neural-topic head-to-head, …"
+    },
+    "manifest_loaded": "Capa de datos viva — manifest cargado correctamente.",
+    "manifest_static": "Las cifras son del manifest del repo — la app sirve material precalculado, no realiza fitting en el navegador."
   },
   "methodology": {
-    "title": "Metodología"
+    "title": "Metodología",
+    "index": {
+      "lead": "Cuatro entradas: la teoría detrás del modelo, las representaciones que el corpus acepta, el pipeline que produce los datos, y cómo los tópicos se aplican a tareas downstream.",
+      "reading": "Lectura sugerida: Teoría → Representaciones → Pipeline → Aplicación. Las páginas Bayesian Method Comparison y Multi-Axis Addendum B de la wiki cierran el ciclo metodológico.",
+      "theory_tag": "PTM · LDA",
+      "theory_title": "Teoría",
+      "theory_body": "El modelo probabilístico de tópicos (PTM) y por qué un píxel hiperespectral puede tratarse como documento. LDA en notación de placas, inferencia variacional, generalización a HDP y CTM.",
+      "repr_tag": "V1..V12 + Deep",
+      "repr_title": "Representaciones",
+      "repr_body": "Doce recetas de wordificación (V1 banda → V12 GMM-token), tres esquemas (uniform/quantile/equalised), Q ∈ {8, 16, 32}. Más cinco encoders profundos: CAE-1D / CAE-2D / CAE-3D anchor & full-patch / β-VAE. PCA, NMF, ICA como baselines K-dim de comparación justa.",
+      "pipe_tag": "57 builders",
+      "pipe_title": "Pipeline",
+      "pipe_body": "Diagrama de las 12 etapas del data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Cinco builders torch detectan GPU automáticamente con fallback CPU.",
+      "app_tag": "directo · routed · embedded",
+      "app_title": "Aplicación",
+      "app_body": "Cómo se aplican los tópicos a tareas downstream: feature plano (theta_logistic, dominado por raw), gating (topic_routed_soft = soft mixture de especialistas por tópico, gana o iguala raw en 6/6), embedded (concat [θ | pca_K], pequeño efecto en IP). El B-3 follow-up cierra: el simplex Dirichlet importa, no la compresión K-dim."
+    }
   },
   "methodology_theory": {
     "title": "Teoría — PTM, LDA, HSI"
@@ -21,18 +146,75 @@
     "title": "Aplicación a clasificación y regresión vía tópicos"
   },
   "databases": {
-    "title": "Bases de datos"
+    "title": "Bases de datos",
+    "lead": "21 datasets agrupados en 4 familias. Cada uno declara modalidad, dominios, estado de supervisión, y si tiene raíces locales disponibles para el pipeline. Los datos crudos no se sirven desde la app web — sólo los derivados publicables.",
+    "family_a_tagline": "Curvas USGS / ECOSTRESS — espectros de referencia con etiqueta o medición.",
+    "family_b_tagline": "Cubos AVIRIS / ROSIS / Hyperion con etiquetas pixel-a-pixel — Indian Pines, Salinas, Pavia U, KSC, Botswana.",
+    "family_cd_tagline": "HIDSAG geo-mining + MicaSense MSI — regiones con mediciones físicas o geoquímicas externas.",
+    "family_e_tagline": "Cubos sin etiquetas confiables — Borsoi unmixing benchmarks (Samson, Jasper Ridge, Urban) con endmembers manuales.",
+    "datasets_count": "{{count}} datasets · {{local}} con raíz local",
+    "summary": {
+      "cataloged": "Datasets catalogados",
+      "local_avail": "Con descarga local",
+      "raw_volume": "Volumen crudo",
+      "sources": "Fuentes"
+    }
   },
   "workspace": {
     "title": "Laboratorio",
+    "lead": "Flujo guiado en cuatro pasos: familia → conjunto → representación → explorar. Cada paso depende de los anteriores; puedes retroceder en cualquier momento.",
     "step": {
       "family": "Familia de datos",
       "subset": "Conjunto",
       "representation": "Representación",
       "explore": "Explorar"
+    },
+    "briefing": {
+      "envelope_caption": "envolvente espectral por clase",
+      "envelope_unavailable": "envolvente no disponible",
+      "loading_scene_context": "Cargando contexto de la escena…",
+      "stat_dim": "dim",
+      "stat_bands": "bandas",
+      "stat_wavelength": "wl",
+      "stat_classes": "clases",
+      "stat_labelled": "etiquetadas",
+      "stat_k_topics": "K tópicos",
+      "more_classes": "+{{count}} más"
+    },
+    "tabs": {
+      "raw": "Cruda · clases",
+      "browser": "Browser · 8000 espectros",
+      "topics": "Tópicos · LDAvis",
+      "topiclabel": "Tópico vs etiqueta",
+      "routed": "Routed · ranking",
+      "raster": "Mapa espacial",
+      "embed3d": "Embedding 3D · θ-PCA",
+      "stability": "Estabilidad · 7-seed",
+      "deep": "Deep latents",
+      "usgs": "USGS · librería v7",
+      "metrics": "Reconstrucción + MI",
+      "group_raw": "Datos brutos",
+      "group_topics": "Modelo de tópicos",
+      "group_spatial": "Geometría espacial",
+      "group_diagnostics": "Diagnóstico"
     }
   },
   "benchmarks": {
-    "title": "Benchmarks"
+    "title": "Benchmarks",
+    "lead": "16+ paneles organizados por eje del framework Addendum B. Usa los tabs para saltar al grupo que te interesa. URL con #hash permite compartir un tab específico.",
+    "tabs": {
+      "summary": "Resumen",
+      "summary_tag": "Batería multi-eje + baselines",
+      "gating": "B-3 gating",
+      "gating_tag": "Topic-routed · deep gate · neural topic · Bayesian",
+      "deep": "Representaciones profundas",
+      "deep_tag": "Curva K · anchor vs full · β-collapse · anomalía",
+      "axes": "Otros ejes",
+      "axes_tag": "Cross-scene · rate-distortion · MI · endmember · espacial · super-topics",
+      "hidsag": "HIDSAG",
+      "hidsag_tag": "Familia-D regresión geoquímica",
+      "llm": "B-12 LLM",
+      "llm_tag": "Tea-leaves word intrusion (gated)"
+    }
   }
 }

--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -22,13 +22,13 @@ type BenchmarksTab =
   | "hidsag"
   | "llm";
 
-const BENCHMARKS_TABS: { id: BenchmarksTab; label: string; tag: string; color: string }[] = [
-  { id: "summary", label: "Summary", tag: "Multi-axis battery + baselines", color: "rgba(56, 189, 248, 1)" },
-  { id: "gating", label: "B-3 gating", tag: "Topic-routed · deep gate · neural topic · Bayesian", color: "rgba(40, 160, 80, 1)" },
-  { id: "deep", label: "Deep representations", tag: "K-curve · anchor vs full · β-collapse · anomaly", color: "rgba(170, 60, 200, 1)" },
-  { id: "axes", label: "Other axes", tag: "Cross-scene · rate-distortion · MI · endmember · spatial · super-topics", color: "rgba(214, 140, 40, 1)" },
-  { id: "hidsag", label: "HIDSAG", tag: "Family-D geochemistry regression", color: "rgba(214, 39, 40, 1)" },
-  { id: "llm", label: "B-12 LLM", tag: "Tea-leaves word intrusion (gated)", color: "rgba(140, 86, 75, 1)" },
+const BENCHMARKS_TABS: { id: BenchmarksTab; labelKey: string; tagKey: string; color: string }[] = [
+  { id: "summary", labelKey: "summary", tagKey: "summary_tag", color: "rgba(56, 189, 248, 1)" },
+  { id: "gating", labelKey: "gating", tagKey: "gating_tag", color: "rgba(40, 160, 80, 1)" },
+  { id: "deep", labelKey: "deep", tagKey: "deep_tag", color: "rgba(170, 60, 200, 1)" },
+  { id: "axes", labelKey: "axes", tagKey: "axes_tag", color: "rgba(214, 140, 40, 1)" },
+  { id: "hidsag", labelKey: "hidsag", tagKey: "hidsag_tag", color: "rgba(214, 39, 40, 1)" },
+  { id: "llm", labelKey: "llm", tagKey: "llm_tag", color: "rgba(140, 86, 75, 1)" },
 ];
 
 function readHashTab(): BenchmarksTab | null {
@@ -77,7 +77,7 @@ export default function Benchmarks() {
   return (
     <PageShell
       title={t("pages:benchmarks.title")}
-      lead="16+ paneles organizados por eje del framework Addendum B. Usa los tabs para saltar al grupo que te interesa. URL con #hash permite compartir un tab específico."
+      lead={t("pages:benchmarks.lead")}
     >
       {isLoading && (
         <p style={{ color: "var(--color-fg-faint)" }}>Cargando estadísticas…</p>
@@ -216,6 +216,7 @@ function BenchmarksTabBar({
   tab: BenchmarksTab;
   onPick: (t: BenchmarksTab) => void;
 }) {
+  const { t } = useTranslation(["pages"]);
   return (
     <nav
       role="tablist"
@@ -227,18 +228,18 @@ function BenchmarksTabBar({
         backdropFilter: "blur(8px)",
       }}
     >
-      {BENCHMARKS_TABS.map((t) => {
-        const isActive = tab === t.id;
+      {BENCHMARKS_TABS.map((tt) => {
+        const isActive = tab === tt.id;
         return (
           <button
-            key={t.id}
+            key={tt.id}
             role="tab"
             aria-selected={isActive}
             type="button"
-            onClick={() => onPick(t.id)}
+            onClick={() => onPick(tt.id)}
             className="rounded-lg border px-4 py-2.5 text-sm text-left transition-all hover:-translate-y-0.5"
             style={{
-              borderColor: isActive ? t.color : "var(--color-border)",
+              borderColor: isActive ? tt.color : "var(--color-border)",
               backgroundColor: isActive ? "var(--color-accent-soft)" : "var(--color-panel)",
               boxShadow: isActive ? "var(--color-shadow)" : "none",
               minWidth: 180,
@@ -246,15 +247,15 @@ function BenchmarksTabBar({
           >
             <div
               className="text-[10.5px] uppercase tracking-widest font-semibold"
-              style={{ color: t.color }}
+              style={{ color: tt.color }}
             >
-              {t.label}
+              {t(`pages:benchmarks.tabs.${tt.labelKey}`)}
             </div>
             <div
               className="text-[11px] mt-0.5"
               style={{ color: isActive ? "var(--color-fg)" : "var(--color-fg-faint)" }}
             >
-              {t.tag}
+              {t(`pages:benchmarks.tabs.${tt.tagKey}`)}
             </div>
           </button>
         );

--- a/frontend/src/pages/Databases.tsx
+++ b/frontend/src/pages/Databases.tsx
@@ -82,7 +82,7 @@ export default function Databases() {
   return (
     <PageShell
       title={t("pages:databases.title")}
-      lead="21 datasets agrupados en 4 familias. Cada uno declara modalidad, dominios, estado de supervisión, y si tiene raíces locales disponibles para el pipeline. Los datos crudos no se sirven desde la app web — sólo los derivados publicables."
+      lead={t("pages:databases.lead")}
     >
       {isLoading && (
         <p style={{ color: "var(--color-fg-faint)" }}>
@@ -389,30 +389,30 @@ function KvRow({ label, value }: { label: string; value: string }) {
   );
 }
 
-const FAMILY_VISUAL_META: Record<string, { tag: string; color: string; icon: "spectra" | "scenes" | "regions" | "unlabeled"; tagline: string }> = {
+const FAMILY_VISUAL_META: Record<string, { tag: string; color: string; icon: "spectra" | "scenes" | "regions" | "unlabeled"; taglineKey: string }> = {
   "individual-spectra": {
     tag: "Family A",
     color: "rgba(56, 189, 248, 1)",
     icon: "spectra",
-    tagline: "Curvas USGS / ECOSTRESS — espectros de referencia con etiqueta o medición.",
+    taglineKey: "family_a_tagline",
   },
   "labeled-spectral-image": {
     tag: "Family B",
     color: "rgba(40, 160, 80, 1)",
     icon: "scenes",
-    tagline: "Cubos AVIRIS / ROSIS / Hyperion con etiquetas pixel-a-pixel — Indian Pines, Salinas, Pavia U, KSC, Botswana.",
+    taglineKey: "family_b_tagline",
   },
   "regions-with-measurements": {
     tag: "Family C/D",
     color: "rgba(214, 140, 40, 1)",
     icon: "regions",
-    tagline: "HIDSAG geo-mining + MicaSense MSI — regiones con mediciones físicas o geoquímicas externas.",
+    taglineKey: "family_cd_tagline",
   },
   "unlabeled-spectral-image": {
     tag: "Family E",
     color: "rgba(170, 60, 200, 1)",
     icon: "unlabeled",
-    tagline: "Cubos sin etiquetas confiables — Borsoi unmixing benchmarks (Samson, Jasper Ridge, Urban) con endmembers manuales.",
+    taglineKey: "family_e_tagline",
   },
 };
 
@@ -425,6 +425,7 @@ function FamilyVisualHero({
   active: string | null;
   onPick: (fid: string) => void;
 }) {
+  const { t } = useTranslation(["pages"]);
   return (
     <section className="mb-6">
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
@@ -462,8 +463,7 @@ function FamilyVisualHero({
                   className="text-[11px] font-mono"
                   style={{ color: "var(--color-fg-faint)" }}
                 >
-                  {g.entries.length}
-                  {localCount < g.entries.length ? <span className="opacity-70"> · {localCount} local</span> : null}
+                  {t("pages:databases.datasets_count", { count: g.entries.length, local: localCount })}
                 </span>
               </div>
               <FamilyIcon kind={meta.icon} color={meta.color} />
@@ -477,7 +477,7 @@ function FamilyVisualHero({
                 className="mt-1 text-[12px] leading-relaxed"
                 style={{ color: "var(--color-fg-subtle)" }}
               >
-                {meta.tagline}
+                {t(`pages:databases.${meta.taglineKey}`)}
               </p>
             </button>
           );

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -15,50 +15,20 @@ const LABELLED_SCENES = [
   { id: "botswana", label: "Botswana", sensor: "Hyperion" },
 ];
 
-const HEADLINES = [
-  {
-    label: "Datasets",
-    value: "21",
-    sub: "across 4 families",
-    href: "/databases",
-  },
-  {
-    label: "Wordification recipes",
-    value: "12",
-    sub: "V1 (band) → V12 (GMM)",
-    href: "/methodology/representations",
-  },
-  {
-    label: "Builders",
-    value: "57",
-    sub: "data-pipeline modules",
-    href: "/methodology/pipeline",
-  },
-  {
-    label: "Derived artifacts",
-    value: "1592",
-    sub: "live in production",
-    href: "/benchmarks",
-  },
-  {
-    label: "API endpoints",
-    value: "104",
-    sub: "smoke 87/87 green",
-    href: "/benchmarks",
-  },
-  {
-    label: "Topic-model variants",
-    value: "11",
-    sub: "LDA · ProdLDA · ETM · …",
-    href: "/methodology/representations",
-  },
-];
+const HEADLINE_DEFS = [
+  { keyLabel: "datasets_label", keySub: "datasets_sub", value: "21", href: "/databases" },
+  { keyLabel: "recipes_label", keySub: "recipes_sub", value: "12", href: "/methodology/representations" },
+  { keyLabel: "builders_label", keySub: "builders_sub", value: "57", href: "/methodology/pipeline" },
+  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1592", href: "/benchmarks" },
+  { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "104", href: "/benchmarks" },
+  { keyLabel: "variants_label", keySub: "variants_sub", value: "11", href: "/methodology/representations" },
+] as const;
 
 const FINDINGS = [
   {
     badge: "B-3",
     title: "θ as a gate beats raw on labelled scenes",
-    body: "topic_routed_soft matches or beats raw_logistic on all 6 labelled scenes; theta_logistic (θ as flat feature) loses by 30–50 pp everywhere. The framing 'θ is a gate, not a feature' is empirically validated.",
+    body: "topic_routed_soft matches or beats raw_logistic on all 6 labelled scenes; theta_logistic (θ as a flat feature) loses by 30–50 pp everywhere. The framing 'θ is a gate, not a feature' is empirically validated.",
     accent: "rgba(40, 160, 80, 1)",
   },
   {
@@ -70,7 +40,7 @@ const FINDINGS = [
   {
     badge: "Topic family",
     title: "LDA wins ARI · ProdLDA wins coherence · ETM is the safe middle",
-    body: "Cycles 61–63 head-to-head on 220-per-class stratified samples: LDA wins KMeans-vs-label ARI 4/6 scenes; ProdLDA wins c_v topic coherence 6/6; ETM beats ProdLDA on ARI 6/6 (multi-seed N=5).",
+    body: "Cycles 61–63 head-to-head on 220-per-class stratified samples: LDA wins KMeans-vs-label ARI on 4/6 scenes; ProdLDA wins c_v topic coherence 6/6; ETM beats ProdLDA on ARI 6/6 (multi-seed N=5).",
     accent: "rgba(31, 119, 180, 1)",
   },
   {
@@ -82,19 +52,19 @@ const FINDINGS = [
   {
     badge: "GPU stack",
     title: "50–120× speedup on the deep / neural family",
-    body: "RTX 4070 Laptop CUDA 12.6: cae_3d_full K=32 single scene 60 min CPU → 30 s GPU. Full K-curve {4, 8, 16, 32} × 6 scenes 9–12 h CPU → 10 min GPU. Determinism drift ±0.010 ARI < per-seed σ ≈ 0.05.",
+    body: "RTX 4070 Laptop CUDA 12.6: cae_3d_full K=32 single scene goes from ~60 min CPU to ~30 s GPU. Full K-curve {4, 8, 16, 32} × 6 scenes from 9–12 h CPU to ~10 min GPU. Determinism drift ±0.010 ARI is below per-seed σ ≈ 0.05.",
     accent: "rgba(214, 140, 40, 1)",
   },
   {
     badge: "Stability",
     title: "9-method × 6-scene seed stability ladder",
-    body: "PCA = ICA (1.000 deterministic) > LDA > NMF > CAE-2D > CAE-1D > CAE-3D > dense-AE > β-VAE. KSC β-VAE off-diag ≈ 0.18 — KL stochasticity overwhelms inter-seed signal.",
+    body: "PCA = ICA (1.000 deterministic) > LDA > NMF > CAE-2D > CAE-1D > CAE-3D > dense-AE > β-VAE. KSC β-VAE off-diag ≈ 0.18 — KL stochasticity overwhelms the inter-seed signal.",
     accent: "rgba(140, 86, 75, 1)",
   },
   {
     badge: "Posterior collapse",
     title: "β-VAE Salinas at β ≥ 8 — textbook failure mode",
-    body: "Salinas β-VAE at β=8 and β=16 collapses to ARI = 0.000: encoder converges to q(z|x) ≈ p(z) regardless of input; latent uninformative. Salinas-A's compact 6-class structure resists the same regulariser. Visible black cells in the Benchmarks β-sweep heatmap.",
+    body: "Salinas β-VAE at β=8 and β=16 collapses to ARI = 0.000: the encoder converges to q(z|x) ≈ p(z) regardless of input; the latent is uninformative. Salinas-A's compact 6-class structure resists the same regulariser. Visible black cells in the Benchmarks β-sweep heatmap.",
     accent: "rgba(120, 50, 50, 1)",
   },
 ];
@@ -145,6 +115,7 @@ export default function Overview() {
    =======================================================================*/
 
 function HeroSpectralViz({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
+  const { t } = useTranslation(["pages"]);
   const ip = scenes?.[0];
   const wl = ip?.wavelengths_nm ?? [];
   const classDist = ip?.class_distribution ?? [];
@@ -207,17 +178,19 @@ function HeroSpectralViz({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
               className="text-[11px] uppercase tracking-widest font-semibold"
               style={{ color: "var(--color-accent)" }}
             >
-              Live spectral signature
+              {t("pages:overview.hero.spectral_signature")}
             </span>
             <span className="text-[11px]" style={{ color: "var(--color-fg-faint)" }}>
-              Indian Pines · 16 classes · {wl.length} bands · 400–2500 nm
+              {wl.length
+                ? t("pages:overview.hero.indian_pines_caption", { bands: wl.length })
+                : t("pages:overview.hero.indian_pines_caption_loading")}
             </span>
           </div>
           <h2
             className="text-xl md:text-2xl font-semibold tracking-tight mb-4"
             style={{ color: "var(--color-fg)" }}
           >
-            Tratamos cada píxel hiperespectral como un documento.
+            {t("pages:overview.hero.title")}
           </h2>
 
           <svg
@@ -295,12 +268,7 @@ function HeroSpectralViz({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
             className="mt-2 text-[12.5px] leading-relaxed"
             style={{ color: "var(--color-fg-subtle)" }}
           >
-            Cada curva es la firma media de una clase agronómica del cubo Indian
-            Pines. La diversidad inter-clase a 1100 / 1400 / 1900 nm —
-            absorciones de agua y feldespatos — es lo que el corpus textual
-            tiene que recuperar discretamente. <strong>Esa firma es un
-            documento</strong>; la pregunta del proyecto es qué tópicos
-            (estructura latente compartida) viven en él.
+            {t("pages:overview.hero.caption")}
           </p>
         </div>
 
@@ -311,7 +279,7 @@ function HeroSpectralViz({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
               className="text-[11px] uppercase tracking-widest font-semibold"
               style={{ color: "var(--color-accent)" }}
             >
-              Datacube anatomy
+              {t("pages:overview.hero.datacube_anatomy")}
             </span>
           </div>
           <HypercubeMini />
@@ -319,11 +287,7 @@ function HeroSpectralViz({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
             className="mt-3 text-[12.5px] leading-relaxed"
             style={{ color: "var(--color-fg-subtle)" }}
           >
-            Un cubo HSI es <strong>(H × W × B)</strong>. Cada píxel `x[i, j]`
-            es un vector espectral de B bandas. El proyecto lo recorre como un
-            <em> corpus</em>, lo discretiza en tokens, ajusta tópicos
-            <code className="font-mono mx-1 text-[11px]">θ ∈ Δ^(K-1)</code>
-            y los compara contra baselines K-dim.
+            {t("pages:overview.hero.datacube_caption")}
           </p>
         </div>
       </div>
@@ -403,12 +367,13 @@ function HypercubeMini() {
    =======================================================================*/
 
 function HeadlineNumbers() {
+  const { t } = useTranslation(["pages"]);
   return (
     <section className="mt-8">
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-        {HEADLINES.map((h) => (
+        {HEADLINE_DEFS.map((h) => (
           <Link
-            key={h.label}
+            key={h.keyLabel}
             to={h.href}
             className="rounded-lg border p-4 transition-all hover:scale-[1.02] hover:shadow-lg"
             style={{
@@ -421,7 +386,7 @@ function HeadlineNumbers() {
               className="text-[10.5px] uppercase tracking-widest font-medium"
               style={{ color: "var(--color-fg-faint)" }}
             >
-              {h.label}
+              {t(`pages:overview.headlines.${h.keyLabel}`)}
             </div>
             <div
               className="mt-1 text-3xl font-semibold tracking-tight"
@@ -430,7 +395,7 @@ function HeadlineNumbers() {
               {h.value}
             </div>
             <div className="text-[11px]" style={{ color: "var(--color-fg-subtle)" }}>
-              {h.sub}
+              {t(`pages:overview.headlines.${h.keySub}`)}
             </div>
           </Link>
         ))}
@@ -444,10 +409,11 @@ function HeadlineNumbers() {
    =======================================================================*/
 
 function FindingsCarousel() {
+  const { t } = useTranslation(["pages"]);
   const [idx, setIdx] = useState(0);
   useEffect(() => {
-    const t = setInterval(() => setIdx((i) => (i + 1) % FINDINGS.length), 7000);
-    return () => clearInterval(t);
+    const timer = setInterval(() => setIdx((i) => (i + 1) % FINDINGS.length), 7000);
+    return () => clearInterval(timer);
   }, []);
   const cur = FINDINGS[idx]!;
 
@@ -477,7 +443,7 @@ function FindingsCarousel() {
             className="text-[11px] uppercase tracking-widest"
             style={{ color: "var(--color-fg-faint)" }}
           >
-            Hallazgo destacado · {idx + 1} / {FINDINGS.length}
+            {t("pages:overview.findings.section_badge", { idx: idx + 1, total: FINDINGS.length })}
           </span>
         </div>
         <h2
@@ -516,6 +482,7 @@ function FindingsCarousel() {
    =======================================================================*/
 
 function HypercubeAnatomy() {
+  const { t } = useTranslation(["pages"]);
   return (
     <section className="mt-12">
       <div className="mb-4">
@@ -523,22 +490,19 @@ function HypercubeAnatomy() {
           className="text-[11px] uppercase tracking-widest font-semibold"
           style={{ color: "var(--color-accent)" }}
         >
-          Pipeline anatómico
+          {t("pages:overview.pipeline_anatomy.tag")}
         </span>
         <h2
           className="text-xl md:text-2xl font-semibold tracking-tight mt-1"
           style={{ color: "var(--color-fg)" }}
         >
-          Del cubo HSI a θ ∈ Δ^(K-1)
+          {t("pages:overview.pipeline_anatomy.title")}
         </h2>
         <p
           className="mt-2 max-w-3xl text-[13.5px] leading-relaxed"
           style={{ color: "var(--color-fg-subtle)" }}
         >
-          Cuatro pasos que la app sirve precalculados detrás de cada endpoint
-          <code className="font-mono mx-1 text-[11px]">/api/topic-views/{`{scene}`}</code>:
-          definir documento, discretizar a tokens, ajustar el modelo,
-          inspeccionar la mezcla θ por píxel.
+          {t("pages:overview.pipeline_anatomy.lead")}
         </p>
       </div>
 
@@ -575,24 +539,24 @@ function HypercubeAnatomy() {
 
           {/* Step 1: Cube + pixel */}
           <g transform="translate(40, 50)">
-            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">1 · Documento</text>
-            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">build_groupings</text>
+            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">{t("pages:overview.pipeline_anatomy.stage1_title")}</text>
+            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">{t("pages:overview.pipeline_anatomy.stage1_sub")}</text>
             {/* mini cube */}
             <polygon points="20,40 130,40 152,58 42,58" fill="url(#ovw-step1)" stroke="currentColor" strokeOpacity="0.4" strokeWidth="0.8"/>
             <rect x="20" y="58" width="110" height="120" fill="url(#ovw-step1)" stroke="currentColor" strokeOpacity="0.4" strokeWidth="0.8"/>
             <polygon points="130,58 152,58 152,178 130,178" fill="rgba(56,189,248,0.25)" stroke="currentColor" strokeOpacity="0.4" strokeWidth="0.8"/>
             {/* pixel highlight */}
             <rect x="68" y="98" width="10" height="10" fill="rgba(214,39,40,0.9)"/>
-            <text x="80" y="107" fontSize="9.5" fill="currentColor" opacity="0.7">pixel</text>
-            <text x="20" y="200" fontSize="10" fill="currentColor" opacity="0.7">x ∈ ℝᴮ por píxel · region · sample</text>
+            <text x="80" y="107" fontSize="9.5" fill="currentColor" opacity="0.7">{t("pages:overview.pipeline_anatomy.stage1_pixel")}</text>
+            <text x="20" y="200" fontSize="10" fill="currentColor" opacity="0.7">{t("pages:overview.pipeline_anatomy.stage1_note")}</text>
           </g>
 
           <line x1="210" y1="135" x2="290" y2="135" stroke="currentColor" strokeWidth="1.4" markerEnd="url(#ovw-arr)" opacity="0.55"/>
 
           {/* Step 2: Discretization (12 V-recipes) */}
           <g transform="translate(300, 50)">
-            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">2 · Discretización</text>
-            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">build_wordifications · V1..V12</text>
+            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">{t("pages:overview.pipeline_anatomy.stage2_title")}</text>
+            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">{t("pages:overview.pipeline_anatomy.stage2_sub")}</text>
             <rect x="0" y="32" width="220" height="148" fill="url(#ovw-step2)" stroke="currentColor" strokeOpacity="0.4" strokeWidth="0.8" rx="6"/>
             {/* tokens list */}
             {Array.from({length: 6}, (_, i) => (
@@ -603,17 +567,17 @@ function HypercubeAnatomy() {
                 </text>
               </g>
             ))}
-            <text x="12" y="138" fontSize="9.5" fill="currentColor" opacity="0.7">band-frequency · band-magnitude · …</text>
-            <text x="12" y="154" fontSize="9.5" fill="currentColor" opacity="0.7">12 recipes × 3 schemes × Q∈{`{8,16,32}`}</text>
-            <text x="12" y="170" fontSize="9.5" fill="currentColor" opacity="0.55" fontStyle="italic">vocab V ∈ [103, 220]</text>
+            <text x="12" y="138" fontSize="9.5" fill="currentColor" opacity="0.7">{t("pages:overview.pipeline_anatomy.stage2_note1")}</text>
+            <text x="12" y="154" fontSize="9.5" fill="currentColor" opacity="0.7">{t("pages:overview.pipeline_anatomy.stage2_note2")}</text>
+            <text x="12" y="170" fontSize="9.5" fill="currentColor" opacity="0.55" fontStyle="italic">{t("pages:overview.pipeline_anatomy.stage2_note3")}</text>
           </g>
 
           <line x1="540" y1="135" x2="620" y2="135" stroke="currentColor" strokeWidth="1.4" markerEnd="url(#ovw-arr)" opacity="0.55"/>
 
           {/* Step 3: Topic model */}
           <g transform="translate(630, 50)">
-            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">3 · Modelo de tópicos</text>
-            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">LDA · ProdLDA · ETM · CAE-{`{1D,2D,3D}`} · β-VAE</text>
+            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">{t("pages:overview.pipeline_anatomy.stage3_title")}</text>
+            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">{t("pages:overview.pipeline_anatomy.stage3_sub")}</text>
             <rect x="0" y="32" width="180" height="148" fill="url(#ovw-step3)" stroke="currentColor" strokeOpacity="0.4" strokeWidth="0.8" rx="6"/>
             {/* phi rows */}
             {Array.from({length: 4}, (_, k) => (
@@ -625,22 +589,22 @@ function HypercubeAnatomy() {
                 ))}
               </g>
             ))}
-            <text x="10" y="160" fontSize="9.5" fill="currentColor" opacity="0.7">φ ∈ ℝ^{`{K×V}`}, θ ∈ Δ^(K-1)</text>
-            <text x="10" y="174" fontSize="9.5" fill="currentColor" opacity="0.55" fontStyle="italic">K ∈ [4, 32]</text>
+            <text x="10" y="160" fontSize="9.5" fill="currentColor" opacity="0.7">{t("pages:overview.pipeline_anatomy.stage3_note1")}</text>
+            <text x="10" y="174" fontSize="9.5" fill="currentColor" opacity="0.55" fontStyle="italic">{t("pages:overview.pipeline_anatomy.stage3_note2")}</text>
           </g>
 
           <line x1="820" y1="135" x2="900" y2="135" stroke="currentColor" strokeWidth="1.4" markerEnd="url(#ovw-arr)" opacity="0.55"/>
 
           {/* Step 4: theta inspection */}
           <g transform="translate(910, 50)">
-            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">4 · Inferencia θ</text>
-            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">topic_routed · evaluation</text>
+            <text x="0" y="-12" fontSize="11.5" fill="currentColor" fontWeight="600" opacity="0.88">{t("pages:overview.pipeline_anatomy.stage4_title")}</text>
+            <text x="0" y="2" fontSize="10" fill="currentColor" opacity="0.55">{t("pages:overview.pipeline_anatomy.stage4_sub")}</text>
             <rect x="0" y="32" width="130" height="148" fill="url(#ovw-step4)" stroke="currentColor" strokeOpacity="0.4" strokeWidth="0.8" rx="6"/>
             {/* simplex */}
             <polygon points="65,55 25,165 105,165" fill="rgba(214,140,40,0.25)" stroke="rgba(214,140,40,0.7)" strokeWidth="1.2"/>
-            <text x="65" y="49" fontSize="10" textAnchor="middle" fill="currentColor" opacity="0.75" fontFamily="ui-monospace, monospace">topic 1</text>
-            <text x="20" y="174" fontSize="10" fill="currentColor" opacity="0.75" fontFamily="ui-monospace, monospace">topic 2</text>
-            <text x="105" y="174" fontSize="10" textAnchor="end" fill="currentColor" opacity="0.75" fontFamily="ui-monospace, monospace">topic 3</text>
+            <text x="65" y="49" fontSize="10" textAnchor="middle" fill="currentColor" opacity="0.75" fontFamily="ui-monospace, monospace">{t("pages:overview.pipeline_anatomy.stage4_topic1")}</text>
+            <text x="20" y="174" fontSize="10" fill="currentColor" opacity="0.75" fontFamily="ui-monospace, monospace">{t("pages:overview.pipeline_anatomy.stage4_topic2")}</text>
+            <text x="105" y="174" fontSize="10" textAnchor="end" fill="currentColor" opacity="0.75" fontFamily="ui-monospace, monospace">{t("pages:overview.pipeline_anatomy.stage4_topic3")}</text>
             {/* points = pixels on simplex */}
             {[
               [65, 90], [50, 110], [80, 105], [70, 130], [55, 145], [90, 140], [60, 160], [85, 155], [75, 100],
@@ -659,6 +623,7 @@ function HypercubeAnatomy() {
    =======================================================================*/
 
 function ScenesShowcase({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
+  const { t } = useTranslation(["pages"]);
   return (
     <section className="mt-12">
       <div className="mb-4 flex items-end justify-between flex-wrap gap-3">
@@ -667,21 +632,19 @@ function ScenesShowcase({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
             className="text-[11px] uppercase tracking-widest font-semibold"
             style={{ color: "var(--color-accent)" }}
           >
-            Six labelled scenes
+            {t("pages:overview.scenes.tag")}
           </span>
           <h2
             className="text-xl md:text-2xl font-semibold tracking-tight mt-1"
             style={{ color: "var(--color-fg)" }}
           >
-            Cada escena con su distribución de clases
+            {t("pages:overview.scenes.title")}
           </h2>
           <p
             className="mt-1.5 max-w-3xl text-[13.5px] leading-relaxed"
             style={{ color: "var(--color-fg-subtle)" }}
           >
-            Cada barra es una clase agronómica/urbana/mineral con su frecuencia
-            relativa real. KSC y Botswana son benchmark difíciles
-            (clase-mayoritaria diluida, baja SNR).
+            {t("pages:overview.scenes.lead")}
           </p>
         </div>
         <Link
@@ -689,7 +652,7 @@ function ScenesShowcase({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
           className="text-[12.5px] underline-offset-4"
           style={{ color: "var(--color-accent)" }}
         >
-          Ir al catálogo completo →
+          {t("pages:overview.scenes.open_catalogue")}
         </Link>
       </div>
 
@@ -710,6 +673,7 @@ function SceneCard({
   meta: { id: string; label: string; sensor: string };
   peek: ScenePeek | null | undefined;
 }) {
+  const { t } = useTranslation(["pages"]);
   const dist = peek?.class_distribution ?? [];
   return (
     <Link
@@ -737,8 +701,8 @@ function SceneCard({
         style={{ color: "var(--color-fg-subtle)" }}
       >
         {peek
-          ? `${peek.n_classes} clases · ${peek.n_labelled_pixels.toLocaleString("en-US")} pixeles etiquetados · ${peek.wavelengths_nm.length} bandas`
-          : "Cargando estadística…"}
+          ? `${peek.n_classes} ${t("pages:overview.scenes.n_classes_short")} · ${peek.n_labelled_pixels.toLocaleString("en-US")} ${t("pages:overview.scenes.n_pixels_short")} · ${peek.wavelengths_nm.length} ${t("pages:overview.scenes.n_bands_short")}`
+          : t("pages:overview.scenes.loading_stat")}
       </div>
       {dist.length ? (
         <div className="w-full h-7 flex rounded overflow-hidden border" style={{ borderColor: "var(--color-border)" }}>
@@ -768,7 +732,7 @@ function SceneCard({
             </span>
           ))}
           {dist.length > 4 ? (
-            <span className="text-[10.5px]" style={{ color: "var(--color-fg-faint)" }}>+{dist.length - 4} más</span>
+            <span className="text-[10.5px]" style={{ color: "var(--color-fg-faint)" }}>{t("pages:overview.scenes.more_classes", { count: dist.length - 4 })}</span>
           ) : null}
         </div>
       ) : null}
@@ -781,23 +745,24 @@ function SceneCard({
    =======================================================================*/
 
 function PillarsTriptych() {
+  const { t } = useTranslation(["pages"]);
   const pillars = [
     {
-      title: "Documentos",
-      tag: "Pilar 1",
-      body: "Cómo construir un documento: por píxel, por región (SLIC, Felzenszwalb), por parche o por muestra completa. Cuatro alternativas materializadas en build_groupings; cambian la unidad estadística aguas arriba.",
+      title: t("pages:overview.pillars.documents_title"),
+      tag: t("pages:overview.pillars.lever_label", { idx: 1 }),
+      body: t("pages:overview.pillars.documents_body"),
       icon: "doc",
     },
     {
-      title: "Discretización",
-      tag: "Pilar 2",
-      body: "Cómo el espectro continuo se vuelve token discreto: doce recetas V1..V12, tres esquemas de cuantización (uniform, quantile, equalised), tres niveles Q ∈ {8, 16, 32}.",
+      title: t("pages:overview.pillars.discretisation_title"),
+      tag: t("pages:overview.pillars.lever_label", { idx: 2 }),
+      body: t("pages:overview.pillars.discretisation_body"),
       icon: "tok",
     },
     {
-      title: "Modelo",
-      tag: "Pilar 3",
-      body: "LDA canónico (collapsed Gibbs, variational Bayes, online), HDP, CTM, ProdLDA, ETM, NMF, PCA, ICA, dense-AE, CAE-1D/2D/3D, β-VAE — todos a la misma K para comparación justa.",
+      title: t("pages:overview.pillars.model_title"),
+      tag: t("pages:overview.pillars.lever_label", { idx: 3 }),
+      body: t("pages:overview.pillars.model_body"),
       icon: "mod",
     },
   ];
@@ -805,10 +770,10 @@ function PillarsTriptych() {
     <section className="mt-12">
       <div className="mb-4">
         <span className="text-[11px] uppercase tracking-widest font-semibold" style={{ color: "var(--color-accent)" }}>
-          Tres palancas
+          {t("pages:overview.pillars.tag")}
         </span>
         <h2 className="text-xl md:text-2xl font-semibold tracking-tight mt-1" style={{ color: "var(--color-fg)" }}>
-          Cualquier resultado tópico es atribuible a estas tres palancas
+          {t("pages:overview.pillars.title")}
         </h2>
       </div>
       <div className="grid sm:grid-cols-3 gap-4">
@@ -899,29 +864,30 @@ function PillarIcon({ kind }: { kind: "doc" | "tok" | "mod" }) {
    =======================================================================*/
 
 function MethodCoverage() {
+  const { t } = useTranslation(["pages"]);
   const groups = [
     {
-      title: "LDA-family · 9 variants",
+      title: t("pages:overview.coverage.lda_family"),
       color: "rgba(56,189,248,1)",
       items: ["LDA (canonical)", "gensim_vb", "gensim_multicore", "sklearn_online", "sklearn_sparse", "tomotopy_lda", "tomotopy_hdp", "tomotopy_ctm", "dmr_lda_hidsag"],
     },
     {
-      title: "Neural topic · 2 variants",
+      title: t("pages:overview.coverage.neural_topic"),
       color: "rgba(170,60,200,1)",
       items: ["ProdLDA (Pyro)", "ETM (low-rank ρα^T)"],
     },
     {
-      title: "Deep representations · 5",
+      title: t("pages:overview.coverage.deep_repr"),
       color: "rgba(40,160,80,1)",
       items: ["CAE-1D (K∈{4,6,8,10,12,16,32})", "CAE-2D (K∈{4,8,16,32})", "CAE-3D anchor (K∈{4,8,16,32})", "CAE-3D full-patch (K∈{4,8})", "β-VAE (β∈{1,2,4,8,16})"],
     },
     {
-      title: "K-dim baselines · 4",
+      title: t("pages:overview.coverage.k_baselines"),
       color: "rgba(214,140,40,1)",
       items: ["PCA-K", "NMF-K", "ICA-K", "dense-AE"],
     },
     {
-      title: "12-axis Addendum-B battery",
+      title: t("pages:overview.coverage.axes"),
       color: "rgba(214,39,40,1)",
       items: ["B-1 linear probe", "B-2 rate-distortion", "B-3 topic-routed + deep gate", "B-4 mutual information", "B-5 embedded baseline", "B-6 seed stability (N=7/15/30)", "B-7 USGS alignment", "B-8 cross-scene transfer", "B-9 anomaly", "B-10 spatial coherence", "B-11 endmember", "B-12 LLM tea-leaves"],
     },
@@ -930,10 +896,10 @@ function MethodCoverage() {
     <section className="mt-12">
       <div className="mb-4">
         <span className="text-[11px] uppercase tracking-widest font-semibold" style={{ color: "var(--color-accent)" }}>
-          Method coverage
+          {t("pages:overview.coverage.tag")}
         </span>
         <h2 className="text-xl md:text-2xl font-semibold tracking-tight mt-1" style={{ color: "var(--color-fg)" }}>
-          11 + 5 + 4 + 12 axes — todo evaluado en la misma escena cuando aplica
+          {t("pages:overview.coverage.title")}
         </h2>
       </div>
       <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-3">
@@ -975,23 +941,24 @@ function MethodCoverage() {
    =======================================================================*/
 
 function ReadingPath() {
+  const { t } = useTranslation(["pages"]);
   const steps = [
-    { tag: "Metodología", title: "Teoría", body: "El modelo PTM/LDA y por qué un píxel HSI puede tratarse como documento.", href: "/methodology/theory" },
-    { tag: "Metodología", title: "Representaciones", body: "La grilla V1..V12 × esquemas × Q + 5 deep encoders.", href: "/methodology/representations" },
-    { tag: "Metodología", title: "Pipeline", body: "Qué scripts corren localmente para producir el material que la app sirve.", href: "/methodology/pipeline" },
-    { tag: "Metodología", title: "Aplicación", body: "Cómo se aplican los tópicos a clasificación y regresión: directo / routed / embedded.", href: "/methodology/application" },
-    { tag: "Datos", title: "Bases de datos", body: "Los 21 datasets con su acceso, raíz local y archivos fuente.", href: "/databases" },
-    { tag: "Lab", title: "Workspace", body: "Flujo guiado familia → conjunto → representación → 11 tabs por escena etiquetada.", href: "/workspace" },
-    { tag: "Eval", title: "Benchmarks", body: "16 cards: multi-axis battery, Bayesian HDI, K-curve, β-collapse, neural-topic head-to-head, …", href: "/benchmarks" },
+    { tag: t("pages:overview.reading_path.step1_tag"), title: t("pages:overview.reading_path.step1_title"), body: t("pages:overview.reading_path.step1_body"), href: "/methodology/theory" },
+    { tag: t("pages:overview.reading_path.step2_tag"), title: t("pages:overview.reading_path.step2_title"), body: t("pages:overview.reading_path.step2_body"), href: "/methodology/representations" },
+    { tag: t("pages:overview.reading_path.step3_tag"), title: t("pages:overview.reading_path.step3_title"), body: t("pages:overview.reading_path.step3_body"), href: "/methodology/pipeline" },
+    { tag: t("pages:overview.reading_path.step4_tag"), title: t("pages:overview.reading_path.step4_title"), body: t("pages:overview.reading_path.step4_body"), href: "/methodology/application" },
+    { tag: t("pages:overview.reading_path.step5_tag"), title: t("pages:overview.reading_path.step5_title"), body: t("pages:overview.reading_path.step5_body"), href: "/databases" },
+    { tag: t("pages:overview.reading_path.step6_tag"), title: t("pages:overview.reading_path.step6_title"), body: t("pages:overview.reading_path.step6_body"), href: "/workspace" },
+    { tag: t("pages:overview.reading_path.step7_tag"), title: t("pages:overview.reading_path.step7_title"), body: t("pages:overview.reading_path.step7_body"), href: "/benchmarks" },
   ];
   return (
     <section className="mt-12 mb-8">
       <div className="mb-4">
         <span className="text-[11px] uppercase tracking-widest font-semibold" style={{ color: "var(--color-accent)" }}>
-          Cómo leer este sitio
+          {t("pages:overview.reading_path.tag")}
         </span>
         <h2 className="text-xl md:text-2xl font-semibold tracking-tight mt-1" style={{ color: "var(--color-fg)" }}>
-          Camino sugerido — 7 paradas
+          {t("pages:overview.reading_path.title")}
         </h2>
       </div>
       <ol className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -97,7 +97,7 @@ export default function Workspace() {
   return (
     <PageShell
       title={t("pages:workspace.title")}
-      lead="Flujo guiado en cuatro pasos: familia → conjunto → representación → explorar. Cada paso depende de los anteriores; puedes retroceder en cualquier momento."
+      lead={t("pages:workspace.lead")}
     >
       <Stepper currentIndex={currentStepIndex} state={state.value} ctx={state.context} />
 
@@ -431,6 +431,7 @@ function ExploreStep({
   rep: string | null;
   onBack: () => void;
 }) {
+  const { t } = useTranslation(["pages"]);
   const isLabelled = subsetId !== null && LABELLED_SCENES.has(subsetId);
   const [tab, setTab] = useState<ExploreTab>("raw");
 
@@ -577,38 +578,38 @@ function ExploreStep({
           >
             {([
               {
-                category: "Datos brutos",
+                category: t("pages:workspace.tabs.group_raw"),
                 color: "rgba(56, 189, 248, 1)",
                 tabs: [
-                  { id: "raw" as const, label: "Cruda · clases" },
-                  { id: "browser" as const, label: "Browser · 8000 espectros" },
+                  { id: "raw" as const, label: t("pages:workspace.tabs.raw") },
+                  { id: "browser" as const, label: t("pages:workspace.tabs.browser") },
                 ],
               },
               {
-                category: "Modelo de tópicos",
+                category: t("pages:workspace.tabs.group_topics"),
                 color: "rgba(40, 160, 80, 1)",
                 tabs: [
-                  { id: "topics" as const, label: "Tópicos · LDAvis" },
-                  { id: "topiclabel" as const, label: "Tópico vs etiqueta" },
-                  { id: "routed" as const, label: "Routed · ranking" },
+                  { id: "topics" as const, label: t("pages:workspace.tabs.topics") },
+                  { id: "topiclabel" as const, label: t("pages:workspace.tabs.topiclabel") },
+                  { id: "routed" as const, label: t("pages:workspace.tabs.routed") },
                 ],
               },
               {
-                category: "Geometría espacial",
+                category: t("pages:workspace.tabs.group_spatial"),
                 color: "rgba(170, 60, 200, 1)",
                 tabs: [
-                  { id: "raster" as const, label: "Mapa espacial" },
-                  { id: "embed3d" as const, label: "Embedding 3D · θ-PCA" },
+                  { id: "raster" as const, label: t("pages:workspace.tabs.raster") },
+                  { id: "embed3d" as const, label: t("pages:workspace.tabs.embed3d") },
                 ],
               },
               {
-                category: "Diagnóstico",
+                category: t("pages:workspace.tabs.group_diagnostics"),
                 color: "rgba(214, 140, 40, 1)",
                 tabs: [
-                  { id: "stability" as const, label: "Estabilidad · 7-seed" },
-                  { id: "deep" as const, label: "Deep latents" },
-                  { id: "usgs" as const, label: "USGS · librería v7" },
-                  { id: "metrics" as const, label: "Reconstrucción + MI" },
+                  { id: "stability" as const, label: t("pages:workspace.tabs.stability") },
+                  { id: "deep" as const, label: t("pages:workspace.tabs.deep") },
+                  { id: "usgs" as const, label: t("pages:workspace.tabs.usgs") },
+                  { id: "metrics" as const, label: t("pages:workspace.tabs.metrics") },
                 ],
               },
             ] as { category: string; color: string; tabs: { id: ExploreTab; label: string }[] }[]).map((group) => (
@@ -4088,6 +4089,7 @@ function FamilyPickerStep({
    =======================================================================*/
 
 function SceneBriefingHero({ subsetId, rep }: { subsetId: string; rep: string | null }) {
+  const { t } = useTranslation(["pages"]);
   const eda = useQuery({
     queryKey: ["briefing-eda", subsetId],
     queryFn: () => api.edaPerScene(subsetId),
@@ -4111,7 +4113,7 @@ function SceneBriefingHero({ subsetId, rep }: { subsetId: string; rep: string | 
         }}
       >
         <p style={{ color: "var(--color-fg-faint)" }} className="text-sm">
-          Cargando contexto de la escena…
+          {t("pages:workspace.briefing.loading_scene_context")}
         </p>
       </div>
     );
@@ -4193,12 +4195,12 @@ function SceneBriefingHero({ subsetId, rep }: { subsetId: string; rep: string | 
             ) : null}
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-1 text-[12.5px]" style={{ color: "var(--color-fg-subtle)" }}>
-            <BriefingStat label="dim" value={`${shape[0]}×${shape[1]}`} />
-            <BriefingStat label="bands" value={String(wl.length)} />
-            <BriefingStat label="wl" value={`${wlLo.toFixed(0)}–${wlHi.toFixed(0)} nm`} />
-            <BriefingStat label="clases" value={String(data.n_classes ?? classDist.length)} />
-            <BriefingStat label="labelled" value={(data.n_labelled_pixels ?? 0).toLocaleString("en-US")} />
-            {tv.data ? <BriefingStat label="K topics" value={String(tv.data.topic_count)} /> : null}
+            <BriefingStat label={t("pages:workspace.briefing.stat_dim")} value={`${shape[0]}×${shape[1]}`} />
+            <BriefingStat label={t("pages:workspace.briefing.stat_bands")} value={String(wl.length)} />
+            <BriefingStat label={t("pages:workspace.briefing.stat_wavelength")} value={`${wlLo.toFixed(0)}–${wlHi.toFixed(0)} nm`} />
+            <BriefingStat label={t("pages:workspace.briefing.stat_classes")} value={String(data.n_classes ?? classDist.length)} />
+            <BriefingStat label={t("pages:workspace.briefing.stat_labelled")} value={(data.n_labelled_pixels ?? 0).toLocaleString("en-US")} />
+            {tv.data ? <BriefingStat label={t("pages:workspace.briefing.stat_k_topics")} value={String(tv.data.topic_count)} /> : null}
           </div>
           {classDist.length ? (
             <div className="mt-2.5">
@@ -4218,7 +4220,7 @@ function SceneBriefingHero({ subsetId, rep }: { subsetId: string; rep: string | 
                     {c.name}
                   </span>
                 ))}
-                {classDist.length > 5 ? <span>+{classDist.length - 5} más</span> : null}
+                {classDist.length > 5 ? <span>{t("pages:workspace.briefing.more_classes", { count: classDist.length - 5 })}</span> : null}
               </div>
             </div>
           ) : null}
@@ -4234,11 +4236,11 @@ function SceneBriefingHero({ subsetId, rep }: { subsetId: string; rep: string | 
             </svg>
           ) : (
             <div className="text-[10.5px]" style={{ color: "var(--color-fg-faint)" }}>
-              envelope no disponible
+              {t("pages:workspace.briefing.envelope_unavailable")}
             </div>
           )}
           <div className="text-[9.5px] uppercase tracking-widest font-medium text-center mt-0.5" style={{ color: "var(--color-fg-faint)" }}>
-            envolvente espectral por clase
+            {t("pages:workspace.briefing.envelope_caption")}
           </div>
         </div>
 

--- a/frontend/src/pages/methodology/Index.tsx
+++ b/frontend/src/pages/methodology/Index.tsx
@@ -1,47 +1,21 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 import { PageShell } from "@/components/PageShell";
 
 const SUBPAGES = [
-  {
-    path: "/methodology/theory",
-    title: "Teoría",
-    tag: "PTM · LDA",
-    body: "El modelo probabilístico de tópicos (PTM) y por qué un píxel hiperespectral puede tratarse como un documento. LDA en notación de placas, inferencia variacional, generalización a HDP y CTM. Equations: \\theta \\sim \\mathrm{Dir}(\\alpha), \\phi \\sim \\mathrm{Dir}(\\eta), z \\sim \\mathrm{Cat}(\\theta), w \\sim \\mathrm{Cat}(\\phi_z).",
-    color: "rgba(56, 189, 248, 1)",
-    icon: "theory" as const,
-  },
-  {
-    path: "/methodology/representations",
-    title: "Representaciones",
-    tag: "V1..V12 + Deep",
-    body: "Doce recetas de wordificación (V1 banda → V12 GMM-token), tres esquemas (uniform/quantile/equalised), Q ∈ {8, 16, 32}. Más cinco encoders profundos: CAE-1D / CAE-2D / CAE-3D anchor & full-patch / β-VAE. PCA, NMF, ICA como baselines K-dim de comparación justa.",
-    color: "rgba(170, 60, 200, 1)",
-    icon: "repr" as const,
-  },
-  {
-    path: "/methodology/pipeline",
-    title: "Pipeline",
-    tag: "57 builders",
-    body: "Diagrama de las 12 etapas del data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Cinco builders torch (cae_1d, cae_2d, cae_3d, beta_vae, prodlda) detectan GPU automáticamente con fallback CPU.",
-    color: "rgba(40, 160, 80, 1)",
-    icon: "pipe" as const,
-  },
-  {
-    path: "/methodology/application",
-    title: "Aplicación",
-    tag: "directo · routed · embedded",
-    body: "Cómo se aplican los tópicos a tareas downstream: feature plano (theta_logistic, dominado por raw), gating (topic_routed_soft = soft mixture de especialistas por tópico, gana o iguala raw en 6/6), embedded (concat [θ | pca_K], pequeño efecto en IP). El B-3 follow-up cierra: el simplex Dirichlet importa, no la compresión K-dim.",
-    color: "rgba(214, 140, 40, 1)",
-    icon: "app" as const,
-  },
+  { path: "/methodology/theory", tagKey: "theory_tag", titleKey: "theory_title", bodyKey: "theory_body", color: "rgba(56, 189, 248, 1)", icon: "theory" as const },
+  { path: "/methodology/representations", tagKey: "repr_tag", titleKey: "repr_title", bodyKey: "repr_body", color: "rgba(170, 60, 200, 1)", icon: "repr" as const },
+  { path: "/methodology/pipeline", tagKey: "pipe_tag", titleKey: "pipe_title", bodyKey: "pipe_body", color: "rgba(40, 160, 80, 1)", icon: "pipe" as const },
+  { path: "/methodology/application", tagKey: "app_tag", titleKey: "app_title", bodyKey: "app_body", color: "rgba(214, 140, 40, 1)", icon: "app" as const },
 ];
 
 export default function MethodologyIndex() {
+  const { t } = useTranslation(["pages"]);
   return (
     <PageShell
-      title="Metodología"
-      lead="Cuatro entradas: la teoría detrás del modelo, las representaciones que el corpus acepta, el pipeline que produce los datos, y cómo los tópicos se aplican a tareas downstream."
+      title={t("pages:methodology.title")}
+      lead={t("pages:methodology.index.lead")}
     >
       <div className="grid sm:grid-cols-2 gap-4 mt-2">
         {SUBPAGES.map((p) => (
@@ -65,7 +39,7 @@ export default function MethodologyIndex() {
                 className="text-[11px] uppercase tracking-widest font-semibold"
                 style={{ color: p.color }}
               >
-                {p.tag}
+                {t(`pages:methodology.index.${p.tagKey}`)}
               </span>
               <span aria-hidden className="text-[14px]" style={{ color: p.color, opacity: 0.4 }}>→</span>
             </div>
@@ -74,13 +48,13 @@ export default function MethodologyIndex() {
               className="mt-3 text-lg font-semibold tracking-tight"
               style={{ color: "var(--color-fg)" }}
             >
-              {p.title}
+              {t(`pages:methodology.index.${p.titleKey}`)}
             </h2>
             <p
               className="mt-2 text-[13.5px] leading-relaxed"
               style={{ color: "var(--color-fg-subtle)" }}
             >
-              {p.body}
+              {t(`pages:methodology.index.${p.bodyKey}`)}
             </p>
           </Link>
         ))}
@@ -95,10 +69,7 @@ export default function MethodologyIndex() {
           color: "var(--color-fg-subtle)",
         }}
       >
-        <strong style={{ color: "var(--color-fg)" }}>Lectura sugerida</strong>:
-        Teoría → Representaciones → Pipeline → Aplicación. La hoja de
-        Bayesian Method Comparison y la página Multi-Axis Addendum B
-        de la wiki cierran el ciclo metodológico.
+        {t("pages:methodology.index.reading")}
       </div>
     </PageShell>
   );
@@ -106,16 +77,12 @@ export default function MethodologyIndex() {
 
 function SubpageIcon({ kind, color }: { kind: "theory" | "repr" | "pipe" | "app"; color: string }) {
   if (kind === "theory") {
-    // plate notation simplified
     return (
       <svg viewBox="0 0 320 80" width="100%" height="76" aria-hidden="true">
-        {/* outer plate */}
         <rect x="14" y="10" width="290" height="60" fill="none" stroke={color} strokeWidth="1.4" rx="6"/>
         <text x="294" y="64" fontSize="10" textAnchor="end" fill={color} fontFamily="ui-monospace, monospace" opacity="0.75">D</text>
-        {/* inner plate */}
         <rect x="100" y="22" width="190" height="38" fill="none" stroke={color} strokeOpacity="0.6" strokeWidth="1.2" rx="6"/>
         <text x="282" y="55" fontSize="10" textAnchor="end" fill={color} fontFamily="ui-monospace, monospace" opacity="0.55">N_d</text>
-        {/* nodes */}
         <circle cx="40" cy="40" r="11" fill="none" stroke={color} strokeWidth="1.4"/>
         <text x="40" y="44" fontSize="10" textAnchor="middle" fill={color} fontFamily="ui-monospace, monospace">α</text>
         <circle cx="80" cy="40" r="11" fill="none" stroke={color} strokeWidth="1.4"/>
@@ -126,7 +93,6 @@ function SubpageIcon({ kind, color }: { kind: "theory" | "repr" | "pipe" | "app"
         <text x="200" y="44" fontSize="10" textAnchor="middle" fill={color} fontFamily="ui-monospace, monospace">w</text>
         <circle cx="260" cy="40" r="11" fill="none" stroke={color} strokeWidth="1.4"/>
         <text x="260" y="44" fontSize="10" textAnchor="middle" fill={color} fontFamily="ui-monospace, monospace">φ</text>
-        {/* arrows */}
         <line x1="51" y1="40" x2="69" y2="40" stroke={color} strokeWidth="1.2"/>
         <line x1="91" y1="40" x2="124" y2="40" stroke={color} strokeWidth="1.2"/>
         <line x1="146" y1="40" x2="189" y2="40" stroke={color} strokeWidth="1.2"/>
@@ -135,7 +101,6 @@ function SubpageIcon({ kind, color }: { kind: "theory" | "repr" | "pipe" | "app"
     );
   }
   if (kind === "repr") {
-    // 12 recipes grid + deep encoder badge
     return (
       <svg viewBox="0 0 320 80" width="100%" height="76" aria-hidden="true">
         {Array.from({ length: 12 }, (_, i) => (
@@ -144,7 +109,6 @@ function SubpageIcon({ kind, color }: { kind: "theory" | "repr" | "pipe" | "app"
             <text x={i * 22 + 13} y="29" fontSize="8.5" textAnchor="middle" fill="currentColor" opacity="0.85" fontFamily="ui-monospace, monospace">V{i + 1}</text>
           </g>
         ))}
-        {/* deep encoder badge */}
         <rect x="4" y="46" width="110" height="22" rx="6" fill={color} fillOpacity="0.18" stroke={color} strokeWidth="1.1"/>
         <text x="59" y="61" fontSize="10" textAnchor="middle" fill={color} fontFamily="ui-monospace, monospace" fontWeight="600">CAE-1D · 2D · 3D</text>
         <rect x="120" y="46" width="80" height="22" rx="6" fill={color} fillOpacity="0.18" stroke={color} strokeWidth="1.1"/>
@@ -155,7 +119,6 @@ function SubpageIcon({ kind, color }: { kind: "theory" | "repr" | "pipe" | "app"
     );
   }
   if (kind === "pipe") {
-    // 12-stage pipeline DAG
     return (
       <svg viewBox="0 0 320 80" width="100%" height="76" aria-hidden="true">
         {[0, 60, 120, 180, 240].map((x, i) => (
@@ -176,12 +139,10 @@ function SubpageIcon({ kind, color }: { kind: "theory" | "repr" | "pipe" | "app"
       </svg>
     );
   }
-  // app
   return (
     <svg viewBox="0 0 320 80" width="100%" height="76" aria-hidden="true">
-      {/* three flow rectangles: directo, routed, embedded */}
       {[
-        { label: "directo", desc: "θ flat → logistic", x: 4 },
+        { label: "direct", desc: "θ flat → logistic", x: 4 },
         { label: "routed", desc: "P_k(y|x) gated by θ_k", x: 110 },
         { label: "embedded", desc: "[θ | PCA_K] → logistic", x: 216 },
       ].map((b, i) => (


### PR DESCRIPTION
All hard-coded Spanish strings in cycles 65-68 visual components now go through useTranslation t(). Both languages provided in pages.json. English is hard default (lng:'en' from cycle 67); Spanish remains a localStorage opt-in.