### PR TITLE
cycle 76 (visual): Spatial structure tab (closes #278)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -383,6 +383,10 @@ export const api = {
     request<QuantizationSensitivity>(
       `/generated/quantization_sensitivity/${encodeURIComponent(sceneId)}.json`,
     ),
+  felzenszwalbGroupings: (sceneId: string) =>
+    request<FelzenszwalbGroupings>(
+      `/generated/groupings/felzenszwalb/${encodeURIComponent(sceneId)}.json`,
+    ),
   topicAnomaly: (sceneId: string) =>
     request<TopicAnomaly>(
       `/api/topic-anomaly/${encodeURIComponent(sceneId)}`,
@@ -770,6 +774,7 @@ export type TopicSpatialContinuous = {
   scene_id: string;
   topic_count: number;
   spatial_shape: [number, number];
+  n_sampled_pixels?: number;
   per_topic_continuous_spatial: {
     topic_id: number;
     morans_I_continuous?: number;
@@ -840,6 +845,14 @@ export type QuantizationSensitivity = {
   canonical_scheme: string;
   canonical_Q: number;
   probes: QuantizationProbe[];
+};
+
+export type FelzenszwalbGroupings = {
+  n_groups: number;
+  group_size_distribution: { min: number; p25: number; p50: number; p75: number; max: number };
+  between_within_variance_ratio: number;
+  agreement_vs_label: { ari: number; nmi: number; v_measure: number; n_labelled_pixels: number };
+  mean_spectrum_per_group: { group_id: number; size: number; mean: number[] }[];
 };
 
 export type EndmemberBaseline = {

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -191,6 +191,7 @@
       "raster": "Spatial map",
       "embed3d": "Embedding 3D · θ-PCA",
       "repfit": "Representation fit · 3D",
+      "spatial": "Spatial · Moran's I + groupings",
       "stability": "Stability · 7-seed",
       "deep": "Deep latents",
       "anomaly": "Anomaly · vs misclass",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -191,6 +191,7 @@
       "raster": "Mapa espacial",
       "embed3d": "Embedding 3D · θ-PCA",
       "repfit": "Fit de representación · 3D",
+      "spatial": "Espacial · Moran's I + agrupaciones",
       "stability": "Estabilidad · 7-seed",
       "deep": "Deep latents",
       "anomaly": "Anomalía · vs misclass",

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 79";
+export const APP_VERSION = "cycle 76";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -492,6 +492,7 @@ type ExploreTab =
   | "raster"
   | "embed3d"
   | "repfit"
+  | "spatial"
   | "unmixing"
   | "interpret"
   | "anomaly"
@@ -668,6 +669,22 @@ function ExploreStep({
     staleTime: 30 * 60_000,
   });
 
+  const topicSpatial = useQuery({
+    queryKey: ["topic-spatial-cont", subsetId],
+    queryFn: () => api.topicSpatialContinuous(subsetId!),
+    enabled: isLabelled && tab === "spatial",
+  });
+  const groupings = useQuery({
+    queryKey: ["felzenszwalb", subsetId],
+    queryFn: () => api.felzenszwalbGroupings(subsetId!),
+    enabled: isLabelled && tab === "spatial",
+  });
+  const groupingsEda = useQuery({
+    queryKey: ["eda", subsetId, "for-groupings"],
+    queryFn: () => api.edaPerScene(subsetId!),
+    enabled: isLabelled && tab === "spatial",
+  });
+
   return (
     <section>
       <header className="flex items-baseline justify-between mb-4 gap-3">
@@ -773,6 +790,7 @@ function ExploreStep({
                   { id: "raster" as const, label: t("pages:workspace.tabs.raster") },
                   { id: "embed3d" as const, label: t("pages:workspace.tabs.embed3d") },
                   { id: "repfit" as const, label: t("pages:workspace.tabs.repfit") },
+                  { id: "spatial" as const, label: t("pages:workspace.tabs.spatial") },
                 ],
               },
               {
@@ -924,6 +942,15 @@ function ExploreStep({
               error={(quantSens.error as Error | null) ?? (xsTransfer.error as Error | null)}
               quant={quantSens.data ?? null}
               transfer={xsTransfer.data ?? null}
+            />
+          )}
+          {tab === "spatial" && (
+            <SpatialStructureTab
+              isLoading={topicSpatial.isLoading || groupings.isLoading || groupingsEda.isLoading}
+              error={(topicSpatial.error as Error | null) ?? (groupings.error as Error | null)}
+              spatial={topicSpatial.data ?? null}
+              groupings={groupings.data ?? null}
+              eda={groupingsEda.data ?? null}
             />
           )}
           {tab === "browser" && (
@@ -6326,6 +6353,207 @@ function CrossSceneTransferCard({
           Self-transfer F1 = {transfer.transfer_matrix_macro_f1[curIdx]?.[curIdx]?.toFixed(3) ?? "—"}.
         </p>
       ) : null}
+    </div>
+  );
+}
+
+function SpatialStructureTab({
+  isLoading,
+  error,
+  spatial,
+  groupings,
+  eda,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  spatial: import("@/api/client").TopicSpatialContinuous | null;
+  groupings: import("@/api/client").FelzenszwalbGroupings | null;
+  eda: import("@/api/client").ScenePerScene | null;
+}) {
+  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading spatial structure…</p>;
+  if (error) {
+    return (
+      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
+        <p style={{ color: "var(--color-warn)" }}>Could not load spatial data.</p>
+        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      {spatial ? <SpatialAutocorrelationCard spatial={spatial} /> : null}
+      {groupings ? <FelzenszwalbCard groupings={groupings} eda={eda} /> : null}
+    </div>
+  );
+}
+
+function SpatialAutocorrelationCard({ spatial }: { spatial: import("@/api/client").TopicSpatialContinuous }) {
+  const ts = spatial.per_topic_continuous_spatial;
+  const maxI = Math.max(...ts.map((t) => Math.abs(t.morans_I_continuous ?? 0)), 1);
+  const maxC = Math.max(...ts.map((t) => t.gearys_C_continuous ?? 0), 1);
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+    >
+      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
+        Spatial autocorrelation per topic · {spatial.spatial_shape[0]}×{spatial.spatial_shape[1]} grid
+      </h4>
+      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
+        Moran's I {">"} 0 ⇒ topic clusters spatially (high values cluster with high). Geary's C {"<"} 1
+        ⇒ similar. n_sampled_pixels = {spatial.n_sampled_pixels} on the topic-θ mask. Aggregated
+        Moran's I (mean over topics) = {spatial.aggregated_morans_I_mean_over_topics?.toFixed(3) ?? "—"}.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-[12px]" style={{ color: "var(--color-fg)" }}>
+          <thead>
+            <tr style={{ color: "var(--color-fg-faint)" }}>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">topic</th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">Moran's I</th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">Geary's C</th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">mean θ in mask</th>
+              <th className="text-left font-mono text-[11px] pb-1">I bar</th>
+              <th className="text-left font-mono text-[11px] pb-1">C bar</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ts.map((t) => {
+              const I = t.morans_I_continuous ?? 0;
+              const C = t.gearys_C_continuous ?? 0;
+              const m = t.mean_abundance_in_mask ?? 0;
+              return (
+                <tr key={t.topic_id} style={{ borderTop: "1px solid var(--color-border)" }}>
+                  <td className="py-1 pr-3 font-mono">
+                    <span className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle" style={{ backgroundColor: TOPIC_COLORS[(t.topic_id - 1) % TOPIC_COLORS.length] }} />
+                    t{t.topic_id}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">{I.toFixed(3)}</td>
+                  <td className="py-1 pr-3 text-right font-mono">{C.toFixed(3)}</td>
+                  <td className="py-1 pr-3 text-right font-mono">{m.toFixed(3)}</td>
+                  <td className="py-1 w-[110px]">
+                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
+                      <div className="h-2 rounded" style={{ width: `${(Math.abs(I) / maxI) * 100}%`, backgroundColor: I >= 0 ? "rgba(40,160,80,0.85)" : "rgba(214,39,40,0.85)" }} />
+                    </div>
+                  </td>
+                  <td className="py-1 w-[110px]">
+                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
+                      <div className="h-2 rounded" style={{ width: `${(C / maxC) * 100}%`, backgroundColor: "rgba(56,189,248,0.85)" }} />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function FelzenszwalbCard({
+  groupings,
+  eda,
+}: {
+  groupings: import("@/api/client").FelzenszwalbGroupings;
+  eda: import("@/api/client").ScenePerScene | null;
+}) {
+  const palette = ["#0072B2", "#D55E00", "#009E73", "#CC79A7", "#F0E442", "#56B4E9", "#E69F00", "#999999"];
+  const showGroups = groupings.mean_spectrum_per_group.slice(0, 8);
+
+  const W = 720;
+  const H = 240;
+  const pad = { l: 44, r: 16, t: 12, b: 32 };
+  const innerW = W - pad.l - pad.r;
+  const innerH = H - pad.t - pad.b;
+
+  const ys = showGroups.flatMap((g) => g.mean);
+  const yLo = ys.length ? Math.min(...ys) : 0;
+  const yHi = ys.length ? Math.max(...ys) : 1;
+  const span = yHi - yLo || 1;
+  const yMin = yLo - span * 0.05;
+  const yMax = yHi + span * 0.05;
+
+  const wavelengths = eda?.wavelengths_nm ?? [];
+  const xMin = wavelengths[0] ?? 0;
+  const xMax = wavelengths[wavelengths.length - 1] ?? (showGroups[0]?.mean.length ?? 1);
+
+  const xScale = (x: number) => pad.l + ((x - xMin) / Math.max(1e-9, xMax - xMin)) * innerW;
+  const yScale = (y: number) => pad.t + innerH - ((y - yMin) / Math.max(1e-9, yMax - yMin)) * innerH;
+
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+    >
+      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
+        Felzenszwalb groupings · {groupings.n_groups} segments
+      </h4>
+      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
+        Spatial segmentation produces {groupings.n_groups} groups. Between/within variance ratio =
+        {" "}{groupings.between_within_variance_ratio.toFixed(3)} (higher = groups are well-separated
+        compared to their internal scatter). Agreement vs label ARI =
+        {" "}{groupings.agreement_vs_label.ari.toFixed(3)} · NMI =
+        {" "}{groupings.agreement_vs_label.nmi.toFixed(3)} on{" "}
+        {groupings.agreement_vs_label.n_labelled_pixels.toLocaleString()} labelled pixels.
+      </p>
+
+      <div className="grid sm:grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+        <UnmixingStat label="n groups" value={String(groupings.n_groups)} />
+        <UnmixingStat label="size · min / p50 / max" value={`${groupings.group_size_distribution.min} / ${groupings.group_size_distribution.p50} / ${groupings.group_size_distribution.max}`} />
+        <UnmixingStat label="BWVR" value={groupings.between_within_variance_ratio.toFixed(3)} />
+        <UnmixingStat label="ARI vs label" value={groupings.agreement_vs_label.ari.toFixed(3)} />
+        <UnmixingStat label="NMI vs label" value={groupings.agreement_vs_label.nmi.toFixed(3)} />
+      </div>
+
+      <div className="overflow-x-auto">
+        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 900 }}>
+          <line x1={pad.l} y1={pad.t + innerH} x2={pad.l + innerW} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
+          <line x1={pad.l} y1={pad.t} x2={pad.l} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
+          {[0, 0.25, 0.5, 0.75, 1].map((f) => {
+            const wv = xMin + f * (xMax - xMin);
+            const x = pad.l + f * innerW;
+            return (
+              <g key={`xt-${f}`}>
+                <line x1={x} y1={pad.t + innerH} x2={x} y2={pad.t + innerH + 4} stroke="currentColor" opacity={0.4} />
+                <text x={x} y={pad.t + innerH + 16} fontSize="10" textAnchor="middle" fill="currentColor" opacity={0.7} fontFamily="ui-monospace, monospace">
+                  {wavelengths.length > 0 ? `${Math.round(wv)} nm` : Math.round(wv)}
+                </text>
+              </g>
+            );
+          })}
+          {showGroups.map((g, idx) => {
+            const points = g.mean
+              .map((v, i) => {
+                const xv = wavelengths[i] ?? i;
+                return `${xScale(xv).toFixed(2)},${yScale(v).toFixed(2)}`;
+              })
+              .join(" ");
+            return (
+              <polyline
+                key={`g-${g.group_id}`}
+                points={points}
+                fill="none"
+                stroke={palette[idx % palette.length]}
+                strokeWidth={1.4}
+                opacity={0.85}
+              />
+            );
+          })}
+        </svg>
+      </div>
+      <div className="flex flex-wrap gap-1.5 mt-1">
+        {showGroups.map((g, idx) => (
+          <span key={`leg-${g.group_id}`} className="inline-flex items-baseline gap-1 rounded px-1.5 py-0.5 text-[10.5px] font-mono" style={{ backgroundColor: "var(--color-accent-soft)" }}>
+            <span className="inline-block rounded-full w-2 h-2" style={{ backgroundColor: palette[idx % palette.length] }} />
+            group {g.group_id} (n={g.size})
+          </span>
+        ))}
+        {groupings.mean_spectrum_per_group.length > showGroups.length ? (
+          <span className="text-[10.5px] font-mono" style={{ color: "var(--color-fg-faint)" }}>
+            +{groupings.mean_spectrum_per_group.length - showGroups.length} more
+          </span>
+        ) : null}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Adds Spatial tab: Moran's I + Geary's C per topic + Felzenszwalb groupings (n_groups, BWVR, ARI vs label, group mean spectra overlay). Closes #278.