### PR TITLE
develop → main: cycle 71b (version banner in footer)

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,19 +1,51 @@
 import { useTranslation } from "react-i18next";
 
+import { APP_BRANCH, APP_BUILD_TIME, APP_COMMIT_SHA, APP_VERSION } from "@/lib/version";
+
+function formatBuildTime(iso: string): string {
+  if (!iso || iso === "dev") return "dev";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}Z`;
+}
+
 export function Footer() {
   const { t } = useTranslation();
+  const built = formatBuildTime(APP_BUILD_TIME);
   return (
     <footer
       className="border-t mt-12"
       style={{ borderColor: "var(--color-border)" }}
     >
       <div
-        className="mx-auto max-w-screen-2xl px-6 py-6 text-sm flex flex-wrap items-center gap-4"
+        className="mx-auto max-w-screen-2xl px-6 py-6 text-sm flex flex-wrap items-center gap-x-4 gap-y-2"
         style={{ color: "var(--color-fg-faint)" }}
       >
         <span>{t("common:site_title")}</span>
         <span>·</span>
         <span>{t("common:site_tagline")}</span>
+        <span className="ml-auto inline-flex items-baseline gap-x-3 font-mono text-[11.5px]">
+          <span title="App version (manual, bumped per cycle)">
+            <span style={{ color: "var(--color-fg-faint)" }}>v</span>
+            <span style={{ color: "var(--color-fg-subtle)" }}>{APP_VERSION}</span>
+          </span>
+          <span aria-hidden style={{ opacity: 0.4 }}>·</span>
+          <span title="Git commit SHA at build time">
+            <span style={{ color: "var(--color-fg-faint)" }}>sha </span>
+            <span style={{ color: "var(--color-fg-subtle)" }}>{APP_COMMIT_SHA}</span>
+          </span>
+          <span aria-hidden style={{ opacity: 0.4 }}>·</span>
+          <span title="Git branch at build time">
+            <span style={{ color: "var(--color-fg-faint)" }}>br </span>
+            <span style={{ color: "var(--color-fg-subtle)" }}>{APP_BRANCH}</span>
+          </span>
+          <span aria-hidden style={{ opacity: 0.4 }}>·</span>
+          <span title="Build timestamp (UTC) — when the bundle was produced">
+            <span style={{ color: "var(--color-fg-faint)" }}>built </span>
+            <span style={{ color: "var(--color-fg-subtle)" }}>{built}</span>
+          </span>
+        </span>
       </div>
     </footer>
   );

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -1,0 +1,14 @@
+declare const __APP_BUILD_TIME__: string;
+declare const __APP_COMMIT_SHA__: string;
+declare const __APP_BRANCH__: string;
+
+export const APP_VERSION = "cycle 71";
+
+export const APP_BUILD_TIME: string =
+  typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";
+
+export const APP_COMMIT_SHA: string =
+  typeof __APP_COMMIT_SHA__ !== "undefined" ? __APP_COMMIT_SHA__ : "dev";
+
+export const APP_BRANCH: string =
+  typeof __APP_BRANCH__ !== "undefined" ? __APP_BRANCH__ : "dev";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,11 +2,41 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
+import { execSync } from "node:child_process";
 
 const apiTarget = process.env.VITE_API_BASE ?? "http://127.0.0.1:8105";
 
+function readGitShortSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function readGitBranch(): string {
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+const BUILD_TIME = new Date().toISOString();
+const COMMIT_SHA = readGitShortSha();
+const BRANCH = readGitBranch();
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_BUILD_TIME__: JSON.stringify(BUILD_TIME),
+    __APP_COMMIT_SHA__: JSON.stringify(COMMIT_SHA),
+    __APP_BRANCH__: JSON.stringify(BRANCH),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Ships cycle 71b: footer now shows v / sha / br / built so deploys are verifiable. Closes #260.