### PR TITLE
Cycle 113: i18n + README harmonisation post c100-108

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,23 @@ every deploy.
 ## Live deployment
 
 - **Public URL**: <https://lda-hsi.fasl-work.com>
-- **Smoke**: 87/87 GET endpoints return 200 in <10 s, run as part of
-  every `deploy/update.sh` (see [`scripts/smoke.sh`](scripts/smoke.sh)
-  and [`scripts/smoke.ps1`](scripts/smoke.ps1))
+- **Smoke**: 109/109 GET endpoints return 200 in <10 s + four SPA
+  shell content assertions added in cycle 108 (body length ≥ 500
+  chars, `<div id="root"`, `<script type="module"`, `cycle N`
+  version marker in entry chunk or any modulepreload chunk). Runs
+  as part of every `deploy/update.sh` (see
+  [`scripts/smoke.sh`](scripts/smoke.sh) and
+  [`scripts/smoke.ps1`](scripts/smoke.ps1)). The content
+  assertions close the empty-body deploy class that escaped in
+  cycles 99-101.
 - **Manifest**: 1592 derived artifacts (1359 JSON + 147 binary +
   27 PNG), audited zero-issues by [`data-pipeline/audit_manifest.py`](data-pipeline/audit_manifest.py)
-- **API surface**: ~104 endpoints across 6 labelled scenes × 17
-  per-scene endpoints + 5 HIDSAG subsets × 6 endpoints + 12 cross-scene
-  endpoints — full catalog at the [Backend Architecture and Payloads](https://github.com/fsantibanezleal/CAOS_LDA_HSI/wiki/Backend-Architecture-and-Payloads)
+- **API surface**: ~110 endpoints across 6 labelled scenes × ~17
+  per-scene endpoints + 5 HIDSAG subsets × 6 endpoints + 12
+  cross-scene endpoints + `/api/wordifications` (108-config
+  corpus index, cycle 102) + `/api/lda-sweep/<scene>` (K-sweep
+  per scene, cycle 107) — full catalog at the
+  [Backend Architecture and Payloads](https://github.com/fsantibanezleal/CAOS_LDA_HSI/wiki/Backend-Architecture-and-Payloads)
   wiki page
 
 ## Architecture at a glance
@@ -80,7 +89,9 @@ every deploy.
                  │              Tailwind v4 + react-i18next +         │
                  │              TanStack Query v5 + Zustand + XState) │
                  │  Pages: Overview · Methodology · Databases ·       │
-                 │         Workspace (11 tabs) · Benchmarks (16 cards)│
+                 │         Workspace (27 tabs in 4 groups:            │
+                 │           Raw / Topic model / Spatial / Diagnostics)│
+                 │         · Benchmarks (16 cards)                    │
                  └──────────────────────┘
 ```
 
@@ -185,6 +196,42 @@ visually and the Bayesian endpoints make decisive:
 7. **GPU acceleration ~50–120× for the deep / neural family**
    (cycle 59). Full `cae_3d_full` K-curve {4, 8, 16, 32} × 6 scenes
    went from ~9–12 h CPU to ~10 min GPU on RTX 4070 Laptop.
+
+### Frontend cycles 100–108 (Step 3-8 closure + smoke hardening)
+
+After the analytical surface stabilised at cycles 51–63, cycles
+100–108 closed every remaining gap in the Workspace 8-step flow
+(`_CAOS_MANAGE/wip/caos-lda-hsi/web-app-spec.md`):
+
+- **c100** — FalseColorBandPicker (Step 4 raw RGB) with 4
+  scientific presets: True colour 660/550/450, Vegetation NIR
+  800/660/550, SWIR mineral 2200/1650/660, Water absorption
+  1400/1900/2200. Renders 8000 stratified samples as SVG.
+- **c101** — ApplyToDocumentTab (Step 7) — closes the spec's
+  *Apply-to-document* step entirely. DocPicker + DocDetailPanel +
+  PerTopicLabelBars; computes per-doc θ vs scene marginal ratio.
+- **c102** — RecipesTab (Step 4 corpus) — V1..V12 × {U, Q, L} ×
+  {8, 16, 32} explorer over `/api/wordifications`. Surfaces D, B,
+  V_full, V_actual, entropy, doc-length distribution, top tokens.
+- **c103** — 2nd-topic compare overlay on Step 5 dominant-topic
+  raster + Pairwise overlap card (|A|, |B|, 4-neighbor adjacency
+  count proxying spatial confusability).
+- **c104** — P(topic|label) inverse heatmap toggle on Step 6.
+  Computes `P(t|L) = N_t·P(L|t) / Σ_t' N_t'·P(L|t')` client-side
+  from already-loaded `topic_to_data`. No new API.
+- **c105** — Topic↔topic similarity graph overlay on Step 6.
+  JS-MDS layout + cosine-similarity edges with threshold slider
+  (0.30 → 0.95, default 0.70) + top-6 most-similar pairs panel.
+- **c106** — Per-recipe V1..V12 SVG schematics in Methodology >
+  Representations. 12 ~130×78 px illustrations + one-line captions.
+- **c107** — K-sweep model-selection explorer (new `qkexplore`
+  tab) over `/api/lda-sweep/<scene>` with K ∈ {4, 6, 8, 10, 12, 16}.
+  Renders perplexity / topic_diversity / matched_cosine curves
+  and the builder-recommended K (★ canonical, ● recommended).
+- **c108** — Smoke harness hardening. Adds SPA shell content
+  assertions (body length, `<div id="root"`, `<script type="module"`,
+  entry-chunk version marker) so empty-body deploys fail smoke
+  instead of being reported green.
 
 ## Quick start
 

--- a/frontend/src/components/methodology/RecipeSchematics.tsx
+++ b/frontend/src/components/methodology/RecipeSchematics.tsx
@@ -537,7 +537,7 @@ const SCHEMATICS: {
   {
     id: "V7",
     title: "V7 absorption-triplet",
-    caption: "Tokens = positions/widths of the strongest absorption valleys.",
+    caption: "Each strongest absorption valley → triplet token (centroid-band bucket, depth bin, area bin).",
     Component: RecipeV7Svg,
   },
   {
@@ -555,7 +555,7 @@ const SCHEMATICS: {
   {
     id: "V10",
     title: "V10 band-group",
-    caption: "Bands are grouped contiguously; per-group statistics become tokens.",
+    caption: "Three coarse spectral regions (VNIR / SWIR-1 / SWIR-2) → one mean-bin token per region.",
     Component: RecipeV10Svg,
   },
   {

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -106,7 +106,7 @@
       "step5_body": "The 21 datasets with their access path, local root and source files.",
       "step6_tag": "Lab",
       "step6_title": "Workspace",
-      "step6_body": "Guided flow family → subset → representation → 11 tabs per labelled scene.",
+      "step6_body": "Guided flow family → subset → representation → 27 tabs per labelled scene, grouped into Raw data · Topic model · Spatial geometry · Diagnostics.",
       "step7_tag": "Eval",
       "step7_title": "Benchmarks",
       "step7_body": "16 cards: multi-axis battery, Bayesian HDI, K-curve, β-collapse, neural-topic head-to-head, …"
@@ -225,7 +225,7 @@
           "Init-sensitive: σ(ARI) ≈ 0.03 across N=5 seeds."
         ],
         "hypothesis": "Amortised encoder should match LDA on ARI and improve c_v thanks to the neural decoder.",
-        "findings": "Wins c_v 6/6 scenes vs LDA and ETM. Loses ARI 4/6 vs LDA (5/6 vs ETM). Confirms the explicit tradeoff: coherence vs discriminability. Operational rule: ProdLDA for interpretability, LDA for clustering."
+        "findings": "Wins c_v 6/6 scenes vs LDA and ETM. Loses ARI 4/6 vs LDA and 6/6 vs ETM under N=5 multi-seed estimation (cycle 63). Confirms the explicit tradeoff: coherence vs discriminability. Operational rule: ProdLDA for interpretability, LDA for clustering."
       },
       "etm": {
         "label": "ETM · Embedded Topic Model",
@@ -237,7 +237,7 @@
           "Better for large vocabularies; HSI has V ≈ 200 bands."
         ],
         "hypothesis": "A shared word embedding should help when there's spectral redundancy (correlated bands).",
-        "findings": "ETM > ProdLDA on ARI 5/6 scenes (ProdLDA wins only on KSC). Coherence c_v in the middle: ProdLDA > ETM > LDA. ETM is the best ARI+c_v compromise."
+        "findings": "ETM > ProdLDA on ARI 6/6 scenes under N=5 multi-seed estimation (cycle 63 — the single-seed ProdLDA-on-KSC win disappears with variance). Coherence c_v in the middle: ProdLDA > ETM > LDA. ETM is the best ARI+c_v compromise."
       },
       "nmf": {
         "label": "NMF · K=8",
@@ -297,7 +297,7 @@
           "Stride 2 between layers progressively reduces the spectral dimension."
         ],
         "hypothesis": "Hyperspectral spectra have band-to-band autocorrelation. CAE-1D should capture local features (edges, peaks) better than PCA/dense AE.",
-        "findings": "Better seed stability (ARI std 15–20% lower than LDA on 5/6 scenes). Silhouette comparable to PCA but with lower σ. Default deep-compression option when stability is the goal."
+        "findings": "Sits mid-ladder in the 9-method seed-stability ranking (below LDA / NMF / CAE-2D, above CAE-3D / dense-AE / β-VAE — see README headline #6). Silhouette comparable to PCA. The 1D conv inductive bias on band-to-band autocorrelation makes it the deep encoder closest to PCA on the ARI / σ tradeoff."
       },
       "cae_2d": {
         "label": "CAE-2D · K=8 (anchor)",
@@ -345,7 +345,7 @@
           "Canonical default here: β = 2."
         ],
         "hypothesis": "A disentangled latent should help interpretability without sacrificing much reconstruction.",
-        "findings": "At β = 2, comparable to CAE-1D on ARI/NMI. K-curve sweep β ∈ {1, 2, 8, 16} shows documented collapse at β ≥ 8 (KL → 0, only the prior remains). β = 2 is the sweet spot."
+        "findings": "At β = 2, comparable to CAE-1D on ARI/NMI. β-sweep over β ∈ {1, 2, 4, 8, 16} (cycle 42 5-β grid) shows documented collapse at β ≥ 8 (KL → 0, only the prior remains). β = 2 is the sweet spot."
       },
       "endmember": {
         "label": "Endmembers · NFINDR + NNLS",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -106,7 +106,7 @@
       "step5_body": "Los 21 datasets con su acceso, raíz local y archivos fuente.",
       "step6_tag": "Lab",
       "step6_title": "Workspace",
-      "step6_body": "Flujo guiado familia → conjunto → representación → 11 tabs por escena etiquetada.",
+      "step6_body": "Flujo guiado familia → conjunto → representación → 27 tabs por escena etiquetada, agrupadas en Datos crudos · Modelo de tópicos · Geometría espacial · Diagnósticos.",
       "step7_tag": "Eval",
       "step7_title": "Benchmarks",
       "step7_body": "16 cards: multi-axis battery, Bayesian HDI, K-curve, β-collapse, neural-topic head-to-head, …"
@@ -225,7 +225,7 @@
           "Sensible a init: σ(ARI) ≈ 0.03 a través de N=5 seeds."
         ],
         "hypothesis": "Encoder amortizado debería igualar LDA en ARI y mejorar c_v gracias al decoder neural.",
-        "findings": "Gana c_v 6/6 escenas vs LDA y ETM. Pierde ARI 4/6 vs LDA (5/6 vs ETM). Confirma tradeoff explícito: coherence vs discriminability. Regla operativa: ProdLDA para interpretabilidad, LDA para clustering."
+        "findings": "Gana c_v 6/6 escenas vs LDA y ETM. Pierde ARI 4/6 vs LDA y 6/6 vs ETM bajo estimación multi-seed N=5 (cycle 63). Confirma tradeoff explícito: coherence vs discriminability. Regla operativa: ProdLDA para interpretabilidad, LDA para clustering."
       },
       "etm": {
         "label": "ETM · Embedded Topic Model",
@@ -237,7 +237,7 @@
           "Mejor para vocabularios grandes; HSI tiene V ≈ 200 bandas."
         ],
         "hypothesis": "Embedding compartido entre palabras debería ayudar cuando hay redundancia espectral (bandas correlacionadas).",
