### PR TITLE
Cycles 132+133: two-tier tab nav + extract Workspace helpers to modules

### DIFF
--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -2,7 +2,7 @@ declare const __APP_BUILD_TIME__: string;
 declare const __APP_COMMIT_SHA__: string;
 declare const __APP_BRANCH__: string;
 
-export const APP_VERSION = "cycle 131";
+export const APP_VERSION = "cycle 133";
 
 export const APP_BUILD_TIME: string =
   typeof __APP_BUILD_TIME__ !== "undefined" ? __APP_BUILD_TIME__ : "dev";

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -23,6 +23,20 @@ import { workspaceMachine } from "@/state/workspaceMachine";
 import type { DatasetFamily, RepresentationKind } from "@/state/useSelectionStore";
 import { cn } from "@/lib/cn";
 
+// Workspace tab registry + per-phase grouping + per-tab wiki map
+// (cycle 133 modularisation of what used to be inlined in this file).
+import {
+  type ExploreTab,
+  EXPLORE_TAB_ORDER,
+  TAB_WIKI_PAGE,
+  WIKI_BASE,
+} from "./workspace/state/tabs";
+import { ExploreNav } from "./workspace/components/ExploreNav";
+import {
+  type RoutedPrediction,
+  computeRoutedPrediction,
+} from "./workspace/helpers/routedPrediction";
+
 const Scatter3D = lazy(() =>
   import("@/components/plots/Scatter3D").then((m) => ({ default: m.Scatter3D })),
 );
@@ -530,35 +544,9 @@ function RepresentationPickerStep({
   );
 }
 
