### PR TITLE
Cycle 112: TypeScript types extended for parity with live API + recommended_K marker

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -198,6 +198,24 @@ export type TopWord = {
   relevance: number;
 };
 
+export type TopicPairLogOddsToken = {
+  token: string;
+  log_odds: number;
+  p_in_i: number;
+  p_in_j: number;
+};
+
+export type LdaConfig = {
+  method: string;
+  max_iter: number;
+  doc_topic_prior: number;
+  topic_word_prior: number;
+  random_state: number;
+  wordification: string;
+  quantization_scale: number;
+  samples_per_class: number;
+};
+
 export type TopicViews = {
   scene_id: string;
   scene_name: string;
@@ -209,9 +227,18 @@ export type TopicViews = {
   topic_prevalence: number[];
   topic_band_profiles: number[][];
   topic_distance_cosine: number[][];
+  topic_distance_js?: number[][];
+  topic_distance_hellinger?: number[][];
+  topic_word_jaccard_top15?: number[][];
   topic_intertopic_2d_js: [number, number][];
   topic_intertopic_3d_js: [number, number, number][];
   top_words_per_topic: Record<string, TopWord[][]>;
+  topic_pair_log_odds?: Record<string, TopicPairLogOddsToken[]>;
+  corpus_marginal?: number[];
+  lda_config?: LdaConfig;
+  perplexity?: number;
+  generated_at?: string;
+  builder_version?: string;
 };
 
 export type LabelCell = {
@@ -235,8 +262,25 @@ export type EmbeddingPoint3D = EmbeddingPoint2D & {
   z: number;
 };
 
+export type TopDocumentForTopic = {
+  doc_id: string;
+  theta_k: number;
+  label_id: number;
+  label_name: string;
+  xy: [number, number];
+  theta_full: number[];
+};
+
+export type DominantTopicMapMeta = {
+  format: "binary_uint8";
+  shape: [number, number];
+  sentinel_unlabelled: number;
+  path: string;
+};
+
 export type TopicToData = {
   scene_id: string;
+  scene_name?: string;
   topic_count: number;
   document_count: number;
   spatial_shape: [number, number];
@@ -248,6 +292,10 @@ export type TopicToData = {
   theta_embedding_pca_2d: EmbeddingPoint2D[];
   theta_embedding_pca_3d: EmbeddingPoint3D[];
   theta_embedding_explained_variance: number[];
+  top_documents_per_topic?: TopDocumentForTopic[][];
+  dominant_topic_map?: DominantTopicMapMeta;
+  generated_at?: string;
+  builder_version?: string;
 };
 
 export const api = {
@@ -453,6 +501,10 @@ export type LdaSweep = {
   quantization_scale: number;
   train_fraction: number;
   grid: LdaSweepEntry[];
+  recommended_K?: number;
+  recommendation_method?: string;
+  generated_at?: string;
+  builder_version?: string;
 };
 
 export type RateDistortionCurve = {
@@ -1003,6 +1055,10 @@ export type WordificationPayload = {
   zero_token_doc_rate?: number;
   corpus_marginal_entropy_bits?: number;
   top_tokens_by_count?: WordificationTopToken[];
+  wavelengths_nm_first_last?: [number, number];
+  local_doc_term_path?: string;
+  generated_at?: string;
+  builder_version?: string;
 };
 
 export type EndmemberBaseline = {

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 107";
+export const APP_VERSION = "cycle 112";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -9624,6 +9624,7 @@ function QKExploreTab({
   const div = sweep.grid.map((g) => g.topic_diversity_mean);
   const cos = sweep.grid.map((g) => g.matched_cosine_mean ?? 0);
   const canonicalK = 12;
+  const recommendedK = sweep.recommended_K ?? null;
 
   return (
     <div className="space-y-5">
@@ -9655,6 +9656,35 @@ function QKExploreTab({
           <em>not</em> supported because each combo would require ~minutes of
           server compute.
         </p>
+        {recommendedK !== null && (
+          <div
+            className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 mb-3 text-[12.5px]"
+            style={{
+              borderColor: "var(--color-accent)",
+              backgroundColor: "var(--color-accent-soft)",
+              color: "var(--color-accent)",
+            }}
+          >
+            <span className="font-semibold">Builder recommendation:</span>
+            <span className="font-mono">K={recommendedK}</span>
+            {sweep.recommendation_method && (
+              <span
+                className="font-mono text-[11px]"
+                style={{ color: "var(--color-fg-faint)" }}
+              >
+                ({sweep.recommendation_method})
+              </span>
+            )}
+            {recommendedK !== canonicalK && (
+              <span
+                className="text-[11px] italic"
+                style={{ color: "var(--color-fg-faint)" }}
+              >
+                — differs from canonical K={canonicalK}
+              </span>
+            )}
+          </div>
+        )}
         <div className="grid lg:grid-cols-3 gap-4">
           <SweepCurveCard
             title="Perplexity (test)"
@@ -9719,19 +9749,22 @@ function QKExploreTab({
           <tbody>
             {sweep.grid.map((g) => {
               const isCanon = g.K === canonicalK;
+              const isRec = recommendedK !== null && g.K === recommendedK;
               return (
                 <tr
                   key={g.K}
                   style={{
                     borderTop: "1px solid var(--color-border)",
-                    backgroundColor: isCanon
-                      ? "var(--color-accent-soft)"
-                      : "transparent",
+                    backgroundColor:
+                      isCanon || isRec
+                        ? "var(--color-accent-soft)"
+                        : "transparent",
                   }}
                 >
                   <td className="py-1 pr-3 font-mono">
                     K={g.K}
                     {isCanon ? " ★" : ""}
+                    {isRec && !isCanon ? " ●" : ""}
                   </td>
                   <td className="py-1 pr-3 text-right font-mono">
                     {g.perplexity_test_mean.toFixed(3)}
@@ -9764,7 +9797,11 @@ function QKExploreTab({
           className="text-[11.5px] mt-3"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          ★ = canonical K used everywhere else in the Workspace. For Q
+          ★ = canonical K used everywhere else in the Workspace.{" "}
+          {recommendedK !== null && recommendedK !== canonicalK
+            ? "● = builder-recommended K from sweep aggregation. "
+            : ""}
+          For Q
           sensitivity (vocabulary granularity), see the{" "}
           <span className="font-mono">robust</span> tab.
         </p>


### PR DESCRIPTION
Closes #378. Extends 4 TypeScript types to match the live API JSON shapes (audit §4 of #374). Lights up the qkexplore tab's builder-recommended_K marker as a concrete affordance unlocked by the type changes.