### PR TITLE
Cycle 107: Step 8 K-sweep model-selection explorer (browse-only)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -393,6 +393,8 @@ export const api = {
     request<QuantizationSensitivity>(
       `/generated/quantization_sensitivity/${encodeURIComponent(sceneId)}.json`,
     ),
+  ldaSweep: (sceneId: string) =>
+    request<LdaSweep>(`/api/lda-sweep/${encodeURIComponent(sceneId)}`),
   felzenszwalbGroupings: (sceneId: string) =>
     request<FelzenszwalbGroupings>(
       `/generated/groupings/felzenszwalb/${encodeURIComponent(sceneId)}.json`,
@@ -422,6 +424,35 @@ export type RateDistortionCurvePoint = {
   rmse_test: number;
   rmse_test_normalised?: number;
   perplexity_test?: number;
+};
+
+export type LdaSweepEntry = {
+  K: number;
+  n_seeds: number;
+  perplexity_test_mean: number;
+  perplexity_test_std: number;
+  npmi_mean?: number | null;
+  topic_diversity_mean: number;
+  matched_cosine_mean?: number;
+  matched_cosine_min?: number;
+  per_seed?: {
+    seed: number;
+    perplexity_train: number;
+    perplexity_test: number;
+    npmi: number | null;
+    topic_diversity: number;
+  }[];
+};
+
+export type LdaSweep = {
+  scene_id: string;
+  K_grid: number[];
+  seeds: number[];
+  samples_per_class: number;
+  wordification: string;
+  quantization_scale: number;
+  train_fraction: number;
+  grid: LdaSweepEntry[];
 };
 
 export type RateDistortionCurve = {

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -440,6 +440,7 @@
       "routed": "Routed · ranking",
       "interpret": "Interpretability cards",
       "recipes": "Recipes · V1..V12 · Q",
+      "qkexplore": "K-sweep · model selection",
       "supertopics": "Super-topics · cross-scene",
       "raster": "Spatial map",
       "embed3d": "Embedding 3D · θ-PCA",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -440,6 +440,7 @@
       "routed": "Routed · ranking",
       "interpret": "Cards de interpretabilidad",
       "recipes": "Recetas · V1..V12 · Q",
+      "qkexplore": "Barrido de K · selección",
       "supertopics": "Super-tópicos · cross-scene",
       "raster": "Mapa espacial",
       "embed3d": "Embedding 3D · θ-PCA",

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 106";
+export const APP_VERSION = "cycle 107";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -553,6 +553,7 @@ type ExploreTab =
   | "robust"
   | "agreement"
   | "applydoc"
+  | "qkexplore"
   | "stability"
   | "deep"
   | "usgs"
@@ -633,7 +634,7 @@ function ExploreStep({
         return;
       }
       if (e.key === "[" || e.key === "]") {
-        const order: ExploreTab[] = ["raw", "browser", "topics", "topiclabel", "routed", "interpret", "supertopics", "raster", "embed3d", "repfit", "compare3d", "spatial", "stability", "deep", "anomaly", "neural", "gating", "unmixing", "llm", "probe", "robust", "agreement", "usgs", "metrics"];
+        const order: ExploreTab[] = ["raw", "browser", "topics", "topiclabel", "routed", "interpret", "supertopics", "raster", "embed3d", "repfit", "compare3d", "spatial", "stability", "deep", "anomaly", "neural", "gating", "unmixing", "llm", "probe", "robust", "qkexplore", "agreement", "usgs", "metrics"];
         const idx = order.indexOf(tab);
         if (idx === -1) return;
         const next = e.key === "]" ? (idx + 1) % order.length : (idx - 1 + order.length) % order.length;
@@ -754,6 +755,12 @@ function ExploreStep({
     queryKey: ["wordifications-index"],
     queryFn: () => api.wordificationsIndex(),
     enabled: isLabelled && tab === "recipes",
+    staleTime: 30 * 60_000,
+  });
+  const ldaSweepQ = useQuery({
+    queryKey: ["lda-sweep", subsetId],
+    queryFn: () => api.ldaSweep(subsetId!),
+    enabled: isLabelled && tab === "qkexplore",
     staleTime: 30 * 60_000,
   });
 
@@ -970,6 +977,7 @@ function ExploreStep({
                   { id: "llm" as const, label: t("pages:workspace.tabs.llm") },
                   { id: "probe" as const, label: t("pages:workspace.tabs.probe") },
                   { id: "robust" as const, label: t("pages:workspace.tabs.robust") },
+                  { id: "qkexplore" as const, label: t("pages:workspace.tabs.qkexplore") },
                   { id: "agreement" as const, label: t("pages:workspace.tabs.agreement") },
                   { id: "applydoc" as const, label: t("pages:workspace.tabs.applydoc") },
                   { id: "unmixing" as const, label: t("pages:workspace.tabs.unmixing") },
@@ -1163,6 +1171,13 @@ function ExploreStep({
               error={(quantSens.error as Error | null) ?? (xsTransfer.error as Error | null)}
               quant={quantSens.data ?? null}
               transfer={xsTransfer.data ?? null}
+            />
+          )}
+          {tab === "qkexplore" && (
+            <QKExploreTab
+              isLoading={ldaSweepQ.isLoading}
+              error={ldaSweepQ.error as Error | null}
+              sweep={ldaSweepQ.data ?? null}
             />
           )}
           {tab === "spatial" && (
@@ -8793,6 +8808,7 @@ const TAB_WIKI_PAGE: Record<ExploreTab, string> = {
   agreement: "Multi-Axis-Addendum-B",
   applydoc: "Multi-Axis-Addendum-B",
   recipes: "Corpus-Construction",
+  qkexplore: "Mathematical-Background",
   neural: "Mathematical-Background",
   gating: "Multi-Axis-Addendum-B",
   llm: "Multi-Axis-Addendum-B",
@@ -9566,6 +9582,353 @@ function RecipeDetailCard({ payload }: { payload: import("@/api/client").Wordifi
           </div>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function QKExploreTab({
+  isLoading,
+  error,
+  sweep,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  sweep: import("@/api/client").LdaSweep | null;
+}) {
+  if (isLoading)
+    return <p style={{ color: "var(--color-fg-faint)" }}>Loading K-sweep…</p>;
+  if (error)
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>Could not load lda_sweep.</p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  if (!sweep || sweep.grid.length === 0) return null;
+
+  const Ks = sweep.grid.map((g) => g.K);
+  const perpMean = sweep.grid.map((g) => g.perplexity_test_mean);
+  const perpStd = sweep.grid.map((g) => g.perplexity_test_std);
+  const div = sweep.grid.map((g) => g.topic_diversity_mean);
+  const cos = sweep.grid.map((g) => g.matched_cosine_mean ?? 0);
+  const canonicalK = 12;
+
+  return (
+    <div className="space-y-5">
+      <div
+        className="rounded-lg border p-5"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <h4
+          className="text-base font-semibold mb-2"
+          style={{ color: "var(--color-fg)" }}
+        >
+          K-sweep · LDA model selection
+        </h4>
+        <p
+          className="text-sm mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          Precomputed sweep of K ∈ {`{${sweep.K_grid.join(", ")}}`} on{" "}
+          <span className="font-mono">{sweep.wordification}</span>, Q=
+          {sweep.quantization_scale}, averaged over {sweep.seeds.length} seeds
+          ({Math.round(sweep.train_fraction * 100)}% train split,{" "}
+          {sweep.samples_per_class.toLocaleString()} samples per class). The
+          Workspace currently fits at canonical K={canonicalK}; this tab shows
+          what the model would look like at other K values — live refit is{" "}
+          <em>not</em> supported because each combo would require ~minutes of
+          server compute.
+        </p>
+        <div className="grid lg:grid-cols-3 gap-4">
+          <SweepCurveCard
+            title="Perplexity (test)"
+            subtitle="lower is better; ↓ shows the model captures the held-out word distribution"
+            xs={Ks}
+            ys={perpMean}
+            stds={perpStd}
+            highlightX={canonicalK}
+          />
+          <SweepCurveCard
+            title="Topic diversity"
+            subtitle="fraction of unique top-words across topics; ↓ as K grows = topics overlap more"
+            xs={Ks}
+            ys={div}
+            highlightX={canonicalK}
+          />
+          <SweepCurveCard
+            title="Matched cosine"
+            subtitle="seed-to-seed mean cosine of best-matched topics; ↑ = more stable fit"
+            xs={Ks}
+            ys={cos}
+            highlightX={canonicalK}
+          />
+        </div>
+      </div>
+
+      <div
+        className="rounded-lg border p-5"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <h4
+          className="text-base font-semibold mb-2"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Per-K detail
+        </h4>
+        <table className="w-full text-[12.5px]" style={{ color: "var(--color-fg)" }}>
+          <thead>
+            <tr style={{ color: "var(--color-fg-faint)" }}>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">K</th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                perplexity mean
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                perplexity std
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                topic diversity
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                matched cosine mean
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1">
+                matched cosine min
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sweep.grid.map((g) => {
+              const isCanon = g.K === canonicalK;
+              return (
+                <tr
+                  key={g.K}
+                  style={{
+                    borderTop: "1px solid var(--color-border)",
+                    backgroundColor: isCanon
+                      ? "var(--color-accent-soft)"
+                      : "transparent",
+                  }}
+                >
+                  <td className="py-1 pr-3 font-mono">
+                    K={g.K}
+                    {isCanon ? " ★" : ""}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {g.perplexity_test_mean.toFixed(3)}
+                  </td>
+                  <td
+                    className="py-1 pr-3 text-right font-mono"
+                    style={{ color: "var(--color-fg-faint)" }}
+                  >
+                    ±{g.perplexity_test_std.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {g.topic_diversity_mean.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {g.matched_cosine_mean != null
+                      ? g.matched_cosine_mean.toFixed(3)
+                      : "—"}
+                  </td>
+                  <td className="py-1 text-right font-mono">
+                    {g.matched_cosine_min != null
+                      ? g.matched_cosine_min.toFixed(3)
+                      : "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        <p
+          className="text-[11.5px] mt-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          ★ = canonical K used everywhere else in the Workspace. For Q
+          sensitivity (vocabulary granularity), see the{" "}
+          <span className="font-mono">robust</span> tab.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SweepCurveCard({
+  title,
+  subtitle,
+  xs,
+  ys,
+  stds,
+  highlightX,
+}: {
+  title: string;
+  subtitle: string;
+  xs: number[];
+  ys: number[];
+  stds?: number[];
+  highlightX?: number;
+}) {
+  const W = 240;
+  const H = 130;
+  const PAD = 28;
+  const xMin = Math.min(...xs);
+  const xMax = Math.max(...xs);
+  const yLo = Math.min(...ys.map((y, i) => y - (stds?.[i] ?? 0)));
+  const yHi = Math.max(...ys.map((y, i) => y + (stds?.[i] ?? 0)));
+  const pad = (yHi - yLo) * 0.1 || 0.05;
+  const yMin = yLo - pad;
+  const yMax = yHi + pad;
+  const px = (x: number) =>
+    PAD + ((x - xMin) / (xMax - xMin)) * (W - 2 * PAD);
+  const py = (y: number) =>
+    H - PAD - ((y - yMin) / (yMax - yMin)) * (H - 2 * PAD);
+  const linePts = xs.map((x, i) => `${px(x).toFixed(1)},${py(ys[i]!).toFixed(1)}`).join(" ");
+  const bandPts = stds
+    ? xs
+        .map(
+          (x, i) => `${px(x).toFixed(1)},${py(ys[i]! - stds[i]!).toFixed(1)}`,
+        )
+        .concat(
+          [...xs]
+            .reverse()
+            .map(
+              (x, i) =>
+                `${px(x).toFixed(1)},${py(ys[xs.length - 1 - i]! + stds[xs.length - 1 - i]!).toFixed(1)}`,
+            ),
+        )
+        .join(" ")
+    : null;
+  return (
+    <div
+      className="rounded-md border p-3"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-bg)",
+      }}
+    >
+      <div
+        className="text-[12.5px] font-semibold mb-0.5"
+        style={{ color: "var(--color-fg)" }}
+      >
+        {title}
+      </div>
+      <div
+        className="text-[11px] mb-2 leading-snug"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        {subtitle}
+      </div>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${W} ${H}`}
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-label={title}
+        style={{ color: "var(--color-fg)", display: "block" }}
+      >
+        <line
+          x1={PAD}
+          y1={H - PAD}
+          x2={W - PAD}
+          y2={H - PAD}
+          stroke="var(--color-border)"
+        />
+        <line
+          x1={PAD}
+          y1={PAD}
+          x2={PAD}
+          y2={H - PAD}
+          stroke="var(--color-border)"
+        />
+        {bandPts && (
+          <polygon
+            points={bandPts}
+            fill="var(--color-accent)"
+            opacity="0.18"
+          />
+        )}
+        <polyline
+          points={linePts}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth="1.5"
+        />
+        {xs.map((x, i) => (
+          <circle
+            key={i}
+            cx={px(x)}
+            cy={py(ys[i]!)}
+            r={x === highlightX ? 4 : 2.5}
+            fill="var(--color-accent)"
+            stroke={
+              x === highlightX ? "var(--color-fg)" : "var(--color-accent)"
+            }
+            strokeWidth={x === highlightX ? 1.5 : 0}
+          />
+        ))}
+        {xs.map((x, i) => (
+          <text
+            key={`xl-${i}`}
+            x={px(x)}
+            y={H - PAD + 12}
+            textAnchor="middle"
+            fontSize="10"
+            fontFamily="ui-monospace, monospace"
+            fill="var(--color-fg-faint)"
+          >
+            {x}
+          </text>
+        ))}
+        <text
+          x={PAD - 4}
+          y={py(yMax)}
+          textAnchor="end"
+          fontSize="10"
+          fontFamily="ui-monospace, monospace"
+          fill="var(--color-fg-faint)"
+        >
+          {yMax.toFixed(2)}
+        </text>
+        <text
+          x={PAD - 4}
+          y={py(yMin)}
+          textAnchor="end"
+          fontSize="10"
+          fontFamily="ui-monospace, monospace"
+          fill="var(--color-fg-faint)"
+        >
+          {yMin.toFixed(2)}
+        </text>
+        <text
+          x={W / 2}
+          y={H - 4}
+          textAnchor="middle"
+          fontSize="10"
+          fill="var(--color-fg-faint)"
+        >
+          K
+        </text>
+      </svg>
     </div>
   );
 }


### PR DESCRIPTION
K-sweep over K in {4,6,8,10,12,16} with perplexity / topic_diversity / matched_cosine curves and per-K detail table. Honest framing: live refit not supported, this is browse-only over precomputed sweep results. Closes #368.