### PR TITLE
Cycle 229: pipeline metadata envelopes in 6 builders (#444)

### DIFF
--- a/data-pipeline/build_analysis_payload.py
+++ b/data-pipeline/build_analysis_payload.py
@@ -9,6 +9,7 @@ modelling service.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -253,6 +254,12 @@ def main() -> None:
         ],
         "scene_diagnostics": scene_diagnostics,
         "library_diagnostics": library_diagnostics,
+        "framework_axis": "Cross-axis: derived analysis bundle "
+                           "consumed by the Benchmarks page; not a single "
+                           "F-axis but joins scene + library views.",
+        "generated_at": datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_analysis_payload v0.1",
     }
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/data-pipeline/build_demo.py
+++ b/data-pipeline/build_demo.py
@@ -10,6 +10,7 @@ small, deterministic, fully public example that explains:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from itertools import permutations
 from pathlib import Path
 
@@ -341,6 +342,11 @@ def build_demo() -> dict:
 def main() -> None:
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     payload = build_demo()
+    payload.update({
+        "framework_axis": "Demo bundle: snapshot consumed by /demo route",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_demo v0.2",
+    })
     with OUTPUT.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2, ensure_ascii=False)
     print(f"Wrote demo payload to {OUTPUT}")

--- a/data-pipeline/build_field_samples.py
+++ b/data-pipeline/build_field_samples.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -331,6 +332,11 @@ def main() -> None:
         "source": "Official orthomosaics from the MicaSense RedEdge sample page",
         "scenes": scenes,
     }
+    payload.update({
+        "framework_axis": "Compact per-scene field-sample summaries for the Databases page",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_field_samples v0.2",
+    })
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
     print(f"Wrote derived field-scene payload to {OUTPUT_PATH}")

--- a/data-pipeline/build_local_inventory.py
+++ b/data-pipeline/build_local_inventory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -19,6 +20,18 @@ OUTPUT_PATH = CORE_DERIVED_DIR / "local_dataset_inventory.json"
 
 def main() -> None:
     payload = build_local_inventory()
+    payload.update({
+        "framework_axis": (
+            "Infrastructure: unified local dataset inventory used by "
+            "the validation backend and by audit_manifest.py. Not a "
+            "single F-axis but underpins every per-scene/per-subset "
+            "axis as the canonical 'which datasets are local?' "
+            "ground truth."
+        ),
+        "generated_at": datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_local_inventory v0.2",
+    })
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)

--- a/data-pipeline/build_real_samples.py
+++ b/data-pipeline/build_real_samples.py
@@ -8,6 +8,7 @@ regimes are treated as topics or topic-like strata.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -648,6 +649,11 @@ def main() -> None:
         "source": "Official UPV/EHU scenes and compact public unmixing scenes",
         "scenes": scenes,
     }
+    payload.update({
+        "framework_axis": "Compact per-scene real-sample summaries (class distribution + class mean spectra) consumed by Overview + Databases",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_real_samples v0.2",
+    })
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
     print(f"Wrote derived real-scene payload to {OUTPUT_PATH}")

--- a/data-pipeline/build_spectral_library_samples.py
+++ b/data-pipeline/build_spectral_library_samples.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 import re
 import zipfile
 from pathlib import Path
@@ -167,6 +168,11 @@ def main() -> None:
         "samples": samples,
     }
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    payload.update({
+        "framework_axis": "Compact spectral-library samples (USGS / ECOSTRESS curated) consumed by the spectral browser tab",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_spectral_library_samples v0.2",
+    })
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
     print(f"Wrote spectral-library payload to {OUTPUT_PATH}")


### PR DESCRIPTION
Closes the metadata-envelope item in #444. The 6 builders that predated the framework_axis/builder_version/generated_at convention now ship the 3-key envelope so audit_manifest.py can verify reproducibility on their outputs.