### PR TITLE
Cycle 108: smoke harness adds SPA shell + bundle content checks

### DIFF
--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -130,4 +130,67 @@ foreach ($path in $paths) {
     Write-Host "OK $($response.StatusCode) $url"
 }
 
+# ---- SPA shell content checks (cycle 108) -------------------------------
+# Status-code-only checks let an empty/broken React build pass smoke green
+# (lesson from cycle 99-101: xstate matching bug shipped to prod with
+# smoke 84/84). Below we verify the SPA shell is non-trivial AND that its
+# entry chunk contains the canonical version marker baked in by Vite.
+$baseTrimmed = $BaseUrl.TrimEnd('/')
+$rootUrl = "$baseTrimmed/"
+$rootResp = Invoke-WebRequest -UseBasicParsing -Uri $rootUrl
+$rootBody = $rootResp.Content
+$rootLen = $rootBody.Length
+if ($rootLen -lt 500) {
+    throw "SPA shell check failed: body of $rootUrl is only $rootLen chars (<500)"
+}
+if ($rootBody -notmatch '<div id="root"') {
+    throw "SPA shell check failed: body of $rootUrl has no <div id=`"root`">"
+}
+$entryMatch = [regex]::Match($rootBody, '<script[^>]+type="module"[^>]+src="([^"]+)"')
+if (-not $entryMatch.Success) {
+    throw "SPA shell check failed: no <script type=`"module`" src=`"...`"> in $rootUrl"
+}
+$entrySrc = $entryMatch.Groups[1].Value
+if ($entrySrc -match '^https?://') {
+    $entryUrl = $entrySrc
+} elseif ($entrySrc.StartsWith('/')) {
+    $entryUrl = "$baseTrimmed$entrySrc"
+} else {
+    $entryUrl = "$baseTrimmed/$entrySrc"
+}
+$entryResp = Invoke-WebRequest -UseBasicParsing -Uri $entryUrl
+$entryBody = $entryResp.Content
+$entryLen = $entryBody.Length
+if ($entryLen -lt 1000) {
+    throw "SPA bundle check failed: $entryUrl is only $entryLen bytes (<1000)"
+}
+# The version string lives in version.ts and is normally bundled into the
+# main entry chunk. If a future refactor moves it into a lazy chunk, search
+# modulepreload assets too.
+$versionFound = $null
+if ($entryBody -match 'cycle [0-9]+') {
+    $versionFound = "entry"
+} else {
+    $preloadMatches = [regex]::Matches($rootBody, '<link[^>]+rel="modulepreload"[^>]+href="([^"]+)"')
+    foreach ($pm in $preloadMatches) {
+        $preloadSrc = $pm.Groups[1].Value
+        if ($preloadSrc -match '^https?://') {
+            $preloadUrl = $preloadSrc
+        } elseif ($preloadSrc.StartsWith('/')) {
+            $preloadUrl = "$baseTrimmed$preloadSrc"
+        } else {
+            $preloadUrl = "$baseTrimmed/$preloadSrc"
+        }
+        $pResp = Invoke-WebRequest -UseBasicParsing -Uri $preloadUrl
+        if ($pResp.Content -match 'cycle [0-9]+') {
+            $versionFound = "preload:$preloadUrl"
+            break
+        }
+    }
+}
+if (-not $versionFound) {
+    throw "SPA bundle check failed: no `"cycle N`" version marker in entry chunk or modulepreload chunks"
+}
+Write-Host "OK shell $($rootLen)B + entry bundle $($entryLen)B at $entryUrl (version marker in $versionFound)"
+
 Write-Host "Smoke checks passed for $BaseUrl"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -128,4 +128,74 @@ for path in "${paths[@]}"; do
   echo "OK $status $url"
 done
 
+# ---- SPA shell content checks (cycle 108) -------------------------------
+# Status-code-only checks let an empty/broken React build pass smoke green
+# (lesson from cycle 99-101: xstate matching bug shipped to prod with
+# smoke 84/84). Below we verify the SPA shell is non-trivial AND that its
+# entry chunk contains the canonical version marker baked in by Vite.
+root_url="${BASE_URL}/"
+root_body="$(curl -L -s "$root_url")"
+root_len=${#root_body}
+if [[ "$root_len" -lt 500 ]]; then
+  echo "SPA shell check failed: body of $root_url is only $root_len chars (<500)" >&2
+  exit 1
+fi
+if ! grep -q '<div id="root"' <<<"$root_body"; then
+  echo "SPA shell check failed: body of $root_url has no <div id=\"root\">" >&2
+  exit 1
+fi
+entry_src="$(grep -oE '<script[^>]+type="module"[^>]+src="[^"]+"' <<<"$root_body" \
+  | head -1 \
+  | grep -oE 'src="[^"]+"' \
+  | sed -E 's/.*src="([^"]+)".*/\1/')"
+if [[ -z "$entry_src" ]]; then
+  echo "SPA shell check failed: no <script type=\"module\" src=\"...\"> in $root_url" >&2
+  exit 1
+fi
+case "$entry_src" in
+  http://*|https://*)
+    entry_url="$entry_src"
+    ;;
+  /*)
+    entry_url="${BASE_URL}${entry_src}"
+    ;;
+  *)
+    entry_url="${BASE_URL}/${entry_src}"
+    ;;
+esac
+entry_body="$(curl -L -s "$entry_url")"
+entry_len=${#entry_body}
+if [[ "$entry_len" -lt 1000 ]]; then
+  echo "SPA bundle check failed: $entry_url is only $entry_len bytes (<1000)" >&2
+  exit 1
+fi
+# The version string lives in version.ts and is normally bundled into the
+# main entry chunk (because AppFooter imports it). If a future refactor
+# moves it into a lazy chunk, search modulepreload assets too.
+version_found=""
+if grep -qE 'cycle [0-9]+' <<<"$entry_body"; then
+  version_found="entry"
+else
+  preload_srcs="$(grep -oE '<link[^>]+rel="modulepreload"[^>]+href="[^"]+"' <<<"$root_body" \
+    | grep -oE 'href="[^"]+"' \
+    | sed -E 's/.*href="([^"]+)".*/\1/')"
+  while IFS= read -r preload_src; do
+    [[ -z "$preload_src" ]] && continue
+    case "$preload_src" in
+      http://*|https://*) preload_url="$preload_src" ;;
+      /*) preload_url="${BASE_URL}${preload_src}" ;;
+      *) preload_url="${BASE_URL}/${preload_src}" ;;
+    esac
+    if curl -L -s "$preload_url" | grep -qE 'cycle [0-9]+'; then
+      version_found="preload:$preload_url"
+      break
+    fi
+  done <<<"$preload_srcs"
+fi
+if [[ -z "$version_found" ]]; then
+  echo "SPA bundle check failed: no \"cycle N\" version marker in entry chunk or modulepreload chunks" >&2
+  exit 1
+fi
+echo "OK shell ${root_len}B + entry bundle ${entry_len}B at $entry_url (version marker in $version_found)"
+
 echo "Smoke checks passed for $BASE_URL"


### PR DESCRIPTION
Adds shell + entry-chunk content assertions to scripts/smoke.{sh,ps1} so the harness can catch empty-body deploys (cycle 99-101 lesson). Closes #371.