### PR TITLE
cycle 97 (UX): SceneQuickSwitch (closes #335)

### DIFF
--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 96";
+export const APP_VERSION = "cycle 97";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -195,6 +195,7 @@ export default function Workspace() {
             subsetId={state.context.subset}
             rep={state.context.rep}
             onBack={() => send({ type: "BACK" })}
+            onSwitchScene={(s) => send({ type: "SWITCH_SUBSET", subset: s })}
           />
         )}
       </div>
@@ -575,10 +576,12 @@ function ExploreStep({
   subsetId,
   rep,
   onBack,
+  onSwitchScene,
 }: {
   subsetId: string | null;
   rep: string | null;
   onBack: () => void;
+  onSwitchScene: (subset: string) => void;
 }) {
   const { t } = useTranslation(["pages"]);
   const isLabelled = subsetId !== null && LABELLED_SCENES.has(subsetId);
@@ -847,6 +850,10 @@ function ExploreStep({
 
       {isLabelled && (
         <>
+          <SceneQuickSwitch
+            currentScene={subsetId!}
+            onSwitch={(s) => onSwitchScene(s)}
+          />
           <SceneBriefingHero subsetId={subsetId!} rep={rep} />
 
           <nav
@@ -8041,5 +8048,55 @@ function TabFooter({ tab }: { tab: ExploreTab }) {
         report an issue
       </a>
     </footer>
+  );
+}
+
+const LABELLED_SCENE_ORDER: { id: string; short: string }[] = [
+  { id: "indian-pines-corrected", short: "Indian Pines" },
+  { id: "salinas-corrected", short: "Salinas" },
+  { id: "salinas-a-corrected", short: "Salinas-A" },
+  { id: "pavia-university", short: "Pavia U" },
+  { id: "kennedy-space-center", short: "KSC" },
+  { id: "botswana", short: "Botswana" },
+];
+
+function SceneQuickSwitch({
+  currentScene,
+  onSwitch,
+}: {
+  currentScene: string;
+  onSwitch: (s: string) => void;
+}) {
+  return (
+    <div
+      className="rounded-lg border p-2 mb-4 flex items-baseline gap-2 flex-wrap"
+      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}
+    >
+      <span className="text-[10.5px] uppercase tracking-widest font-semibold pr-2" style={{ color: "var(--color-fg-faint)" }}>
+        Quick-switch scene
+      </span>
+      {LABELLED_SCENE_ORDER.map((s) => {
+        const isActive = s.id === currentScene;
+        return (
+          <button
+            key={s.id}
+            type="button"
+            onClick={() => !isActive && onSwitch(s.id)}
+            aria-pressed={isActive}
+            disabled={isActive}
+            className="rounded border px-2.5 py-1 text-[12px] font-mono"
+            style={{
+              borderColor: isActive ? "var(--color-accent)" : "var(--color-border)",
+              color: isActive ? "var(--color-accent)" : "var(--color-fg-subtle)",
+              backgroundColor: isActive ? "var(--color-accent-soft)" : "transparent",
+              cursor: isActive ? "default" : "pointer",
+              fontWeight: isActive ? 600 : 400,
+            }}
+          >
+            {s.short}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/frontend/src/state/workspaceMachine.ts
+++ b/frontend/src/state/workspaceMachine.ts
@@ -27,6 +27,7 @@ export type WorkspaceEvent =
   | { type: "PICK_FAMILY"; family: DatasetFamily }
   | { type: "PICK_SUBSET"; subset: string }
   | { type: "PICK_REP"; rep: RepresentationKind }
+  | { type: "SWITCH_SUBSET"; subset: string }
   | { type: "GO_VIEW"; view: WorkspaceView }
   | { type: "PICK_DOC"; docId: string }
   | { type: "BACK" };
@@ -93,6 +94,9 @@ export const workspaceMachine = setup({
         PICK_DOC: {
           target: "benchmarkFork",
           actions: assign({ docId: ({ event }) => event.docId }),
+        },
+        SWITCH_SUBSET: {
+          actions: assign({ subset: ({ event }) => event.subset }),
         },
         BACK: { target: "pickRep" },
       },


### PR DESCRIPTION
Jump between labelled scenes without re-picking subset/rep. Closes #335.