-        "findings": "ETM > ProdLDA en ARI 5/6 escenas (ProdLDA gana sólo en KSC). Coherencia c_v middle: ProdLDA > ETM > LDA. ETM es el mejor compromiso ARI+c_v."
+        "findings": "ETM > ProdLDA en ARI 6/6 escenas bajo estimación multi-seed N=5 (cycle 63 — la única victoria single-seed de ProdLDA en KSC desaparece con la varianza). Coherencia c_v middle: ProdLDA > ETM > LDA. ETM es el mejor compromiso ARI+c_v."
       },
       "nmf": {
         "label": "NMF · K=8",
@@ -297,7 +297,7 @@
           "Stride 2 entre capas reduce dimensión espectral progresivamente."
         ],
         "hypothesis": "El espectro hiperespectral tiene autocorrelación banda-a-banda. CAE-1D debe capturar features locales (bordes, picos) mejor que PCA/AE denso.",
-        "findings": "Mejor estabilidad de seeds (ARI std 15–20% menor que LDA en 5/6 escenas). Silhouette igualada a PCA pero σ menor. Es la opción default de compresión deep cuando se busca estabilidad."
+        "findings": "Se ubica en el medio de la escalera de estabilidad-9-métodos (por debajo de LDA / NMF / CAE-2D, por encima de CAE-3D / dense-AE / β-VAE — ver README finding #6). Silhouette igualada a PCA. El bias inductivo 1D conv sobre autocorrelación banda-banda lo hace el encoder deep más cercano a PCA en el tradeoff ARI / σ."
       },
       "cae_2d": {
         "label": "CAE-2D · K=8 (anchor)",
@@ -345,7 +345,7 @@
           "Default canónico aquí: β = 2."
         ],
         "hypothesis": "Latente desentrelazado debería ayudar interpretabilidad sin sacrificar mucho reconstrucción.",
