### PR TITLE
develop → main: cycle 71 (Stage-3 rep picker wired to Stage-4)

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -189,6 +189,7 @@
       "routed": "Routed · ranking",
       "raster": "Spatial map",
       "embed3d": "Embedding 3D · θ-PCA",
+      "repfit": "Representation fit · 3D",
       "stability": "Stability · 7-seed",
       "deep": "Deep latents",
       "usgs": "USGS · library v7",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -189,6 +189,7 @@
       "routed": "Routed · ranking",
       "raster": "Mapa espacial",
       "embed3d": "Embedding 3D · θ-PCA",
+      "repfit": "Fit de representación · 3D",
       "stability": "Estabilidad · 7-seed",
       "deep": "Deep latents",
       "usgs": "USGS · librería v7",

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -321,6 +321,60 @@ const REPRESENTATIONS: Representation[] = [
       "K endmembers vía NFINDR (Winter 1999) + abundancias por NNLS con suma-a-uno. Baseline físico contra LDA.",
     status: "shipped",
   },
+  {
+    id: "ica",
+    family: "compression",
+    label: "ICA — FastICA",
+    short: "Independent components",
+    description:
+      "Componentes estadísticamente independientes (FastICA). K=8. Baseline complementario a PCA en compresión lineal.",
+    status: "shipped",
+  },
+  {
+    id: "cae_1d",
+    family: "compression",
+    label: "CAE-1D · K=8",
+    short: "Conv autoencoder 1D",
+    description:
+      "Autoencoder convolucional 1D sobre espectro. Encoder Conv1D → bottleneck K=8 → decoder. GPU-trained.",
+    status: "shipped",
+  },
+  {
+    id: "cae_2d",
+    family: "compression",
+    label: "CAE-2D · K=8",
+    short: "Conv autoencoder 2D anchor",
+    description:
+      "CAE 2D sobre parches espaciales-espectrales. Anchor K=8. Captura textura espacial + perfil espectral.",
+    status: "shipped",
+  },
+  {
+    id: "cae_3d",
+    family: "compression",
+    label: "CAE-3D anchor · K=8",
+    short: "Conv autoencoder 3D anchor",
+    description:
+      "CAE 3D sobre cubos (espacial × espectral). Versión anchor (centro del parche). K=8 GPU-trained.",
+    status: "shipped",
+  },
+  {
+    id: "cae_3d_full",
+    family: "compression",
+    label: "CAE-3D full · K=8",
+    short: "Conv autoencoder 3D full-patch",
+    description:
+      "Variante full-patch del CAE-3D — todos los píxeles del parche contribuyen al loss. K=8 GPU-trained.",
+    status: "shipped",
+  },
+  {
+    id: "beta_vae",
+    family: "compression",
+    label: "β-VAE · K=8",
+    short: "Variational autoencoder",
+    description:
+      "VAE con β=2 que regulariza el KL divergence. Latente probabilístico desentrelazado. K=8 GPU-trained.",
+    status: "shipped",
+  },
 ];
 
 function RepresentationPickerStep({
@@ -437,10 +491,28 @@ type ExploreTab =
   | "routed"
   | "raster"
   | "embed3d"
+  | "repfit"
   | "stability"
   | "deep"
   | "usgs"
   | "metrics";
+
+const TOPIC_FAMILY_REPS = new Set(["lda", "lda_sparse", "lda_tomo", "hdp", "ctm", "prodlda"]);
+const REPRESENTATION_ENDPOINT_METHOD: Record<string, string> = {
+  pca: "pca_8",
+  nmf: "nmf_8",
+  ae: "dense_ae_8",
+  ica: "ica_8",
+  cae_1d: "cae_1d_8",
+  cae_2d: "cae_2d_8",
+  cae_3d: "cae_3d_8",
+  cae_3d_full: "cae_3d_full_8",
+  beta_vae: "beta_vae_8",
+};
+function repToApiMethod(rep: string | null): string | null {
+  if (!rep) return null;
+  return REPRESENTATION_ENDPOINT_METHOD[rep] ?? null;
+}
 
 function ExploreStep({
   subsetId,
@@ -520,6 +592,13 @@ function ExploreStep({
     queryKey: ["mutual-info", subsetId],
     queryFn: () => api.mutualInformation(subsetId!),
     enabled: isLabelled && tab === "metrics",
+  });
+
+  const apiMethod = repToApiMethod(rep);
+  const repFit = useQuery({
+    queryKey: ["rep-fit", subsetId, apiMethod],
+    queryFn: () => api.representation(apiMethod!, subsetId!),
+    enabled: isLabelled && tab === "repfit" && !!apiMethod,
   });
 
   return (
@@ -625,6 +704,7 @@ function ExploreStep({
                 tabs: [
                   { id: "raster" as const, label: t("pages:workspace.tabs.raster") },
                   { id: "embed3d" as const, label: t("pages:workspace.tabs.embed3d") },
+                  { id: "repfit" as const, label: t("pages:workspace.tabs.repfit") },
                 ],
               },
               {
@@ -714,6 +794,15 @@ function ExploreStep({
               isLoading={embed3d.isLoading}
               error={embed3d.error as Error | null}
               data={embed3d.data ?? null}
+            />
+          )}
+          {tab === "repfit" && (
+            <RepresentationFitTab
+              rep={rep}
+              apiMethod={apiMethod}
+              isLoading={repFit.isLoading}
+              error={repFit.error as Error | null}
+              data={repFit.data ?? null}
             />
           )}
           {tab === "browser" && (
@@ -4699,6 +4788,246 @@ function HidsagCorrelationCard({ eda }: { eda: import("@/api/client").HidsagEda 
           )}
         </svg>
       </div>
+    </div>
+  );
+}
+
+function RepresentationFitTab({
+  rep,
+  apiMethod,
+  isLoading,
+  error,
+  data,
+}: {
+  rep: string | null;
+  apiMethod: string | null;
+  isLoading: boolean;
+  error: Error | null;
+  data: import("@/api/client").RepresentationPayload | null;
+}) {
+  if (!rep) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}
+      >
+        <p style={{ color: "var(--color-fg-subtle)" }}>
+          Pick a representation in Stage 3 first.
+        </p>
+      </div>
+    );
+  }
+  if (!apiMethod) {
+    const isTopic = TOPIC_FAMILY_REPS.has(rep);
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}
+      >
+        <p style={{ color: "var(--color-fg-subtle)" }}>
+          {isTopic ? (
+            <>
+              <strong>{rep}</strong> is a topic-family representation — its native 3D embedding is in
+              the <em>Embed 3D</em> tab (θ-PCA-3D), and its topic profiles in <em>Topics</em>.
+            </>
+          ) : rep === "endmember" ? (
+            <>
+              <strong>endmember</strong> is an unmixing baseline — its native panels (endmember spectra,
+              abundance simplex) ship in a dedicated Unmixing Explorer (cycle 73).
+            </>
+          ) : (
+            <>No representation-fit endpoint for <strong>{rep}</strong>.</>
+          )}
+        </p>
+      </div>
+    );
+  }
+  if (isLoading) {
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>Loading representation fit for {apiMethod}…</p>
+    );
+  }
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>Could not load representation fit.</p>
+        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const points: import("@/api/client").EmbeddingPoint3D[] = (data.scatter_2d_3d_subsample ?? []).map((p) => ({
+    doc_id: p.i,
+    x: p.x_3d,
+    y: p.y_3d,
+    z: p.z_3d,
+    label_id: p.label_id,
+  }));
+
+  const evList = data.scatter_pca_3d_explained_variance ?? [];
+  const evTotal = evList.reduce((a, b) => a + b, 0);
+
+  const fitMetaEntries = Object.entries(data.fit_meta || {});
+
+  return (
+    <div className="space-y-5">
+      <div
+        className="rounded-lg border p-5"
+        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+      >
+        <header className="flex flex-wrap items-baseline justify-between gap-3 mb-2">
+          <div>
+            <h4 className="text-base font-semibold tracking-tight" style={{ color: "var(--color-fg)" }}>
+              {rep} · 3D embedding · {data.n_documents} documents
+            </h4>
+            <p className="text-[12.5px]" style={{ color: "var(--color-fg-faint)" }}>
+              backend method <code>{data.method}</code> · latent dim {data.latent_dim} · scatter is PCA-3D
+              {evList.length ? (
+                <>
+                  {" "}of latent space (Σ EV {(evTotal * 100).toFixed(1)}% — components{" "}
+                  {evList.map((v, i) => (
+                    <span key={i} className="font-mono text-[11px]">
+                      {i > 0 ? " · " : ""}{(v * 100).toFixed(1)}%
+                    </span>
+                  ))}
+                  )
+                </>
+              ) : null}
+            </p>
+          </div>
+        </header>
+        <Suspense fallback={<p style={{ color: "var(--color-fg-faint)" }}>Loading 3D…</p>}>
+          <Scatter3D points={points} colorBy="label" selectedTopic={null} />
+        </Suspense>
+        <p className="mt-2 text-[11px]" style={{ color: "var(--color-fg-faint)" }}>
+          Coloured by ground-truth label. Drag to rotate, scroll to zoom, click a point to pick.
+        </p>
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-4">
+        <div
+          className="rounded-lg border p-4"
+          style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+        >
+          <div className="text-[10px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--color-fg-faint)" }}>
+            KMeans vs label
+          </div>
+          <div className="text-[28px] font-mono leading-tight" style={{ color: "var(--color-fg)" }}>
+            {data.downstream_kmeans_vs_label.ari.toFixed(3)}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-fg-faint)" }}>
+            ARI · NMI {data.downstream_kmeans_vs_label.nmi.toFixed(3)}
+          </div>
+        </div>
+        {data.silhouette_label ? (
+          <div
+            className="rounded-lg border p-4"
+            style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+          >
+            <div className="text-[10px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--color-fg-faint)" }}>
+              Silhouette (label-supervised)
+            </div>
+            <div className="text-[28px] font-mono leading-tight" style={{ color: "var(--color-fg)" }}>
+              {data.silhouette_label.overall.toFixed(3)}
+            </div>
+            <div className="text-[11px]" style={{ color: "var(--color-fg-faint)" }}>
+              overall · negative = clusters mixed; positive = well separated
+            </div>
+          </div>
+        ) : null}
+        <div
+          className="rounded-lg border p-4"
+          style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+        >
+          <div className="text-[10px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--color-fg-faint)" }}>
+            Latent dim
+          </div>
+          <div className="text-[28px] font-mono leading-tight" style={{ color: "var(--color-fg)" }}>
+            {data.latent_dim}
+          </div>
+          <div className="text-[11px]" style={{ color: "var(--color-fg-faint)" }}>K = bottleneck size</div>
+        </div>
+      </div>
+
+      {fitMetaEntries.length > 0 ? (
+        <div
+          className="rounded-lg border p-4"
+          style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+        >
+          <div className="text-[10px] uppercase tracking-widest font-semibold mb-2" style={{ color: "var(--color-fg-faint)" }}>
+            Fit metadata
+          </div>
+          <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5 text-[12.5px]" style={{ color: "var(--color-fg)" }}>
+            {fitMetaEntries.map(([k, v]) => (
+              <div key={k} className="flex items-baseline justify-between gap-2 border-b" style={{ borderColor: "var(--color-border)" }}>
+                <span className="font-mono text-[11.5px]" style={{ color: "var(--color-fg-faint)" }}>{k}</span>
+                <span className="font-mono">
+                  {typeof v === "number"
+                    ? Array.isArray(v)
+                      ? "—"
+                      : v.toFixed(4)
+                    : Array.isArray(v)
+                      ? `[${(v as unknown as number[]).slice(0, 4).map((x) => x.toFixed(3)).join(", ")}${(v as unknown as number[]).length > 4 ? "…" : ""}]`
+                      : String(v)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {data.silhouette_label?.per_class ? (
+        <div
+          className="rounded-lg border p-4"
+          style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+        >
+          <div className="text-[10px] uppercase tracking-widest font-semibold mb-2" style={{ color: "var(--color-fg-faint)" }}>
+            Silhouette per class (sorted)
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-[12.5px]" style={{ color: "var(--color-fg)" }}>
+              <thead>
+                <tr style={{ color: "var(--color-fg-faint)" }}>
+                  <th className="text-left font-mono text-[11px] pb-1 pr-3">class</th>
+                  <th className="text-right font-mono text-[11px] pb-1 pr-3">silhouette</th>
+                  <th className="text-left font-mono text-[11px] pb-1">bar</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(data.silhouette_label.per_class)
+                  .sort(([, a], [, b]) => (b as number) - (a as number))
+                  .map(([cls, val]) => {
+                    const v = val as number;
+                    const norm = Math.max(0, Math.min(1, (v + 1) / 2));
+                    return (
+                      <tr key={cls} style={{ borderTop: "1px solid var(--color-border)" }}>
+                        <td className="py-1 pr-3 font-mono">{cls}</td>
+                        <td className="py-1 pr-3 text-right font-mono">{v.toFixed(3)}</td>
+                        <td className="py-1 w-[180px]">
+                          <div className="relative w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
+                            <div
+                              className="absolute top-0 bottom-0 rounded"
+                              style={{
+                                left: v >= 0 ? "50%" : `${50 + norm * 50 - 50}%`,
+                                width: `${Math.abs(v) * 50}%`,
+                                backgroundColor: v >= 0 ? "rgba(40,160,80,0.85)" : "rgba(214,39,40,0.85)",
+                              }}
+                            />
+                            <div className="absolute top-0 bottom-0" style={{ left: "50%", width: 1, backgroundColor: "var(--color-fg-faint)" }} />
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Ships cycle 71: Stage-3 representation picker now actually drives Stage-4 render via /api/representations/{method}/{scene}. New Representation-fit 3D tab with rotating point cloud, ARI/NMI/silhouette, fit metadata. Closes #257.