-type ExploreTab =
-  | "raw"
-  | "browser"
-  | "topics"
-  | "topiclabel"
-  | "routed"
-  | "raster"
-  | "embed3d"
-  | "repfit"
-  | "compare3d"
-  | "spatial"
-  | "unmixing"
-  | "interpret"
-  | "recipes"
-  | "supertopics"
-  | "anomaly"
-  | "neural"
-  | "gating"
-  | "llm"
-  | "probe"
-  | "robust"
-  | "agreement"
-  | "applydoc"
-  | "qkexplore"
-  | "bandmask"
-  | "stability"
-  | "deep"
-  | "usgs"
-  | "metrics";
+// ExploreTab + EXPLORE_TAB_ORDER + EXPLORE_PHASES + TAB_WIKI_PAGE +
+// WIKI_BASE moved to ./workspace/state/tabs.ts (cycle 133). Imported
+// at the top of this file.
 
 const TOPIC_FAMILY_REPS = new Set(["lda", "lda_sparse", "lda_tomo", "hdp", "ctm", "prodlda"]);
 const REPRESENTATION_ENDPOINT_METHOD: Record<string, string> = {
@@ -635,7 +623,7 @@ function ExploreStep({
         return;
       }
       if (e.key === "[" || e.key === "]") {
-        const order: ExploreTab[] = ["raw", "browser", "topics", "topiclabel", "routed", "interpret", "supertopics", "raster", "embed3d", "repfit", "compare3d", "spatial", "stability", "deep", "anomaly", "neural", "gating", "unmixing", "llm", "probe", "robust", "qkexplore", "bandmask", "agreement", "usgs", "metrics"];
+        const order = EXPLORE_TAB_ORDER;
         const idx = order.indexOf(tab);
         if (idx === -1) return;
         const next = e.key === "]" ? (idx + 1) % order.length : (idx - 1 + order.length) % order.length;
@@ -940,94 +928,7 @@ function ExploreStep({
               backdropFilter: "blur(8px)",
             }}
           >
-            {([
-              {
-                category: t("pages:workspace.tabs.group_raw"),
-                color: "rgba(56, 189, 248, 1)",
-                tabs: [
-                  { id: "raw" as const, label: t("pages:workspace.tabs.raw") },
-                  { id: "browser" as const, label: t("pages:workspace.tabs.browser") },
-                ],
-              },
-              {
-                category: t("pages:workspace.tabs.group_topics"),
-                color: "rgba(40, 160, 80, 1)",
-                tabs: [
-                  { id: "topics" as const, label: t("pages:workspace.tabs.topics") },
-                  { id: "topiclabel" as const, label: t("pages:workspace.tabs.topiclabel") },
-                  { id: "routed" as const, label: t("pages:workspace.tabs.routed") },
-                  { id: "interpret" as const, label: t("pages:workspace.tabs.interpret") },
-                  { id: "recipes" as const, label: t("pages:workspace.tabs.recipes") },
-                  { id: "supertopics" as const, label: t("pages:workspace.tabs.supertopics") },
-                ],
-              },
-              {
-                category: t("pages:workspace.tabs.group_spatial"),
-                color: "rgba(170, 60, 200, 1)",
-                tabs: [
-                  { id: "raster" as const, label: t("pages:workspace.tabs.raster") },
-                  { id: "embed3d" as const, label: t("pages:workspace.tabs.embed3d") },
-                  { id: "repfit" as const, label: t("pages:workspace.tabs.repfit") },
-                  { id: "compare3d" as const, label: t("pages:workspace.tabs.compare3d") },
-                  { id: "spatial" as const, label: t("pages:workspace.tabs.spatial") },
-                ],
-              },
-              {
-                category: t("pages:workspace.tabs.group_diagnostics"),
-                color: "rgba(214, 140, 40, 1)",
-                tabs: [
-                  { id: "stability" as const, label: t("pages:workspace.tabs.stability") },
-                  { id: "deep" as const, label: t("pages:workspace.tabs.deep") },
-                  { id: "anomaly" as const, label: t("pages:workspace.tabs.anomaly") },
-                  { id: "neural" as const, label: t("pages:workspace.tabs.neural") },
-                  { id: "gating" as const, label: t("pages:workspace.tabs.gating") },
-                  { id: "llm" as const, label: t("pages:workspace.tabs.llm") },
-                  { id: "probe" as const, label: t("pages:workspace.tabs.probe") },
-                  { id: "robust" as const, label: t("pages:workspace.tabs.robust") },
-                  { id: "qkexplore" as const, label: t("pages:workspace.tabs.qkexplore") },
-                  { id: "bandmask" as const, label: t("pages:workspace.tabs.bandmask") },
-                  { id: "agreement" as const, label: t("pages:workspace.tabs.agreement") },
-                  { id: "applydoc" as const, label: t("pages:workspace.tabs.applydoc") },
-                  { id: "unmixing" as const, label: t("pages:workspace.tabs.unmixing") },
-                  { id: "usgs" as const, label: t("pages:workspace.tabs.usgs") },
-                  { id: "metrics" as const, label: t("pages:workspace.tabs.metrics") },
-                ],
-              },
-            ] as { category: string; color: string; tabs: { id: ExploreTab; label: string }[] }[]).map((group) => (
-              <div key={group.category} className="flex items-baseline flex-wrap gap-2">
-                <span
-                  className="text-[10px] uppercase tracking-widest font-semibold pr-2 w-32 shrink-0"
-                  style={{ color: group.color }}
-                >
-                  {group.category}
-                </span>
-                <div className="flex flex-wrap gap-1.5">
-                  {group.tabs.map((opt) => {
-                    const isActive = tab === opt.id;
-                    return (
-                      <button
-                        key={opt.id}
-                        role="tab"
-                        aria-selected={isActive}
-                        type="button"
-                        onClick={() => setTab(opt.id)}
-                        className={cn(
-                          "rounded-md border px-3 py-1.5 text-[13px] transition-all",
-                          isActive ? "font-semibold shadow-sm" : "opacity-80 hover:opacity-100",
-                        )}
-                        style={{
-                          borderColor: isActive ? group.color : "var(--color-border)",
-                          backgroundColor: isActive ? "var(--color-accent-soft)" : "var(--color-panel)",
-                          color: isActive ? group.color : "var(--color-fg)",
-                        }}
-                      >
-                        {opt.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
+            <ExploreNav tab={tab} setTab={setTab} t={t} />
           </nav>
 
           {selectedTopic !== null && (
@@ -3433,43 +3334,9 @@ function RasterTab({
   );
 }
 
-type RoutedPrediction = {
-  label_id: number;
-  name: string;
-  color: string;
-  p: number;
-};
-
-function computeRoutedPrediction(
-  thetaFull: number[],
-  perTopicLabel: import("@/api/client").LabelCell[][],
-): RoutedPrediction[] {
-  const K = thetaFull.length;
-  if (K === 0 || perTopicLabel.length === 0) return [];
-  const firstRow = perTopicLabel[0]!;
-  const L = firstRow.length;
-  if (L === 0) return [];
-  const acc: { p: number; label_id: number; name: string; color: string }[] =
-    firstRow.map((c) => ({
-      p: 0,
-      label_id: c.label_id,
-      name: c.name,
-      color: c.color,
-    }));
-  for (let k = 0; k < K; k++) {
-    const t = thetaFull[k] ?? 0;
-    if (t <= 0) continue;
-    const row = perTopicLabel[k];
-    if (!row) continue;
-    for (let l = 0; l < L; l++) {
-      acc[l]!.p += t * (row[l]?.p ?? 0);
-    }
-  }
-  let total = 0;
-  for (const a of acc) total += a.p;
-  if (total > 0) for (const a of acc) a.p = a.p / total;
-  return acc;
-}
+// RoutedPrediction + computeRoutedPrediction moved to
+// ./workspace/helpers/routedPrediction.ts (cycle 133). Re-export the
+// type name as an alias so the existing usages here compile unchanged.
 
 function TopDocumentsPreview({
   topic,
@@ -9794,6 +9661,7 @@ const TOPIC_AWARE_TABS: { id: ExploreTab; label: string }[] = [
   { id: "spatial", label: "Spatial" },
 ];
 
+
 function TopicContextStrip({
   selectedTopic,
   onClear,
@@ -9866,39 +9734,6 @@ function TopicContextStrip({
     </div>
   );
 }
-
-const TAB_WIKI_PAGE: Record<ExploreTab, string> = {
-  raw: "Web-App-Workflow",
-  browser: "Web-App-Workflow",
-  topics: "Mathematical-Background",
-  topiclabel: "Mathematical-Background",
-  routed: "Multi-Axis-Addendum-B",
-  raster: "Backend-Architecture",
-  embed3d: "Backend-Architecture",
-  repfit: "Multi-Axis-Addendum-B",
-  compare3d: "Multi-Axis-Addendum-B",
-  interpret: "Mathematical-Background",
-  supertopics: "Corpus-Construction",
-  unmixing: "Multi-Axis-Addendum-B",
-  spatial: "Multi-Axis-Addendum-B",
-  agreement: "Multi-Axis-Addendum-B",
-  applydoc: "Multi-Axis-Addendum-B",
-  recipes: "Corpus-Construction",
-  qkexplore: "Mathematical-Background",
-  bandmask: "Mathematical-Background",
-  neural: "Mathematical-Background",
-  gating: "Multi-Axis-Addendum-B",
-  llm: "Multi-Axis-Addendum-B",
-  probe: "Multi-Axis-Addendum-B",
-  robust: "Multi-Axis-Addendum-B",
-  stability: "Multi-Axis-Addendum-B",
-  deep: "Mathematical-Background",
-  anomaly: "Multi-Axis-Addendum-B",
-  usgs: "Corpus-Construction",
-  metrics: "Bayesian-Method-Comparison",
-};
-
-const WIKI_BASE = "https://github.com/fsantibanezleal/CAOS_LDA_HSI/wiki";
 
 function TabFooter({ tab }: { tab: ExploreTab }) {
   const wikiPage = TAB_WIKI_PAGE[tab];

--- a/frontend/src/pages/workspace/components/ExploreNav.tsx
+++ b/frontend/src/pages/workspace/components/ExploreNav.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import type { TFunction } from "i18next";
+
+import { cn } from "@/lib/cn";
+
+import type { ExplorePhase, ExploreTab } from "../state/tabs";
+import { EXPLORE_PHASES, findPhaseFor } from "../state/tabs";
+
+/**
+ * Two-tier tab navigation for the Workspace Explore step (cycle 132).
+ *
+ * Replaces the cycle-14 wall of 4 rows × N buttons (28 tabs visible at
+ * once) with:
+ *   1. A primary row of 6 narrative "phases" (Data → Topics → Geometry
+ *      → Drilldown → Manipulate → Stability), each shown as a chip with
+ *      its tab count.
+ *   2. A secondary row of tabs scoped to the active phase.
+ *
+ * The phase containing the currently-active tab auto-opens on URL load
+ * and re-syncs whenever the tab changes externally (SceneQuickSwitch,
+ * `[` / `]` keyboard shortcuts).
+ */
+export function ExploreNav({
+  tab,
+  setTab,
+  t,
+}: {
+  tab: ExploreTab;
+  setTab: (id: ExploreTab) => void;
+  t: TFunction<["pages"]>;
+}) {
+  const currentPhase = findPhaseFor(tab);
+  const [activePhaseId, setActivePhaseId] = useState<ExplorePhase["id"]>(
+    currentPhase.id,
+  );
+  useEffect(() => {
+    setActivePhaseId(findPhaseFor(tab).id);
+  }, [tab]);
+  const activePhase =
+    EXPLORE_PHASES.find((p) => p.id === activePhaseId) ?? currentPhase;
+  return (
+    <div className="space-y-2.5">
+      <div
+        role="tablist"
+        aria-label="Workspace phase"
+        className="flex flex-wrap gap-1.5"
+      >
+        {EXPLORE_PHASES.map((phase) => {
+          const isActive = phase.id === activePhaseId;
+          const isContainingCurrent = phase.id === currentPhase.id;
+          return (
+            <button
+              key={phase.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-label={`${phase.label} (${phase.tabs.length} tabs)`}
+              onClick={() => setActivePhaseId(phase.id)}
+              title={phase.description}
+              className={cn(
+                "rounded-md border px-3.5 py-2 text-[13px] font-semibold transition-all inline-flex items-center gap-2",
+                isActive ? "shadow-sm" : "opacity-70 hover:opacity-100",
+              )}
+              style={{
+                borderColor: isActive ? phase.color : "var(--color-border)",
+                backgroundColor: isActive
+                  ? "var(--color-accent-soft)"
+                  : "var(--color-panel)",
+                color: isActive ? phase.color : "var(--color-fg)",
+              }}
+            >
+              <span>{phase.label}</span>
+              <span
+                className="font-mono text-[10.5px] rounded-full px-1.5 py-0.5"
+                style={{
+                  backgroundColor: isActive
+                    ? phase.color
+                    : "var(--color-bg)",
+                  color: isActive ? "#fff" : "var(--color-fg-faint)",
+                  border: isActive ? "none" : "1px solid var(--color-border)",
+                }}
+              >
+                {phase.tabs.length}
+              </span>
+              {isContainingCurrent && !isActive && (
+                <span
+                  aria-hidden
+                  className="inline-block w-1.5 h-1.5 rounded-full"
+                  style={{ backgroundColor: phase.color }}
+                  title="contains the active tab"
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <p
+        className="text-[11.5px] italic"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        {activePhase.description}
+      </p>
+      <div
+        role="tablist"
+        aria-label={`${activePhase.label} panels`}
+        className="flex flex-wrap gap-1.5"
+      >
+        {activePhase.tabs.map((opt) => {
+          const isActive = tab === opt.id;
+          const label = t(
+            `pages:workspace.tabs.${opt.labelKey}` as never,
+          ) as string;
+          return (
+            <button
+              key={opt.id}
+              role="tab"
+              aria-selected={isActive}
+              type="button"
+              onClick={() => setTab(opt.id)}
+              className={cn(
+                "rounded-md border px-3 py-1.5 text-[13px] transition-all",
+                isActive
+                  ? "font-semibold shadow-sm"
+                  : "opacity-80 hover:opacity-100",
+              )}
+              style={{
+                borderColor: isActive
+                  ? activePhase.color
+                  : "var(--color-border)",
+                backgroundColor: isActive
+                  ? "var(--color-accent-soft)"
+                  : "var(--color-panel)",
+                color: isActive ? activePhase.color : "var(--color-fg)",
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/workspace/helpers/routedPrediction.ts
+++ b/frontend/src/pages/workspace/helpers/routedPrediction.ts
@@ -1,0 +1,51 @@
+import type { LabelCell } from "@/api/client";
+
+export type RoutedPrediction = {
+  label_id: number;
+  name: string;
+  color: string;
+  p: number;
+};
+
+/**
+ * Topic-routed-soft prediction per document (cycles 120 / 122).
+ *
+ *   P(L = l | d) = Σ_k  θ_d[k] · P(L = l | topic = k)
+ *
+ * Computed client-side from already-loaded `topic_to_data` fields:
+ *   - `thetaFull[K]` — the document's posterior simplex
+ *   - `perTopicLabel[K][L]` — per-topic empirical P(L | topic) from the
+ *     canonical dominant-topic assignment (`p_label_given_topic_dominant`)
+ *
+ * Renormalises the result so the rendered top-K probabilities present
+ * as clean percentages even when some labels have all-zero rows.
+ */
+export function computeRoutedPrediction(
+  thetaFull: number[],
+  perTopicLabel: LabelCell[][],
+): RoutedPrediction[] {
+  const K = thetaFull.length;
+  if (K === 0 || perTopicLabel.length === 0) return [];
+  const firstRow = perTopicLabel[0]!;
+  const L = firstRow.length;
+  if (L === 0) return [];
+  const acc: RoutedPrediction[] = firstRow.map((c) => ({
+    p: 0,
+    label_id: c.label_id,
+    name: c.name,
+    color: c.color,
+  }));
+  for (let k = 0; k < K; k++) {
+    const t = thetaFull[k] ?? 0;
+    if (t <= 0) continue;
+    const row = perTopicLabel[k];
+    if (!row) continue;
+    for (let l = 0; l < L; l++) {
+      acc[l]!.p += t * (row[l]?.p ?? 0);
+    }
+  }
+  let total = 0;
+  for (const a of acc) total += a.p;
+  if (total > 0) for (const a of acc) a.p = a.p / total;
+  return acc;
+}

--- a/frontend/src/pages/workspace/state/tabs.ts
+++ b/frontend/src/pages/workspace/state/tabs.ts
@@ -1,0 +1,210 @@
+/**
+ * Single source of truth for Workspace ExploreTab ids, ordering,
+ * keyboard nav order, and the 6-phase grouping rendered by
+ * `ExploreNav` (cycle 132). Imported by `Workspace.tsx` (the route
+ * component) and by all per-tab modules in `pages/workspace/tabs/*`.
+ */
+
+export type ExploreTab =
+  | "raw"
+  | "browser"
+  | "topics"
+  | "topiclabel"
+  | "routed"
+  | "raster"
+  | "embed3d"
+  | "repfit"
+  | "compare3d"
+  | "spatial"
+  | "unmixing"
+  | "interpret"
+  | "recipes"
+  | "supertopics"
+  | "anomaly"
+  | "neural"
+  | "gating"
+  | "llm"
+  | "probe"
+  | "robust"
+  | "agreement"
+  | "applydoc"
+  | "qkexplore"
+  | "bandmask"
+  | "stability"
+  | "deep"
+  | "usgs"
+  | "metrics";
+
+/**
+ * Order used by the `[` / `]` keyboard shortcuts to walk the entire
+ * tab list. This is intentionally the *full* flat list — phase-aware
+ * navigation lives in `EXPLORE_PHASES` below.
+ */
+export const EXPLORE_TAB_ORDER: ExploreTab[] = [
+  "raw",
+  "browser",
+  "topics",
+  "topiclabel",
+  "routed",
+  "interpret",
+  "supertopics",
+  "raster",
+  "embed3d",
+  "repfit",
+  "compare3d",
+  "spatial",
+  "stability",
+  "deep",
+  "anomaly",
+  "neural",
+  "gating",
+  "unmixing",
+  "llm",
+  "probe",
+  "robust",
+  "qkexplore",
+  "bandmask",
+  "agreement",
+  "applydoc",
+  "usgs",
+  "metrics",
+];
+
+export type ExplorePhase = {
+  id: "data" | "topics" | "geometry" | "drilldown" | "manipulate" | "stability";
+  label: string;
+  description: string;
+  color: string;
+  tabs: { id: ExploreTab; labelKey: string }[];
+};
+
+/**
+ * Phase grouping rendered by `ExploreNav`. Replaces the cycle-14
+ * 4-row × 28-button wall with a 6-phase narrative flow. Order matches
+ * a normal HSI/LDA workflow: see the data → fit topics → place them
+ * in space → drill into specifics → tweak the model → assess
+ * stability. Total: 2 + 5 + 6 + 4 + 3 + 8 = 28 tabs.
+ */
+export const EXPLORE_PHASES: ExplorePhase[] = [
+  {
+    id: "data",
+    label: "Data",
+    description: "What does the spectra look like?",
+    color: "rgba(56, 189, 248, 1)",
+    tabs: [
+      { id: "raw", labelKey: "raw" },
+      { id: "browser", labelKey: "browser" },
+    ],
+  },
+  {
+    id: "topics",
+    label: "Topics",
+    description: "What does the topic model say?",
+    color: "rgba(40, 160, 80, 1)",
+    tabs: [
+      { id: "topics", labelKey: "topics" },
+      { id: "topiclabel", labelKey: "topiclabel" },
+      { id: "routed", labelKey: "routed" },
+      { id: "interpret", labelKey: "interpret" },
+      { id: "supertopics", labelKey: "supertopics" },
+    ],
+  },
+  {
+    id: "geometry",
+    label: "Geometry",
+    description: "Where do topics live? 3D + spatial views.",
+    color: "rgba(170, 60, 200, 1)",
+    tabs: [
+      { id: "raster", labelKey: "raster" },
+      { id: "embed3d", labelKey: "embed3d" },
+      { id: "repfit", labelKey: "repfit" },
+      { id: "compare3d", labelKey: "compare3d" },
+      { id: "spatial", labelKey: "spatial" },
+      { id: "agreement", labelKey: "agreement" },
+    ],
+  },
+  {
+    id: "drilldown",
+    label: "Drilldown",
+    description: "Inspect specific docs, pixels, regions.",
+    color: "rgba(214, 100, 60, 1)",
+    tabs: [
+      { id: "applydoc", labelKey: "applydoc" },
+      { id: "unmixing", labelKey: "unmixing" },
+      { id: "usgs", labelKey: "usgs" },
+      { id: "anomaly", labelKey: "anomaly" },
+    ],
+  },
+  {
+    id: "manipulate",
+    label: "Manipulate",
+    description: "Step 8: tweak Q, K, band-mask.",
+    color: "rgba(234, 179, 8, 1)",
+    tabs: [
+      { id: "recipes", labelKey: "recipes" },
+      { id: "qkexplore", labelKey: "qkexplore" },
+      { id: "bandmask", labelKey: "bandmask" },
+    ],
+  },
+  {
+    id: "stability",
+    label: "Stability",
+    description: "How trustworthy is the fit?",
+    color: "rgba(244, 63, 94, 1)",
+    tabs: [
+      { id: "stability", labelKey: "stability" },
+      { id: "deep", labelKey: "deep" },
+      { id: "neural", labelKey: "neural" },
+      { id: "gating", labelKey: "gating" },
+      { id: "robust", labelKey: "robust" },
+      { id: "probe", labelKey: "probe" },
+      { id: "llm", labelKey: "llm" },
+      { id: "metrics", labelKey: "metrics" },
+    ],
+  },
+];
+
+export function findPhaseFor(tab: ExploreTab): ExplorePhase {
+  for (const ph of EXPLORE_PHASES) {
+    if (ph.tabs.some((t) => t.id === tab)) return ph;
+  }
+  return EXPLORE_PHASES[0]!;
+}
+
+/**
+ * Map each tab to the wiki page where its formal documentation lives.
+ * Consumed by `TabFooter` to render the per-tab "read the math" link.
+ */
+export const TAB_WIKI_PAGE: Record<ExploreTab, string> = {
+  raw: "Web-App-Workflow",
+  browser: "Web-App-Workflow",
+  topics: "Mathematical-Background",
+  topiclabel: "Mathematical-Background",
+  routed: "Multi-Axis-Addendum-B",
+  raster: "Backend-Architecture",
+  embed3d: "Backend-Architecture",
+  repfit: "Multi-Axis-Addendum-B",
+  compare3d: "Multi-Axis-Addendum-B",
+  interpret: "Mathematical-Background",
+  supertopics: "Corpus-Construction",
+  unmixing: "Multi-Axis-Addendum-B",
+  spatial: "Multi-Axis-Addendum-B",
+  agreement: "Multi-Axis-Addendum-B",
+  applydoc: "Multi-Axis-Addendum-B",
+  recipes: "Corpus-Construction",
+  qkexplore: "Mathematical-Background",
+  bandmask: "Mathematical-Background",
+  neural: "Mathematical-Background",
+  gating: "Multi-Axis-Addendum-B",
+  llm: "Multi-Axis-Addendum-B",
+  probe: "Multi-Axis-Addendum-B",
+  robust: "Multi-Axis-Addendum-B",
+  stability: "Multi-Axis-Addendum-B",
+  deep: "Mathematical-Background",
+  anomaly: "Multi-Axis-Addendum-B",
+  usgs: "Corpus-Construction",
+  metrics: "Bayesian-Method-Comparison",
+};
+
+export const WIKI_BASE = "https://github.com/fsantibanezleal/CAOS_LDA_HSI/wiki";
+export const REPO_BASE = "https://github.com/fsantibanezleal/CAOS_LDA_HSI";


### PR DESCRIPTION
Closes #421. c132 = flow-not-flood navigation redesign (6 phases × 2-8 tabs each, was 4×28-wall). c133 = first modularisation slice (state/tabs.ts + helpers/routedPrediction.ts + components/ExploreNav.tsx). Workspace.tsx shrank from 11760 to 11461 LOC.