-        "findings": "A β = 2, comparable a CAE-1D en ARI/NMI. K-curve sweep β ∈ {1, 2, 8, 16} muestra collapse documentado a β ≥ 8 (KL → 0, sólo el prior queda). β = 2 es el sweet spot."
+        "findings": "A β = 2, comparable a CAE-1D en ARI/NMI. β-sweep sobre β ∈ {1, 2, 4, 8, 16} (cycle 42, 5-β grid) muestra collapse documentado a β ≥ 8 (KL → 0, sólo el prior queda). β = 2 es el sweet spot."
       },
       "endmember": {
         "label": "Endmembers · NFINDR + NNLS",

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 112";
+export const APP_VERSION = "cycle 113";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -889,7 +889,7 @@ function ExploreStep({
             className="text-sm mt-1"
             style={{ color: "var(--color-fg-faint)" }}
           >
-            16 panels across raw data, topic model output, spatial geometry, and diagnostics.
+            27 panels across raw data, topic model output, spatial geometry, and diagnostics.
             Loaded on demand — pick a tab below to fetch its dedicated backend artefact.
           </p>
         </div>
@@ -5338,7 +5338,7 @@ function FamilyPickerStep({
 /* =========================================================================
    Scene briefing hero — appears at top of Workspace when a labelled scene
    is loaded. Shows quick stats + class palette + topic count + spectral
-   envelope mini-viz for at-a-glance scene context across all 11 tabs.
+   envelope mini-viz for at-a-glance scene context across all 27 tabs.
    =======================================================================*/
 
 function SceneBriefingHero({ subsetId, rep }: { subsetId: string; rep: string | null }) {


### PR DESCRIPTION
Closes #381. Eight P0 copy mismatches fixed across en/es pages.json, Workspace.tsx in-place copy, RecipeSchematics V7/V10 captions, and README (smoke count, API surface, tab count, new Frontend c100-108 section).