### PR TITLE
Deploy cycles 220-223: post-audit UX + a11y sweep

### DIFF
--- a/frontend/src/components/plots/IntertopicMap.tsx
+++ b/frontend/src/components/plots/IntertopicMap.tsx
@@ -105,12 +105,23 @@ export function IntertopicMap({
           const isSel = selectedTopic === k;
           const r = radius(prevalence[k] ?? 0);
           const color = TOPIC_PALETTE[k % TOPIC_PALETTE.length] ?? "#0ea5e9";
+          const prevPct = ((prevalence[k] ?? 0) * 100).toFixed(1);
           return (
             <g
               key={k}
               transform={`translate(${x(cx)}, ${y(cy)})`}
-              style={{ cursor: "pointer" }}
+              style={{ cursor: "pointer", outline: "none" }}
               onClick={() => onSelect(k)}
+              role="button"
+              tabIndex={0}
+              aria-label={`topic ${k + 1}, prevalence ${prevPct} percent${isSel ? ", selected" : ""}`}
+              aria-pressed={isSel}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelect(k);
+                }
+              }}
             >
               <circle
                 r={r}
@@ -118,6 +129,16 @@ export function IntertopicMap({
                 opacity={isSel ? 0.55 : 0.32}
                 stroke={color}
                 strokeWidth={isSel ? 2.5 : 1.3}
+              />
+              {/* keyboard-focus ring (CSS focus-visible) */}
+              <circle
+                r={r + 4}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeDasharray="3 3"
+                opacity="0"
+                className="topic-focus-ring"
               />
               <text
                 textAnchor="middle"

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -19,7 +19,7 @@ const HEADLINE_DEFS = [
   { keyLabel: "datasets_label", keySub: "datasets_sub", value: "21", href: "/databases" },
   { keyLabel: "recipes_label", keySub: "recipes_sub", value: "12", href: "/methodology/representations" },
   { keyLabel: "builders_label", keySub: "builders_sub", value: "67", href: "/methodology/pipeline" },
-  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1706", href: "/benchmarks" },
+  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1706", href: "/workspace" },
   { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "86", href: "/benchmarks" },
   { keyLabel: "variants_label", keySub: "variants_sub", value: "11", href: "/methodology/representations" },
 ] as const;
@@ -98,6 +98,7 @@ export default function Overview() {
 
   return (
     <PageShell title={t("pages:overview.title")} lead={t("pages:overview.lead")}>
+      <LandingCTA />
       <HeroSpectralViz scenes={heroScenes.data ?? null} />
       <HeadlineNumbers />
       <FindingsCarousel />
@@ -107,6 +108,61 @@ export default function Overview() {
       <MethodCoverage />
       <ReadingPath />
     </PageShell>
+  );
+}
+
+/* =========================================================================
+   0. Landing CTA — one sentence + 2 primary actions
+   =======================================================================*/
+
+function LandingCTA() {
+  const { t } = useTranslation(["pages"]);
+  return (
+    <div
+      className="rounded-xl border px-6 py-5 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <p
+        className="text-base lg:text-lg leading-snug max-w-3xl"
+        style={{ color: "var(--color-fg)" }}
+      >
+        {t("pages:overview.landing_cta.lead", {
+          defaultValue:
+            "Probabilistic topic models on hyperspectral imagery — a multi-axis evaluation framework that asks whether LDA basis spectra add interpretable value over deep encoders for HSI scene classification.",
+        })}
+      </p>
+      <div className="flex gap-2 flex-wrap" role="group" aria-label="primary actions">
+        <Link
+          to="/workspace"
+          className="rounded-md px-4 py-2 text-sm font-semibold transition-opacity"
+          style={{
+            backgroundColor: "var(--color-accent)",
+            color: "var(--color-on-accent, white)",
+          }}
+        >
+          {t("pages:overview.landing_cta.open_workspace", {
+            defaultValue: "Open the Workspace →",
+          })}
+        </Link>
+        <Link
+          to="/methodology"
+          className="rounded-md px-4 py-2 text-sm font-semibold border transition-opacity"
+          style={{
+            borderColor: "var(--color-border)",
+            color: "var(--color-fg)",
+            backgroundColor: "transparent",
+          }}
+        >
+          {t("pages:overview.landing_cta.read_methodology", {
+            defaultValue: "Read the methodology",
+          })}
+        </Link>
+      </div>
+    </div>
   );
 }
 
@@ -411,10 +467,12 @@ function HeadlineNumbers() {
 function FindingsCarousel() {
   const { t } = useTranslation(["pages"]);
   const [idx, setIdx] = useState(0);
+  const [paused, setPaused] = useState(false);
   useEffect(() => {
+    if (paused) return;
     const timer = setInterval(() => setIdx((i) => (i + 1) % FINDINGS.length), 7000);
     return () => clearInterval(timer);
-  }, []);
+  }, [paused]);
   const cur = FINDINGS[idx]!;
 
   return (
@@ -426,6 +484,12 @@ function FindingsCarousel() {
           backgroundColor: "var(--color-panel)",
           boxShadow: "var(--color-shadow)",
         }}
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+        onFocusCapture={() => setPaused(true)}
+        onBlurCapture={() => setPaused(false)}
+        aria-roledescription="carousel"
+        aria-label={t("pages:overview.findings.section_badge", { idx: idx + 1, total: FINDINGS.length })}
       >
         <div
           aria-hidden="true"

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -18,9 +18,9 @@ const LABELLED_SCENES = [
 const HEADLINE_DEFS = [
   { keyLabel: "datasets_label", keySub: "datasets_sub", value: "21", href: "/databases" },
   { keyLabel: "recipes_label", keySub: "recipes_sub", value: "12", href: "/methodology/representations" },
-  { keyLabel: "builders_label", keySub: "builders_sub", value: "57", href: "/methodology/pipeline" },
-  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1592", href: "/benchmarks" },
-  { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "104", href: "/benchmarks" },
+  { keyLabel: "builders_label", keySub: "builders_sub", value: "67", href: "/methodology/pipeline" },
+  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1706", href: "/benchmarks" },
+  { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "86", href: "/benchmarks" },
   { keyLabel: "variants_label", keySub: "variants_sub", value: "11", href: "/methodology/representations" },
 ] as const;
 

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -115,18 +115,36 @@ export default function Workspace() {
     queryFn: api.inventory,
   });
 
-  // Restore state from URL on first inventory load
+  // Restore state from URL on first inventory load.
+  // Supports two URL shapes:
+  //   ?family=X&subset=Y&rep=Z   (canonical)
+  //   ?scene=<subset>            (shortcut from Overview SceneCard links —
+  //                               infers family from the inventory)
+  // If `rep` is missing on a labelled scene, defaults to "lda" so the user
+  // lands on Explore with the canonical topic basis pre-selected.
   useEffect(() => {
     if (restoredRef.current) return;
     if (!data) return;
-    const fam = searchParams.get("family");
-    const sub = searchParams.get("subset");
+    let fam = searchParams.get("family");
+    let sub = searchParams.get("subset");
     const rp = searchParams.get("rep");
+    const sceneShortcut = searchParams.get("scene");
+    // ?scene= shortcut: look up the dataset entry and use its family_id
+    if (!sub && sceneShortcut) {
+      const ds = data.datasets.find((d) => d.id === sceneShortcut);
+      if (ds) {
+        sub = ds.id;
+        fam = ds.family_id as DatasetFamily;
+      }
+    }
     if (fam) {
       send({ type: "PICK_FAMILY", family: fam as DatasetFamily });
       if (sub) {
         send({ type: "PICK_SUBSET", subset: sub });
-        if (rp) send({ type: "PICK_REP", rep: rp as RepresentationKind });
+        // Default rep to canonical LDA when none is supplied, so Explore
+        // is reachable in one click from the scene shortcut.
+        const resolvedRep = (rp ?? "lda") as RepresentationKind;
+        send({ type: "PICK_REP", rep: resolvedRep });
       }
     }
     restoredRef.current = true;
@@ -555,7 +573,7 @@ function RepresentationPickerStep({
 // WIKI_BASE moved to ./workspace/state/tabs.ts (cycle 133). Imported
 // at the top of this file.
 
-const TOPIC_FAMILY_REPS = new Set(["lda", "lda_sparse", "lda_tomo", "hdp", "ctm", "prodlda"]);
+const TOPIC_FAMILY_REPS = new Set(["lda", "lda_sparse", "lda_tomo", "hdp", "ctm", "prodlda", "etm"]);
 const REPRESENTATION_ENDPOINT_METHOD: Record<string, string> = {
   pca: "pca_8",
   nmf: "nmf_8",
@@ -589,16 +607,26 @@ function ExploreStep({
   const [searchParams, setSearchParams] = useSearchParams();
   const urlTab = searchParams.get("tab") as ExploreTab | null;
   const urlTopic = searchParams.get("topic");
-  const [tab, setTab] = useState<ExploreTab>(urlTab ?? "raw");
+  // When the chosen representation is a topic model the user almost
+  // always wants to see the topics first; only fall back to the EDA
+  // tab when the representation is something else (PCA, NMF, deep
+  // encoders) where there are no topic-side panels to land on.
+  const defaultTab: ExploreTab = rep && TOPIC_FAMILY_REPS.has(rep)
+    ? "topics"
+    : "raw";
+  const [tab, setTab] = useState<ExploreTab>(urlTab ?? defaultTab);
   const [selectedTopic, setSelectedTopic] = useState<number | null>(
     urlTopic != null && /^\d+$/.test(urlTopic) ? Number(urlTopic) : null,
   );
   const [showHelp, setShowHelp] = useState<boolean>(false);
 
-  // Mirror tab + selectedTopic to URL
+  // Mirror tab + selectedTopic to URL.
+  // Don't write the default tab to the URL — keeps it short for the
+  // common case ("?family=...&subset=...&rep=..." is enough; tab is
+  // implicit until the user navigates away from the default).
   useEffect(() => {
     const next = new URLSearchParams(searchParams);
-    if (tab && tab !== "raw") next.set("tab", tab);
+    if (tab && tab !== defaultTab) next.set("tab", tab);
     else next.delete("tab");
     if (selectedTopic !== null) next.set("topic", String(selectedTopic));
     else next.delete("topic");

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -73,3 +73,14 @@ button {
 * {
   box-sizing: border-box;
 }
+
+/* Keyboard focus ring for SVG topic-bubbles in IntertopicMap.
+   Only visible under :focus-visible (i.e. keyboard navigation),
+   not when the user clicks the bubble (that path already uses
+   the selected-state highlight). */
+g[role="button"]:focus-visible .topic-focus-ring {
+  opacity: 0.9;
+}
+g[role="button"]:focus {
+  outline: none;
+}


### PR DESCRIPTION
Promote cycles 220-223 from develop to main:
- c220: Overview hero counters refreshed (builders 57→67, artefacts 1592→1706, endpoints 104→86)
- c221: UX defaults — ?scene= URL shortcut + default rep=lda + default tab=topics when rep is a topic model
- c222: Landing CTA + artifacts link to /workspace + FindingsCarousel pause-on-hover
- c223: IntertopicMap keyboard accessibility (WCAG 2.1)

## Test plan
- [x] All 4 PRs merged to develop with clean tsc + vite build
- [ ] Deploy on Hetzner via deploy/update.sh
- [ ] Smoke 109/109 OK
- [ ] Visual check on https://lda-hsi.fasl-work.com (CTA visible, scene cards link to Explore > Topics, intertopic bubbles keyboard-focusable)