### PR TITLE
Cycle 148: header link to CAOS_LDA_HSI_Paper repo

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { NavLink } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Github, Globe, Sparkles } from "lucide-react";
+import { FileText, Github, Globe, Sparkles } from "lucide-react";
 
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { LanguageToggle } from "@/components/LanguageToggle";
@@ -17,6 +17,7 @@ const NAV_ITEMS = [
 const EXTERNAL = {
   orcid: "https://orcid.org/0000-0002-3614-2087",
   github: "https://github.com/fsantibanezleal/CAOS_LDA_HSI",
+  paper: "https://github.com/fsantibanezleal/CAOS_LDA_HSI_Paper",
   site: "https://fasl-work.com",
 };
 
@@ -84,6 +85,16 @@ export function Header() {
             className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity"
           >
             <Github size={18} />
+          </a>
+          <a
+            href={EXTERNAL.paper}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={t("common:external.paper")}
+            title={t("common:external.paper")}
+            className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity"
+          >
+            <FileText size={18} />
           </a>
           <a
             href={EXTERNAL.site}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -13,7 +13,8 @@
   },
   "external": {
     "orcid": "ORCID",
-    "github": "GitHub",
+    "github": "GitHub (code)",
+    "paper": "Paper (manuscript)",
     "site": "fasl-work.com"
   }
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -13,7 +13,8 @@
   },
   "external": {
     "orcid": "ORCID",
-    "github": "GitHub",
+    "github": "GitHub (código)",
+    "paper": "Paper (manuscrito)",
     "site": "fasl-work.com"
   }
 }


### PR DESCRIPTION
## Summary
- Add a paper-document icon (lucide `FileText`) in the header pointing to the new manuscript repository at https://github.com/fsantibanezleal/CAOS_LDA_HSI_Paper, sitting immediately to the right of the existing GitHub (code) icon.
- Disambiguate the two GitHub-style links in EN/ES i18n labels: code repo is "GitHub (code)" / "GitHub (código)", manuscript repo is "Paper (manuscript)" / "Paper (manuscrito)".

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Header renders both icons with correct tooltips in EN and ES
- [ ] Both links open in a new tab and resolve to the expected repos