### PR TITLE
cycle 74 (visual): Interpretability tab (closes #266)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -367,6 +367,18 @@ export const api = {
     request<EndmemberBaseline>(
       `/api/endmember-baseline/${encodeURIComponent(sceneId)}`,
     ),
+  interpretabilityTopicCards: (sceneId: string) =>
+    request<TopicCardsFile>(
+      `/generated/interpretability/${encodeURIComponent(sceneId)}/topic_cards.json`,
+    ),
+  interpretabilityBandCards: (sceneId: string) =>
+    request<BandCardsFile>(
+      `/generated/interpretability/${encodeURIComponent(sceneId)}/band_cards.json`,
+    ),
+  interpretabilityDocumentCards: (sceneId: string) =>
+    request<DocumentCardsFile>(
+      `/generated/interpretability/${encodeURIComponent(sceneId)}/document_cards.json`,
+    ),
   topicAnomaly: (sceneId: string) =>
     request<TopicAnomaly>(
       `/api/topic-anomaly/${encodeURIComponent(sceneId)}`,
@@ -764,6 +776,47 @@ export type TopicSpatialContinuous = {
   }[];
   aggregated_morans_I_mean_over_topics: number;
   aggregated_gearys_C_mean_over_topics: number;
+};
+
+export type TopicCard = {
+  topic_k: number;
+  peak_wavelength_nm: number;
+  peak_value: number;
+  fwhm_nm: number;
+  p_label_given_topic_top3: { label_id: number; name: string; p: number }[];
+};
+export type TopicCardsFile = {
+  scene_id: string;
+  K: number;
+  topic_cards: TopicCard[];
+};
+
+export type BandCard = {
+  band_index: number;
+  wavelength_nm: number;
+  fisher_ratio: number;
+  f_stat: number;
+  p_value: number;
+  mutual_info_vs_label: number;
+};
+export type BandCardsFile = {
+  scene_id: string;
+  n_bands: number;
+  band_cards: BandCard[];
+};
+
+export type DocumentCard = {
+  doc_id: string;
+  topic_k_dominant: number;
+  theta_full: number[];
+  theta_k_at_dominant: number;
+  label_id: number;
+  label_name: string;
+};
+export type DocumentCardsFile = {
+  scene_id: string;
+  n_documents: number;
+  document_cards: DocumentCard[];
 };
 
 export type EndmemberBaseline = {

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -187,6 +187,7 @@
       "topics": "Topics · LDAvis",
       "topiclabel": "Topic vs label",
       "routed": "Routed · ranking",
+      "interpret": "Interpretability cards",
       "raster": "Spatial map",
       "embed3d": "Embedding 3D · θ-PCA",
       "repfit": "Representation fit · 3D",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -187,6 +187,7 @@
       "topics": "Tópicos · LDAvis",
       "topiclabel": "Tópico vs etiqueta",
       "routed": "Routed · ranking",
+      "interpret": "Cards de interpretabilidad",
       "raster": "Mapa espacial",
       "embed3d": "Embedding 3D · θ-PCA",
       "repfit": "Fit de representación · 3D",

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 73";
+export const APP_VERSION = "cycle 74";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -493,6 +493,7 @@ type ExploreTab =
   | "embed3d"
   | "repfit"
   | "unmixing"
+  | "interpret"
   | "stability"
   | "deep"
   | "usgs"
@@ -613,6 +614,22 @@ function ExploreStep({
     enabled: isLabelled && tab === "unmixing",
   });
 
+  const interpretTopics = useQuery({
+    queryKey: ["interpret-topics", subsetId],
+    queryFn: () => api.interpretabilityTopicCards(subsetId!),
+    enabled: isLabelled && tab === "interpret",
+  });
+  const interpretBands = useQuery({
+    queryKey: ["interpret-bands", subsetId],
+    queryFn: () => api.interpretabilityBandCards(subsetId!),
+    enabled: isLabelled && tab === "interpret",
+  });
+  const interpretDocs = useQuery({
+    queryKey: ["interpret-docs", subsetId],
+    queryFn: () => api.interpretabilityDocumentCards(subsetId!),
+    enabled: isLabelled && tab === "interpret",
+  });
+
   return (
     <section>
       <header className="flex items-baseline justify-between mb-4 gap-3">
@@ -708,6 +725,7 @@ function ExploreStep({
                   { id: "topics" as const, label: t("pages:workspace.tabs.topics") },
                   { id: "topiclabel" as const, label: t("pages:workspace.tabs.topiclabel") },
                   { id: "routed" as const, label: t("pages:workspace.tabs.routed") },
+                  { id: "interpret" as const, label: t("pages:workspace.tabs.interpret") },
                 ],
               },
               {
@@ -824,6 +842,15 @@ function ExploreStep({
               error={(endmember.error as Error | null) ?? (endmemberEda.error as Error | null)}
               data={endmember.data ?? null}
               eda={endmemberEda.data ?? null}
+            />
+          )}
+          {tab === "interpret" && (
+            <InterpretabilityTab
+              isLoading={interpretTopics.isLoading || interpretBands.isLoading || interpretDocs.isLoading}
+              error={(interpretTopics.error as Error | null) ?? (interpretBands.error as Error | null) ?? (interpretDocs.error as Error | null)}
+              topics={interpretTopics.data ?? null}
+              bands={interpretBands.data ?? null}
+              docs={interpretDocs.data ?? null}
             />
           )}
           {tab === "browser" && (
@@ -5424,6 +5451,247 @@ function UnmixingBestMatchTable({ rows }: { rows: { topic_id: number; endmember_
             })}
           </tbody>
         </table>
+      </div>
+    </div>
+  );
+}
+
+function InterpretabilityTab({
+  isLoading,
+  error,
+  topics,
+  bands,
+  docs,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  topics: import("@/api/client").TopicCardsFile | null;
+  bands: import("@/api/client").BandCardsFile | null;
+  docs: import("@/api/client").DocumentCardsFile | null;
+}) {
+  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading interpretability cards…</p>;
+  if (error) {
+    return (
+      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
+        <p style={{ color: "var(--color-warn)" }}>Could not load interpretability cards.</p>
+        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      {topics ? <InterpretTopicCardsGrid topics={topics} /> : null}
+      {bands ? <InterpretBandImportance bands={bands} /> : null}
+      {docs ? <InterpretDocumentSample docs={docs} K={topics?.K ?? 12} /> : null}
+    </div>
+  );
+}
+
+function InterpretTopicCardsGrid({ topics }: { topics: import("@/api/client").TopicCardsFile }) {
+  return (
+    <div>
+      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
+        Topic cards · K = {topics.K}
+      </h4>
+      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
+        One card per LDA topic. Peak wavelength = argmax of φ<sub>k</sub>; FWHM = full width at half-max
+        (sharpness of the spectral signature). p(label | topic) shows the top-3 classes whose
+        documents land on this topic dominantly.
+      </p>
+      <div className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        {topics.topic_cards.map((c) => {
+          const swatch = TOPIC_COLORS[c.topic_k % TOPIC_COLORS.length];
+          const topP = c.p_label_given_topic_top3?.[0]?.p ?? 0;
+          return (
+            <div
+              key={c.topic_k}
+              className="rounded-lg border p-3 relative overflow-hidden"
+              style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+            >
+              <div className="absolute top-0 left-0 right-0 h-1" aria-hidden style={{ backgroundColor: swatch }} />
+              <div className="flex items-baseline justify-between mt-1 mb-1.5">
+                <div className="flex items-baseline gap-2">
+                  <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: swatch }} />
+                  <span className="text-[13px] font-semibold font-mono" style={{ color: "var(--color-fg)" }}>topic {c.topic_k}</span>
+                </div>
+                <span className="text-[10px] uppercase tracking-widest font-medium" style={{ color: "var(--color-fg-faint)" }}>
+                  λ = {c.peak_wavelength_nm.toFixed(0)} nm
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[11.5px] font-mono mb-2" style={{ color: "var(--color-fg-faint)" }}>
+                <span>peak φ = {c.peak_value.toFixed(3)}</span>
+                <span>fwhm = {c.fwhm_nm.toFixed(0)} nm</span>
+              </div>
+              <div className="text-[10.5px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--color-fg-faint)" }}>
+                Top labels
+              </div>
+              <div className="space-y-1">
+                {c.p_label_given_topic_top3.map((lab) => {
+                  const w = topP > 0 ? Math.max(2, (lab.p / topP) * 100) : 0;
+                  return (
+                    <div key={lab.label_id} className="flex items-baseline gap-2 text-[11.5px]">
+                      <span className="font-mono shrink-0" style={{ color: "var(--color-fg-faint)" }}>
+                        {lab.label_id}
+                      </span>
+                      <span className="truncate" style={{ color: "var(--color-fg)" }} title={lab.name}>
+                        {lab.name}
+                      </span>
+                      <span className="ml-auto font-mono text-[10.5px]" style={{ color: "var(--color-fg-faint)" }}>
+                        {(lab.p * 100).toFixed(1)}%
+                      </span>
+                      <div className="w-[60px] h-1.5 rounded ml-1 shrink-0" style={{ backgroundColor: "var(--color-border)" }}>
+                        <div className="h-1.5 rounded" style={{ width: `${w}%`, backgroundColor: swatch }} />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function InterpretBandImportance({ bands }: { bands: import("@/api/client").BandCardsFile }) {
+  const TOP = 24;
+  const sortedFisher = [...bands.band_cards].sort((a, b) => b.fisher_ratio - a.fisher_ratio).slice(0, TOP);
+  const maxFisher = sortedFisher[0]?.fisher_ratio ?? 1;
+  const sortedMI = [...bands.band_cards].sort((a, b) => b.mutual_info_vs_label - a.mutual_info_vs_label).slice(0, TOP);
+  const maxMI = sortedMI[0]?.mutual_info_vs_label ?? 1;
+
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+    >
+      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
+        Band importance · top {TOP} of {bands.n_bands}
+      </h4>
+      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
+        Fisher ratio (between-class / within-class variance) ranks bands by class separability.
+        Mutual information against label is a non-parametric counterpart. Bands at 1100, 1400 and
+        1900 nm are usually water-absorption features.
+      </p>
+      <div className="grid md:grid-cols-2 gap-5">
+        <BandRankingList
+          title="Fisher ratio"
+          accent="rgba(40, 160, 80, 1)"
+          rows={sortedFisher.map((b) => ({ label: `band ${b.band_index} · ${b.wavelength_nm.toFixed(0)} nm`, value: b.fisher_ratio, max: maxFisher, p_value: b.p_value }))}
+        />
+        <BandRankingList
+          title="Mutual information"
+          accent="rgba(170, 60, 200, 1)"
+          rows={sortedMI.map((b) => ({ label: `band ${b.band_index} · ${b.wavelength_nm.toFixed(0)} nm`, value: b.mutual_info_vs_label, max: maxMI }))}
+        />
+      </div>
+    </div>
+  );
+}
+
+function BandRankingList({
+  title,
+  accent,
+  rows,
+}: {
+  title: string;
+  accent: string;
+  rows: { label: string; value: number; max: number; p_value?: number }[];
+}) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-widest font-semibold mb-1.5" style={{ color: accent }}>
+        {title}
+      </div>
+      <div className="space-y-1">
+        {rows.map((r, i) => {
+          const w = r.max > 0 ? Math.max(2, (r.value / r.max) * 100) : 0;
+          return (
+            <div key={`${title}-${i}`} className="flex items-baseline gap-2 text-[11.5px]">
+              <span className="font-mono w-4 text-right shrink-0" style={{ color: "var(--color-fg-faint)" }}>{i + 1}</span>
+              <span className="font-mono truncate" style={{ color: "var(--color-fg)" }} title={r.label}>
+                {r.label}
+              </span>
+              <span className="ml-auto font-mono text-[10.5px] shrink-0" style={{ color: "var(--color-fg-faint)" }}>
+                {r.value.toFixed(r.value >= 1 ? 2 : 3)}
+                {r.p_value !== undefined ? ` · p=${r.p_value < 0.0001 ? "<1e-4" : r.p_value.toFixed(3)}` : ""}
+              </span>
+              <div className="w-[120px] h-1.5 rounded shrink-0" style={{ backgroundColor: "var(--color-border)" }}>
+                <div className="h-1.5 rounded" style={{ width: `${w}%`, backgroundColor: accent }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function InterpretDocumentSample({ docs, K }: { docs: import("@/api/client").DocumentCardsFile; K: number }) {
+  const [showN, setShowN] = useState(24);
+  const sample = docs.document_cards.slice(0, showN);
+
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+    >
+      <div className="flex items-baseline justify-between gap-3 mb-1 flex-wrap">
+        <h4 className="text-base font-semibold" style={{ color: "var(--color-fg)" }}>
+          Document cards · {showN} of {docs.n_documents}
+        </h4>
+        <div className="flex items-baseline gap-1.5">
+          {[12, 24, 48, docs.n_documents].map((n) => (
+            <button
+              key={`show-${n}`}
+              type="button"
+              onClick={() => setShowN(Math.min(n, docs.n_documents))}
+              className="rounded border px-2 py-0.5 text-[11px] font-mono"
+              style={{
+                borderColor: showN === n ? "var(--color-accent)" : "var(--color-border)",
+                color: showN === n ? "var(--color-accent)" : "var(--color-fg-faint)",
+                backgroundColor: showN === n ? "var(--color-accent-soft)" : "transparent",
+              }}
+            >
+              {n === docs.n_documents ? "all" : n}
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
+        Each row is one document (pixel-as-document). Bar shows θ stacked across K = {K} topics
+        coloured by topic. Right columns = dominant topic and ground-truth label.
+      </p>
+      <div className="space-y-1">
+        {sample.map((doc) => {
+          let acc = 0;
+          return (
+            <div key={doc.doc_id} className="flex items-center gap-2 text-[11px]">
+              <span className="font-mono w-16 shrink-0" style={{ color: "var(--color-fg-faint)" }}>{doc.doc_id}</span>
+              <div className="flex-1 h-3 rounded overflow-hidden flex" style={{ backgroundColor: "var(--color-border)" }}>
+                {doc.theta_full.map((p, k) => {
+                  const w = p * 100;
+                  acc += w;
+                  return (
+                    <span
+                      key={`${doc.doc_id}-${k}`}
+                      style={{ width: `${w}%`, backgroundColor: TOPIC_COLORS[k % TOPIC_COLORS.length] }}
+                      title={`topic ${k}: ${(p * 100).toFixed(1)}%`}
+                    />
+                  );
+                })}
+                {acc < 99.9 ? <span style={{ width: `${100 - acc}%`, backgroundColor: "transparent" }} /> : null}
+              </div>
+              <span className="font-mono text-[10.5px] w-10 text-right shrink-0" style={{ color: "var(--color-fg-faint)" }}>
+                t{doc.topic_k_dominant}
+              </span>
+              <span className="font-mono text-[10.5px] truncate shrink-0 w-32" style={{ color: "var(--color-fg)" }} title={doc.label_name}>
+                {doc.label_name}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
Adds Interpretability tab to Workspace Explore. Topic cards grid + Band importance ranking + Document θ stacks. All from real `/generated/interpretability/{scene}/*.json` artifacts. Closes #266.