### PR TITLE
Cycle 223: IntertopicMap keyboard accessibility (WCAG 2.1)

### DIFF
--- a/frontend/src/components/plots/IntertopicMap.tsx
+++ b/frontend/src/components/plots/IntertopicMap.tsx
@@ -105,12 +105,23 @@ export function IntertopicMap({
           const isSel = selectedTopic === k;
           const r = radius(prevalence[k] ?? 0);
           const color = TOPIC_PALETTE[k % TOPIC_PALETTE.length] ?? "#0ea5e9";
+          const prevPct = ((prevalence[k] ?? 0) * 100).toFixed(1);
           return (
             <g
               key={k}
               transform={`translate(${x(cx)}, ${y(cy)})`}
-              style={{ cursor: "pointer" }}
+              style={{ cursor: "pointer", outline: "none" }}
               onClick={() => onSelect(k)}
+              role="button"
+              tabIndex={0}
+              aria-label={`topic ${k + 1}, prevalence ${prevPct} percent${isSel ? ", selected" : ""}`}
+              aria-pressed={isSel}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelect(k);
+                }
+              }}
             >
               <circle
                 r={r}
@@ -118,6 +129,16 @@ export function IntertopicMap({
                 opacity={isSel ? 0.55 : 0.32}
                 stroke={color}
                 strokeWidth={isSel ? 2.5 : 1.3}
+              />
+              {/* keyboard-focus ring (CSS focus-visible) */}
+              <circle
+                r={r + 4}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeDasharray="3 3"
+                opacity="0"
+                className="topic-focus-ring"
               />
               <text
                 textAnchor="middle"

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -73,3 +73,14 @@ button {
 * {
   box-sizing: border-box;
 }
+
+/* Keyboard focus ring for SVG topic-bubbles in IntertopicMap.
+   Only visible under :focus-visible (i.e. keyboard navigation),
+   not when the user clicks the bubble (that path already uses
+   the selected-state highlight). */
+g[role="button"]:focus-visible .topic-focus-ring {
+  opacity: 0.9;
+}
+g[role="button"]:focus {
+  outline: none;
+}


### PR DESCRIPTION
Closes the IntertopicMap a11y item in #442. Topic bubbles now:
- role='button' + tabIndex={0} + aria-label + aria-pressed
- onKeyDown Enter/Space
- focus-visible dashed ring (decorative outer circle, visible only under keyboard focus)

## Test plan
- [x] tsc -b clean
- [x] vite build clean
- [ ] Tab to a topic bubble → see the dashed ring; press Enter → topic selects
- [ ] Click a bubble → no dashed ring (matches `:focus-visible` semantics)