### PR TITLE
cycle 77 (visual): Cross-method agreement + narratives (closes #281)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -387,6 +387,14 @@ export const api = {
     request<FelzenszwalbGroupings>(
       `/generated/groupings/felzenszwalb/${encodeURIComponent(sceneId)}.json`,
     ),
+  crossMethodAgreement: (sceneId: string) =>
+    request<CrossMethodAgreement>(
+      `/generated/cross_method_agreement/${encodeURIComponent(sceneId)}.json`,
+    ),
+  methodNarratives: (sceneId: string) =>
+    request<MethodNarratives>(
+      `/generated/narratives/${encodeURIComponent(sceneId)}.json`,
+    ),
   topicAnomaly: (sceneId: string) =>
     request<TopicAnomaly>(
       `/api/topic-anomaly/${encodeURIComponent(sceneId)}`,
@@ -845,6 +853,28 @@ export type QuantizationSensitivity = {
   canonical_scheme: string;
   canonical_Q: number;
   probes: QuantizationProbe[];
+};
+
+export type CrossMethodAgreement = {
+  scene_id: string;
+  spatial_shape: [number, number];
+  n_compared_pixels: number;
+  method_names: string[];
+  ari_matrix: number[][];
+  nmi_matrix: number[][];
+  v_measure_matrix: number[][];
+};
+
+export type MethodNarrativeEntry = {
+  method: string;
+  captures: Record<string, number | string | null>;
+  separates: string | null;
+  unites: string | null;
+  enables: string | null;
+};
+export type MethodNarratives = {
+  scene_id: string;
+  method_narratives: Record<string, MethodNarrativeEntry>;
 };
 
 export type FelzenszwalbGroupings = {

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -198,6 +198,7 @@
       "llm": "LLM tea leaves",
       "probe": "Linear probe",
       "robust": "Robustness · Q + cross-scene",
+      "agreement": "Method agreement · narratives",
       "unmixing": "Unmixing · endmembers",
       "usgs": "USGS · library v7",
       "metrics": "Reconstruction + MI",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -198,6 +198,7 @@
       "llm": "LLM tea leaves",
       "probe": "Linear probe",
       "robust": "Robustez · Q + cross-scene",
+      "agreement": "Acuerdo entre métodos · narrativas",
       "unmixing": "Unmixing · endmembers",
       "usgs": "USGS · librería v7",
       "metrics": "Reconstrucción + MI",

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 76";
+export const APP_VERSION = "cycle 77";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -499,6 +499,7 @@ type ExploreTab =
   | "llm"
   | "probe"
   | "robust"
+  | "agreement"
   | "stability"
   | "deep"
   | "usgs"
@@ -685,6 +686,17 @@ function ExploreStep({
     enabled: isLabelled && tab === "spatial",
   });
 
+  const crossMethod = useQuery({
+    queryKey: ["cross-method-agreement", subsetId],
+    queryFn: () => api.crossMethodAgreement(subsetId!),
+    enabled: isLabelled && tab === "agreement",
+  });
+  const narratives = useQuery({
+    queryKey: ["narratives", subsetId],
+    queryFn: () => api.methodNarratives(subsetId!),
+    enabled: isLabelled && tab === "agreement",
+  });
+
   return (
     <section>
       <header className="flex items-baseline justify-between mb-4 gap-3">
@@ -803,6 +815,7 @@ function ExploreStep({
                   { id: "llm" as const, label: t("pages:workspace.tabs.llm") },
                   { id: "probe" as const, label: t("pages:workspace.tabs.probe") },
                   { id: "robust" as const, label: t("pages:workspace.tabs.robust") },
+                  { id: "agreement" as const, label: t("pages:workspace.tabs.agreement") },
                   { id: "unmixing" as const, label: t("pages:workspace.tabs.unmixing") },
                   { id: "usgs" as const, label: t("pages:workspace.tabs.usgs") },
                   { id: "metrics" as const, label: t("pages:workspace.tabs.metrics") },
@@ -951,6 +964,14 @@ function ExploreStep({
               spatial={topicSpatial.data ?? null}
               groupings={groupings.data ?? null}
               eda={groupingsEda.data ?? null}
+            />
+          )}
+          {tab === "agreement" && (
+            <CrossMethodAgreementTab
+              isLoading={crossMethod.isLoading || narratives.isLoading}
+              error={(crossMethod.error as Error | null) ?? (narratives.error as Error | null)}
+              agreement={crossMethod.data ?? null}
+              narratives={narratives.data ?? null}
             />
           )}
           {tab === "browser" && (
@@ -6553,6 +6574,205 @@ function FelzenszwalbCard({
             +{groupings.mean_spectrum_per_group.length - showGroups.length} more
           </span>
         ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CrossMethodAgreementTab({
+  isLoading,
+  error,
+  agreement,
+  narratives,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  agreement: import("@/api/client").CrossMethodAgreement | null;
+  narratives: import("@/api/client").MethodNarratives | null;
+}) {
+  const [metric, setMetric] = useState<"ari" | "nmi" | "v_measure">("ari");
+  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading cross-method agreement…</p>;
+  if (error) {
+    return (
+      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
+        <p style={{ color: "var(--color-warn)" }}>Could not load cross-method agreement.</p>
+        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      {agreement ? <AgreementMatrixCard agreement={agreement} metric={metric} setMetric={setMetric} /> : null}
+      {narratives ? <NarrativesGrid narratives={narratives} /> : null}
+    </div>
+  );
+}
+
+function AgreementMatrixCard({
+  agreement,
+  metric,
+  setMetric,
+}: {
+  agreement: import("@/api/client").CrossMethodAgreement;
+  metric: "ari" | "nmi" | "v_measure";
+  setMetric: (m: "ari" | "nmi" | "v_measure") => void;
+}) {
+  const N = agreement.method_names.length;
+  const labelW = 110;
+  const cell = 60;
+  const cellH = 38;
+  const W = labelW + N * cell + 8;
+  const H = labelW + N * cellH + 8;
+  const mat =
+    metric === "ari" ? agreement.ari_matrix
+    : metric === "nmi" ? agreement.nmi_matrix
+    : agreement.v_measure_matrix;
+  const colour = (v: number) => {
+    const t = Math.max(0, Math.min(1, v));
+    const r = Math.round(255 * (1 - t));
+    const g = Math.round(180 * t + 60 * (1 - t));
+    const b = Math.round(60 * t + 60 * (1 - t));
+    return `rgb(${r}, ${g}, ${b})`;
+  };
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+    >
+      <div className="flex items-baseline justify-between gap-3 flex-wrap mb-1">
+        <h4 className="text-base font-semibold" style={{ color: "var(--color-fg)" }}>
+          Cross-method agreement · {N}×{N} {metric.toUpperCase()} matrix
+        </h4>
+        <div className="flex items-baseline gap-1.5">
+          {(["ari", "nmi", "v_measure"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMetric(m)}
+              className="rounded border px-2 py-0.5 text-[11px] font-mono"
+              style={{
+                borderColor: metric === m ? "var(--color-accent)" : "var(--color-border)",
+                color: metric === m ? "var(--color-accent)" : "var(--color-fg-faint)",
+                backgroundColor: metric === m ? "var(--color-accent-soft)" : "transparent",
+              }}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
+        Compares dominant-cluster assignments across {N} segmentation/topic methods on the same{" "}
+        {agreement.n_compared_pixels.toLocaleString()} pixels (grid {agreement.spatial_shape[0]}×{agreement.spatial_shape[1]}). High off-diagonal ⇒ methods agree on partition; low ⇒ they
+        disagree.
+      </p>
+      <div className="overflow-x-auto">
+        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 1080 }}>
+          {agreement.method_names.map((m, j) => (
+            <text
+              key={`c-${m}`}
+              x={labelW + j * cell + cell / 2}
+              y={labelW - 4}
+              fontSize="10"
+              textAnchor="end"
+              transform={`rotate(-30 ${labelW + j * cell + cell / 2} ${labelW - 4})`}
+              fill="currentColor"
+              opacity={0.7}
+              fontFamily="ui-monospace, monospace"
+            >
+              {m}
+            </text>
+          ))}
+          {agreement.method_names.map((m, i) => (
+            <text
+              key={`r-${m}`}
+              x={labelW - 6}
+              y={labelW + i * cellH + cellH / 2 + 4}
+              fontSize="10"
+              textAnchor="end"
+              fill="currentColor"
+              opacity={0.7}
+              fontFamily="ui-monospace, monospace"
+            >
+              {m}
+            </text>
+          ))}
+          {mat.map((row, i) =>
+            row.map((v, j) => (
+              <g key={`${i}-${j}`}>
+                <rect x={labelW + j * cell} y={labelW + i * cellH} width={cell - 1} height={cellH - 1} fill={colour(v)} />
+                <text
+                  x={labelW + j * cell + cell / 2}
+                  y={labelW + i * cellH + cellH / 2 + 2}
+                  fontSize="10.5"
+                  textAnchor="middle"
+                  fill={v > 0.5 ? "white" : "var(--color-fg)"}
+                  fontFamily="ui-monospace, monospace"
+                  fontWeight={i === j ? 600 : 400}
+                >
+                  {v.toFixed(2)}
+                </text>
+              </g>
+            )),
+          )}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function NarrativesGrid({ narratives }: { narratives: import("@/api/client").MethodNarratives }) {
+  const entries = Object.entries(narratives.method_narratives);
+  return (
+    <div>
+      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
+        Method narratives · what each method captures
+      </h4>
+      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
+        Per-method summary of what the segmentation/topic method captures: spectral silhouette
+        (via label-as-cluster), agreement vs label (ARI / NMI / V), spatial Moran's I and max-IoU
+        against topic-dominant. "separates / unites / enables" are reserved for narrative text
+        when populated by the builder.
+      </p>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {entries.map(([method, e]) => {
+          const caps = e.captures || {};
+          const fmt = (v: unknown) =>
+            typeof v === "number" ? (Number.isFinite(v) ? v.toFixed(3) : "—")
+            : v == null ? "—"
+            : String(v);
+          return (
+            <div
+              key={method}
+              className="rounded-lg border p-3"
+              style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
+            >
+              <div className="flex items-baseline justify-between gap-2 mb-1">
+                <span className="text-[13px] font-semibold font-mono" style={{ color: "var(--color-fg)" }}>{method}</span>
+                {typeof caps["ari_vs_label"] === "number" ? (
+                  <span className="text-[10.5px] font-mono px-1.5 py-0.5 rounded" style={{ backgroundColor: "var(--color-accent-soft)", color: "var(--color-accent)" }}>
+                    ARI {fmt(caps["ari_vs_label"])}
+                  </span>
+                ) : null}
+              </div>
+              <div className="space-y-0.5 text-[11.5px] font-mono" style={{ color: "var(--color-fg-faint)" }}>
+                {Object.entries(caps).map(([k, v]) => (
+                  <div key={k} className="flex items-baseline justify-between gap-2">
+                    <span className="truncate" title={k}>{k}</span>
+                    <span style={{ color: "var(--color-fg)" }}>{fmt(v)}</span>
+                  </div>
+                ))}
+              </div>
+              {(e.separates || e.unites || e.enables) ? (
+                <div className="mt-2 space-y-1 text-[11px]" style={{ color: "var(--color-fg)" }}>
+                  {e.separates ? <div><span style={{ color: "var(--color-fg-faint)" }}>separates: </span>{e.separates}</div> : null}
+                  {e.unites ? <div><span style={{ color: "var(--color-fg-faint)" }}>unites: </span>{e.unites}</div> : null}
+                  {e.enables ? <div><span style={{ color: "var(--color-fg-faint)" }}>enables: </span>{e.enables}</div> : null}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
Adds Cross-method agreement tab with 8x8 ARI/NMI/V-measure matrices + per-method narrative cards. Closes #281.