### PR TITLE
Cycle 104: Step 6 P(topic|label) inverse heatmap toggle

### DIFF
--- a/frontend/src/components/plots/InverseLabelHeatmap.tsx
+++ b/frontend/src/components/plots/InverseLabelHeatmap.tsx
@@ -1,0 +1,159 @@
+import { useMemo } from "react";
+
+type Props = {
+  matrix: number[][];
+  labels: { label_id: number; name: string; color: string }[];
+  topicCount: number;
+  selectedTopic: number | null;
+  onSelectTopic: (k: number) => void;
+};
+
+/**
+ * Inverse heatmap. Rows = labels, columns = topics. Cell color encodes
+ * P(topic | label) on a sequential scale; numeric value shown inside
+ * the cell when ≥ 0.05. Click a column to select that topic.
+ */
+export function InverseLabelHeatmap({
+  matrix,
+  labels,
+  topicCount,
+  selectedTopic,
+  onSelectTopic,
+}: Props) {
+  const labelW = 140;
+  const colW = Math.max(28, Math.floor(640 / Math.max(topicCount, 1)));
+  const rowH = 28;
+  const headerH = 36;
+  const w = labelW + colW * topicCount + 16;
+  const h = headerH + rowH * labels.length + 12;
+
+  const dominantPerRow = useMemo(
+    () =>
+      matrix.map((row) => {
+        let max = -1;
+        let idx = 0;
+        for (let j = 0; j < row.length; j++) {
+          if ((row[j] ?? 0) > max) {
+            max = row[j]!;
+            idx = j;
+          }
+        }
+        return { idx, max };
+      }),
+    [matrix],
+  );
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${w} ${h}`}
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Label versus topic inverse heatmap"
+      style={{ color: "var(--color-fg)" }}
+    >
+      <g
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="11"
+        fill="currentColor"
+      >
+        {/* Column headers (topic ids) */}
+        {Array.from({ length: topicCount }, (_, k) => {
+          const cx = labelW + k * colW + colW / 2;
+          const isSel = selectedTopic === k;
+          return (
+            <g key={`h-${k}`} onClick={() => onSelectTopic(k)} style={{ cursor: "pointer" }}>
+              <text
+                x={cx}
+                y={headerH - 10}
+                textAnchor="middle"
+                fontSize="11"
+                fontFamily="ui-monospace, monospace"
+                fontWeight={isSel ? "700" : "500"}
+                fill={isSel ? "var(--color-accent)" : "currentColor"}
+              >
+                t{k + 1}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Rows */}
+        {matrix.map((row, i) => {
+          const lbl = labels[i];
+          if (!lbl) return null;
+          const dom = dominantPerRow[i]!;
+          return (
+            <g key={`row-${i}`}>
+              {/* Color tag + label name */}
+              <rect
+                x={4}
+                y={headerH + i * rowH + 7}
+                width={6}
+                height={rowH - 14}
+                fill={lbl.color}
+                opacity="0.85"
+                rx="1"
+              />
+              <text
+                x={labelW - 8}
+                y={headerH + i * rowH + rowH / 2 + 3}
+                textAnchor="end"
+                fontSize="11"
+                opacity="0.9"
+              >
+                {lbl.name.length > 22 ? `${lbl.name.slice(0, 21)}…` : lbl.name}
+              </text>
+
+              {/* Cells */}
+              {row.map((p, j) => {
+                const x = labelW + j * colW + 1;
+                const y = headerH + i * rowH + 2;
+                const cw = colW - 2;
+                const ch = rowH - 4;
+                const isDom = j === dom.idx && p > 0;
+                const isSelCol = selectedTopic === j;
+                return (
+                  <g
+                    key={`c-${i}-${j}`}
+                    onClick={() => onSelectTopic(j)}
+                    style={{ cursor: "pointer" }}
+                  >
+                    <rect
+                      x={x}
+                      y={y}
+                      width={cw}
+                      height={ch}
+                      fill="var(--color-accent)"
+                      opacity={Math.max(0.04, p)}
+                      stroke={
+                        isDom
+                          ? "var(--color-fg)"
+                          : isSelCol
+                            ? "var(--color-accent)"
+                            : "none"
+                      }
+                      strokeWidth={isDom || isSelCol ? 1.5 : 0}
+                    />
+                    {p >= 0.05 && (
+                      <text
+                        x={x + cw / 2}
+                        y={y + ch / 2 + 4}
+                        textAnchor="middle"
+                        fontSize="10.5"
+                        fontWeight={isDom ? "700" : "500"}
+                        fill={p > 0.5 ? "#fff" : "currentColor"}
+                      >
+                        {Math.round(p * 100)}
+                      </text>
+                    )}
+                  </g>
+                );
+              })}
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 103";
+export const APP_VERSION = "cycle 104";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -16,6 +16,7 @@ import { SpectralBrowser } from "@/components/plots/SpectralBrowser";
 import { SpectralByClass } from "@/components/plots/SpectralByClass";
 import { StabilityHeatmap } from "@/components/plots/StabilityHeatmap";
 import { TopicLabelHeatmap } from "@/components/plots/TopicLabelHeatmap";
+import { InverseLabelHeatmap } from "@/components/plots/InverseLabelHeatmap";
 import { TopicSpectrum } from "@/components/plots/TopicSpectrum";
 import { workspaceMachine } from "@/state/workspaceMachine";
 import type { DatasetFamily, RepresentationKind } from "@/state/useSelectionStore";
@@ -1650,6 +1651,42 @@ function TopicLabelTab({
   selectedTopic: number | null;
   setSelectedTopic: (k: number | null) => void;
 }) {
+  const [direction, setDirection] = useState<"forward" | "inverse">(
+    "forward",
+  );
+
+  const inverse = useMemo(() => {
+    if (!data) return null;
+    const fwd = data.p_label_given_topic_dominant;
+    const counts = data.docs_per_topic_dominant;
+    const K = fwd.length;
+    const L = fwd[0]?.length ?? 0;
+    if (K === 0 || L === 0) return null;
+    const rows: number[][] = [];
+    const labelMeta: { label_id: number; name: string; color: string }[] = [];
+    for (let l = 0; l < L; l++) {
+      const cell0 = fwd[0]![l]!;
+      labelMeta.push({
+        label_id: cell0.label_id,
+        name: cell0.name,
+        color: cell0.color,
+      });
+      const row = new Array<number>(K).fill(0);
+      let denom = 0;
+      for (let k = 0; k < K; k++) {
+        const p = fwd[k]?.[l]?.p ?? 0;
+        const n = counts[k] ?? 0;
+        const joint = n * p;
+        row[k] = joint;
+        denom += joint;
+      }
+      if (denom > 0) {
+        for (let k = 0; k < K; k++) row[k] = row[k]! / denom;
+      }
+      rows.push(row);
+    }
+    return { matrix: rows, labels: labelMeta, K };
+  }, [data]);
 
   if (isLoading)
     return <p style={{ color: "var(--color-fg-faint)" }}>Loading topic–label matrix…</p>;
@@ -1688,28 +1725,97 @@ function TopicLabelTab({
           boxShadow: "var(--color-shadow)",
         }}
       >
-        <h4
-          className="text-base font-semibold mb-2"
-          style={{ color: "var(--color-fg)" }}
-        >
-          P(label | topic) · dominant assignment
-        </h4>
+        <div className="flex items-start justify-between gap-4 mb-2">
+          <h4
+            className="text-base font-semibold"
+            style={{ color: "var(--color-fg)" }}
+          >
+            {direction === "forward"
+              ? "P(label | topic) · dominant assignment"
+              : "P(topic | label) · dominant assignment"}
+          </h4>
+          <div
+            role="tablist"
+            aria-label="Heatmap direction"
+            className="inline-flex rounded-md border"
+            style={{
+              borderColor: "var(--color-border)",
+              backgroundColor: "var(--color-bg)",
+            }}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={direction === "forward"}
+              onClick={() => setDirection("forward")}
+              className="px-2.5 py-1 text-[12px] rounded-l-md"
+              style={{
+                backgroundColor:
+                  direction === "forward"
+                    ? "var(--color-accent-soft)"
+                    : "transparent",
+                color:
+                  direction === "forward"
+                    ? "var(--color-accent)"
+                    : "var(--color-fg-subtle)",
+              }}
+            >
+              P(label | topic)
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={direction === "inverse"}
+              onClick={() => setDirection("inverse")}
+              className="px-2.5 py-1 text-[12px] rounded-r-md"
+              style={{
+                backgroundColor:
+                  direction === "inverse"
+                    ? "var(--color-accent-soft)"
+                    : "transparent",
+                color:
+                  direction === "inverse"
+                    ? "var(--color-accent)"
+                    : "var(--color-fg-subtle)",
+                borderLeft: "1px solid var(--color-border)",
+              }}
+            >
+              P(topic | label)
+            </button>
+          </div>
+        </div>
         <p
           className="text-sm mb-4"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          Each row is one topic; cells show the fraction of pixels assigned to that
-          topic (by dominant θ) that carry each label. The bordered cell is the
-          dominant per row. Click a row to highlight it and see the detail below.
+          {direction === "forward"
+            ? "Each row is one topic; cells show the fraction of pixels assigned to that topic (by dominant θ) that carry each label. The bordered cell is the dominant per row. Click a row to highlight it and see the detail below."
+            : "Each row is one label; cells show the fraction of pixels carrying that label whose dominant topic is k. Computed as P(t|L) = N_t · P(L|t) / Σ_t' N_t' · P(L|t'). Click a column to select that topic."}
         </p>
         <div className="overflow-x-auto">
-          <TopicLabelHeatmap
-            matrix={matrix}
-            selectedTopic={selectedTopic}
-            onSelectTopic={(k) =>
-              setSelectedTopic(k === selectedTopic ? null : k)
-            }
-          />
+          {direction === "forward" ? (
+            <TopicLabelHeatmap
+              matrix={matrix}
+              selectedTopic={selectedTopic}
+              onSelectTopic={(k) =>
+                setSelectedTopic(k === selectedTopic ? null : k)
+              }
+            />
+          ) : inverse ? (
+            <InverseLabelHeatmap
+              matrix={inverse.matrix}
+              labels={inverse.labels}
+              topicCount={inverse.K}
+              selectedTopic={selectedTopic}
+              onSelectTopic={(k) =>
+                setSelectedTopic(k === selectedTopic ? null : k)
+              }
+            />
+          ) : (
+            <p style={{ color: "var(--color-fg-faint)" }}>
+              No inverse matrix to render.
+            </p>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Forward/inverse direction toggle on the topic-label heatmap. The inverse renders P(topic | label) computed client-side from already-loaded topic_to_data.

Closes #359.

## Test plan
- [x] `pnpm build` succeeds
- [x] vite preview smoke: body 134835 chars, "cycle 104" content match
- [ ] Headless Edge verification after prod deploy