### PR TITLE
Cycle 114: Builder docstring drift fixes (no runtime change)

### DIFF
--- a/data-pipeline/build_lda_sweep.py
+++ b/data-pipeline/build_lda_sweep.py
@@ -10,8 +10,12 @@ seeds in {0, 1, 2, 3, 4} and compute:
 
 Output: data/derived/lda_sweep/<scene>.json
 
-Picks a recommended K per scene as the K that maximises (-perplexity_norm
-+ NPMI + matched_cosine_mean) / 3.
+Picks a recommended K per scene as the K that maximises the unweighted
+sum (-perplexity_test_norm + npmi_mean + matched_cosine_mean), where
+perplexity_test_norm is the test-set perplexity rescaled to [0, 1]
+across the K_grid before negation. The recommendation_method string in
+the JSON output records this formula verbatim so the UI can display it
+without recomputing.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_topic_to_data.py
+++ b/data-pipeline/build_topic_to_data.py
@@ -14,8 +14,15 @@ Each output answers, for every topic k:
 - top_documents_per_topic[k]: the top-N documents by theta_k with their
   spatial coordinates, label, and theta vector
 - dominant_topic_map: H x W array assigning each labelled pixel the
-  argmax of its theta (-1 for unlabelled or non-sampled pixels). Stored
-  as a binary uint8 sidecar in local/.
+  argmax of its theta (sentinel value 255 for unlabelled or non-sampled
+  pixels). The JSON ships a metadata stub
+  {format, shape, sentinel_unlabelled, path}; the actual uint8 data is
+  written to two locations:
+  - `data/local/topic_to_data/<scene>_dominant_topic_map.bin` (legacy
+    path, kept for backward compatibility)
+  - `data/derived/topic_to_data/<scene>_dominant_topic_map.bin`
+    (canonical path served by the FastAPI app and consumed by the
+    frontend RasterTab at `/generated/topic_to_data/<scene>_dominant_topic_map.bin`)
 
 This is the single most-asked-for analysis in the master plan and the
 audit's #4 gap. It replaces the previous class_topic_loadings (which

--- a/data-pipeline/build_topic_views.py
+++ b/data-pipeline/build_topic_views.py
@@ -18,7 +18,8 @@ The derived JSON contains:
   relevance(lambda) = lambda * log P(w|k) + (1 - lambda) * log lift
   with lift = P(w|k) / P_global(w) using the *real* corpus marginal
 - topic_distance_matrices: cosine on phi, Jensen-Shannon on phi,
-  Hellinger on phi, Jaccard on top-30 words
+  Hellinger on phi, Jaccard on top-15 words (`topic_word_jaccard_top15`
+  in the JSON; not top-30 as an older revision of this docstring stated)
 - topic_intertopic_2d_js, topic_intertopic_3d_js: classical MDS on the
   Jensen-Shannon distance matrix (LDAvis-faithful 2D + the 3D the user
   asked for)

--- a/data-pipeline/build_wordifications.py
+++ b/data-pipeline/build_wordifications.py
@@ -26,8 +26,23 @@ For each (recipe, quant_scheme, Q, scene) the builder writes:
     vocab.json        token list, recipe metadata, sampling info
 
   data/derived/wordifications/<scene>_<recipe>_<scheme>_Q<q>.json
-    small summary: D, V_actual, doc-length quartiles, zero-token-doc rate,
-    top-N tokens by global frequency, corpus_marginal entropy bits
+    small summary with these keys:
+    - scene_id, recipe, scheme, Q             identification
+    - B, D, V_full, V_actual                  corpus dimensions
+    - doc_length_distribution: mean / std / min / p25 / p50 / p75 / max
+    - zero_token_doc_rate                     fraction of documents whose
+                                              tokenisation produced zero
+                                              non-stopword tokens (rare,
+                                              flag for degenerate combos)
+    - corpus_marginal_entropy_bits            Shannon entropy of the global
+                                              token distribution; vocabulary
+                                              sparsity diagnostic
+    - top_tokens_by_count: list of {token, count, p_global}
+    - wavelengths_nm_first_last               [first, last] wavelength so the
+                                              UI can label the spectral axis
+                                              without re-fetching the full grid
+    - local_doc_term_path                     pointer to the .npz local sidecar
+    - generated_at, builder_version           provenance
 
 Quantization schemes (per_spectrum domain — each spectrum is normalised
 into [0, 1] then binned with Q breakpoints):


### PR DESCRIPTION
Closes #384. Four docstring corrections in data-pipeline/ builders: jaccard top-15 (not 30), dominant_topic_map dual-write paths + sentinel 255 (not -1), full wordifications JSON key list, lda_sweep recommendation formula. No runtime behaviour change.