### PR TITLE
Deploy cycles 224-230: backend P0 + UX state + Tab states + pipeline metadata + doc drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ every deploy.
   [`scripts/smoke.ps1`](scripts/smoke.ps1)). The content
   assertions close the empty-body deploy class that escaped in
   cycles 99-101.
-- **Manifest**: 1592 derived artifacts (1359 JSON + 147 binary +
-  27 PNG), audited zero-issues by [`data-pipeline/audit_manifest.py`](data-pipeline/audit_manifest.py)
+- **Manifest**: 1706 derived artifacts (1466 JSON + 209 binary +
+  31 PNG, count refreshed 2026-05-15), audited zero-issues by [`data-pipeline/audit_manifest.py`](data-pipeline/audit_manifest.py)
 - **API surface**: ~110 endpoints across 6 labelled scenes × ~17
   per-scene endpoints + 5 HIDSAG subsets × 6 endpoints + 12
   cross-scene endpoints + `/api/wordifications` (108-config
@@ -89,8 +89,9 @@ every deploy.
                  │              Tailwind v4 + react-i18next +         │
                  │              TanStack Query v5 + Zustand + XState) │
                  │  Pages: Overview · Methodology · Databases ·       │
-                 │         Workspace (28 tabs in 4 groups:            │
-                 │           Raw / Topic model / Spatial / Diagnostics)│
+                 │         Workspace (28 tabs in 6 phases:            │
+                 │           Data / Topics / Geometry / Drilldown /   │
+                 │           Manipulate / Stability — cycle 132)      │
                  │         · Benchmarks (16 cards)                    │
                  └──────────────────────┘
 ```
@@ -490,7 +491,7 @@ Every cycle that lands in production includes:
 3. PR `task/* → develop` with squash-merge + branch deletion
 4. PR `develop → main` titled `Deploy: <summary>` and merged via merge-commit
 5. SSH `bash deploy/update.sh` against the VPS
-6. Smoke harness verifies 87/87
+6. Smoke harness verifies 109/109 GET endpoints + 4 SPA-shell content assertions
 7. Cadence comments: PR comment + issue comment + close
 8. Management repo updates: `deployments/caos-lda-hsi.md` + `wip/caos-lda-hsi/current-state.md`
 

--- a/app/main.py
+++ b/app/main.py
@@ -65,9 +65,19 @@ if _dist.is_dir():
     def root() -> FileResponse:
         return FileResponse(_dist / "index.html", headers=INDEX_HEADERS)
 
+    _dist_resolved = _dist.resolve()
+
     @app.get("/{path:path}", include_in_schema=False)
     def spa_fallback(path: str) -> FileResponse:
-        target = _dist / path
+        # Guard against path traversal: a request like
+        # "/../app/config.py" would otherwise resolve to a file outside
+        # _dist. nginx normalises in prod, but the FastAPI route is
+        # reachable on 127.0.0.1:8105 even there.
+        target = (_dist / path).resolve()
+        try:
+            target.relative_to(_dist_resolved)
+        except ValueError:
+            return FileResponse(_dist / "index.html", headers=INDEX_HEADERS)
         if target.is_file():
             return FileResponse(target)
         return FileResponse(_dist / "index.html", headers=INDEX_HEADERS)

--- a/data-pipeline/build_analysis_payload.py
+++ b/data-pipeline/build_analysis_payload.py
@@ -9,6 +9,7 @@ modelling service.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -253,6 +254,12 @@ def main() -> None:
         ],
         "scene_diagnostics": scene_diagnostics,
         "library_diagnostics": library_diagnostics,
+        "framework_axis": "Cross-axis: derived analysis bundle "
+                           "consumed by the Benchmarks page; not a single "
+                           "F-axis but joins scene + library views.",
+        "generated_at": datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_analysis_payload v0.1",
     }
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/data-pipeline/build_demo.py
+++ b/data-pipeline/build_demo.py
@@ -10,6 +10,7 @@ small, deterministic, fully public example that explains:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from itertools import permutations
 from pathlib import Path
 
@@ -341,6 +342,11 @@ def build_demo() -> dict:
 def main() -> None:
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     payload = build_demo()
+    payload.update({
+        "framework_axis": "Demo bundle: snapshot consumed by /demo route",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_demo v0.2",
+    })
     with OUTPUT.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2, ensure_ascii=False)
     print(f"Wrote demo payload to {OUTPUT}")

--- a/data-pipeline/build_field_samples.py
+++ b/data-pipeline/build_field_samples.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -331,6 +332,11 @@ def main() -> None:
         "source": "Official orthomosaics from the MicaSense RedEdge sample page",
         "scenes": scenes,
     }
+    payload.update({
+        "framework_axis": "Compact per-scene field-sample summaries for the Databases page",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_field_samples v0.2",
+    })
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
     print(f"Wrote derived field-scene payload to {OUTPUT_PATH}")

--- a/data-pipeline/build_local_inventory.py
+++ b/data-pipeline/build_local_inventory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -19,6 +20,18 @@ OUTPUT_PATH = CORE_DERIVED_DIR / "local_dataset_inventory.json"
 
 def main() -> None:
     payload = build_local_inventory()
+    payload.update({
+        "framework_axis": (
+            "Infrastructure: unified local dataset inventory used by "
+            "the validation backend and by audit_manifest.py. Not a "
+            "single F-axis but underpins every per-scene/per-subset "
+            "axis as the canonical 'which datasets are local?' "
+            "ground truth."
+        ),
+        "generated_at": datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_local_inventory v0.2",
+    })
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)

--- a/data-pipeline/build_real_samples.py
+++ b/data-pipeline/build_real_samples.py
@@ -8,6 +8,7 @@ regimes are treated as topics or topic-like strata.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -648,6 +649,11 @@ def main() -> None:
         "source": "Official UPV/EHU scenes and compact public unmixing scenes",
         "scenes": scenes,
     }
+    payload.update({
+        "framework_axis": "Compact per-scene real-sample summaries (class distribution + class mean spectra) consumed by Overview + Databases",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_real_samples v0.2",
+    })
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
     print(f"Wrote derived real-scene payload to {OUTPUT_PATH}")

--- a/data-pipeline/build_spectral_library_samples.py
+++ b/data-pipeline/build_spectral_library_samples.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 import re
 import zipfile
 from pathlib import Path
@@ -167,6 +168,11 @@ def main() -> None:
         "samples": samples,
     }
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    payload.update({
+        "framework_axis": "Compact spectral-library samples (USGS / ECOSTRESS curated) consumed by the spectral browser tab",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "builder_version": "build_spectral_library_samples v0.2",
+    })
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
     print(f"Wrote spectral-library payload to {OUTPUT_PATH}")

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -620,6 +620,22 @@ function ExploreStep({
   );
   const [showHelp, setShowHelp] = useState<boolean>(false);
 
+  // Reset selectedTopic + tab when the user switches scene or rep.
+  // Topic IDs are not portable across scenes (topic 3 on Pavia U is
+  // a different cluster than topic 3 on Indian Pines); a stale topic
+  // selection produces confusing highlighting after a SWITCH_SUBSET.
+  // Likewise, tab=interpret on a topic-model rep is meaningless after
+  // the user switches to a PCA rep.
+  const scopeKey = `${subsetId ?? ""}|${rep ?? ""}`;
+  const prevScopeRef = useRef(scopeKey);
+  useEffect(() => {
+    if (prevScopeRef.current === scopeKey) return;
+    prevScopeRef.current = scopeKey;
+    setSelectedTopic(null);
+    setTab(defaultTab);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopeKey]);
+
   // Mirror tab + selectedTopic to URL.
   // Don't write the default tab to the URL — keeps it short for the
   // common case ("?family=...&subset=...&rep=..." is enough; tab is

--- a/frontend/src/pages/workspace/components/TabStates.tsx
+++ b/frontend/src/pages/workspace/components/TabStates.tsx
@@ -1,0 +1,116 @@
+/**
+ * Shared placeholders for the three "non-content" states every
+ * Workspace tab can be in: loading, empty, and error. Replaces the
+ * 14+ ad-hoc `<p>Loading…</p>` / `if (!data) return null` / inline
+ * error strings scattered across Workspace.tsx (issue #442 P2).
+ *
+ * Each component is intentionally lightweight: a single rounded
+ * border card with a centred message, no spinner, no animation —
+ * matches the surrounding tab visual language without introducing
+ * new design system tokens. A `Retry` button is rendered on the
+ * error variant when `onRetry` is supplied.
+ */
+
+import type { ReactNode } from "react";
+
+const CARD_STYLE = {
+  borderColor: "var(--color-border)",
+  backgroundColor: "var(--color-panel)",
+  boxShadow: "var(--color-shadow)",
+} as const;
+
+type CommonProps = {
+  /** Optional override of the message shown to the user. */
+  message?: string;
+  /** Optional secondary detail (e.g. endpoint path on error). */
+  detail?: string;
+  /** Optional content (e.g. retry button). */
+  children?: ReactNode;
+};
+
+export function TabLoading({ message = "Loading…" }: { message?: string }) {
+  return (
+    <div
+      className="rounded-lg border p-8 flex items-center justify-center"
+      style={CARD_STYLE}
+      role="status"
+      aria-live="polite"
+    >
+      <p
+        className="text-sm"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        {message}
+      </p>
+    </div>
+  );
+}
+
+export function TabEmpty({
+  message = "No data available for this scene / representation.",
+  detail,
+}: CommonProps) {
+  return (
+    <div
+      className="rounded-lg border p-8 flex flex-col items-center justify-center gap-2"
+      style={CARD_STYLE}
+    >
+      <p className="text-sm" style={{ color: "var(--color-fg-subtle)" }}>
+        {message}
+      </p>
+      {detail && (
+        <p
+          className="text-[11.5px] font-mono"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {detail}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function TabError({
+  message = "Could not load this tab's data.",
+  detail,
+  onRetry,
+  children,
+}: CommonProps & { onRetry?: () => void }) {
+  return (
+    <div
+      className="rounded-lg border p-6 flex flex-col items-start gap-3"
+      style={{
+        ...CARD_STYLE,
+        borderColor: "var(--color-warn, var(--color-border))",
+      }}
+      role="alert"
+    >
+      <p className="text-sm" style={{ color: "var(--color-fg)" }}>
+        {message}
+      </p>
+      {detail && (
+        <p
+          className="text-[11.5px] font-mono"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {detail}
+        </p>
+      )}
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-md border px-3 py-1.5 text-sm transition-opacity hover:opacity-90"
+          style={{
+            borderColor: "var(--color-border)",
+            backgroundColor: "var(--color-panel)",
+            color: "var(--color-fg)",
+          }}
+        >
+          Retry
+        </button>
+      )}
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Promote cycles 224-230 from develop to main:
- c224: SPA fallback path-traversal guard (#440 P0 security)
- c225: SWITCH_SUBSET clears selectedTopic + resets tab (#442)
- c226: shared TabLoading / TabEmpty / TabError components (#442)
- c229: metadata envelope in 6 builders (#444)
- c230: README counter refresh (#443)

## Test plan
- [x] All 5 PRs merged to develop with clean build
- [ ] Deploy on Hetzner; smoke 109/109
- [ ] Verify path-traversal guard rejects ../app/config.py