### PR TITLE
Cycle 220: refresh Overview hero counters (post-c100 drift)

### DIFF
--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -18,9 +18,9 @@ const LABELLED_SCENES = [
 const HEADLINE_DEFS = [
   { keyLabel: "datasets_label", keySub: "datasets_sub", value: "21", href: "/databases" },
   { keyLabel: "recipes_label", keySub: "recipes_sub", value: "12", href: "/methodology/representations" },
-  { keyLabel: "builders_label", keySub: "builders_sub", value: "57", href: "/methodology/pipeline" },
-  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1592", href: "/benchmarks" },
-  { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "104", href: "/benchmarks" },
+  { keyLabel: "builders_label", keySub: "builders_sub", value: "67", href: "/methodology/pipeline" },
+  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1706", href: "/benchmarks" },
+  { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "86", href: "/benchmarks" },
   { keyLabel: "variants_label", keySub: "variants_sub", value: "11", href: "/methodology/representations" },
 ] as const;
 


### PR DESCRIPTION
Overview hero showed pre-c100 counters that don't match current state. Updated:
- builders 57 → 67 (build_*.py modules)
- artefacts 1592 → 1706 (.json/.bin/.npz under data/derived/)
- endpoints 104 → 86 (FastAPI route decorators in app/)

All three numbers cross-checked against the repo at the time of the commit. Wiki Home.md + Analysis-Workflow-Architecture.md already received the same fix in c186 (2026-05-14).