### PR TITLE
Cycle 236: Pydantic response models for the band-masks route family (#440)

### DIFF
--- a/app/models/band_masks.py
+++ b/app/models/band_masks.py
@@ -1,0 +1,206 @@
+"""Pydantic response models for the band-masks route family.
+
+Closes one P1 item from issue #440 ("47 untyped dict response handlers"):
+the five `/band-masks*` endpoints in `app/routers/content.py` now declare
+response models that mirror the frontend types in `frontend/src/api/client.ts`
+(BandMaskIndex, BandMaskCanonicalComparison, BandMaskSummary,
+BandMaskHidsagIndex, BandMaskHidsagSummary).
+
+extra='allow' is set on every payload so backend JSON drift does not silently
+drop fields under FastAPI's response_model filtering.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+_PassThroughConfig = ConfigDict(extra="allow")
+
+
+class BandMaskDefinition(BaseModel):
+    model_config = _PassThroughConfig
+    label: str
+    description: str
+
+
+class BandMaskLdaConfig(BaseModel):
+    model_config = _PassThroughConfig
+    method: str
+    max_iter: int
+    doc_topic_prior: float
+    topic_word_prior: float
+    random_state: int
+    wordification: str
+    quantization_scale: int | None = None
+    samples_per_class: int | None = None
+
+
+class BandMaskLabelCell(BaseModel):
+    model_config = _PassThroughConfig
+    label_id: int
+    name: str
+    count: int
+    p: float
+
+
+class BandMaskCovariateProbability(BaseModel):
+    model_config = _PassThroughConfig
+    covariate: str
+    count: int
+    p: float
+
+
+class BandMaskDominantTopicMapMeta(BaseModel):
+    model_config = _PassThroughConfig
+    format: str
+    shape: list[int]
+    sentinel_unlabelled: int
+    served_path: str
+
+
+class BandMaskThetaGridMeta(BaseModel):
+    model_config = _PassThroughConfig
+    format: str
+    shape: list[int]
+    dtype: str
+    sentinel: str
+    byte_order: str | None = None
+    served_path: str
+
+
+class BandMaskIndexEntry(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    mask_id: str
+    mask_label: str | None = None
+    topic_count: int | None = None
+    n_bands_full: int | None = None
+    n_bands_kept: int | None = None
+    perplexity_train: float | None = None
+    ari_dominant_vs_label: float | None = None
+    mean_confidence: float | None = None
+    summary_path: str | None = None
+    skipped: bool | None = None
+    reason: str | None = None
+
+
+class BandMasksIndexResponse(BaseModel):
+    model_config = _PassThroughConfig
+    generated_at: str
+    builder_version: str
+    mask_definitions: dict[str, BandMaskDefinition]
+    entries: list[BandMaskIndexEntry] = Field(default_factory=list)
+
+
+class BandMaskCanonicalComparisonEntry(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    mask_id: str
+    skipped: bool | None = None
+    reason: str | None = None
+    n_paired_pixels: int | None = None
+    paired_ari_dominant_topics: float | None = None
+    swap_rate_under_hungarian_alignment: float | None = None
+    n_topic_swaps: int | None = None
+    kl_p_label_given_topic_mean: float | None = None
+    kl_p_label_given_topic_max: float | None = None
+    hungarian_assignment: dict[str, int] | None = None
+    topic_count_canonical: int | None = None
+    topic_count_masked: int | None = None
+    n_bands_full: int | None = None
+    n_bands_kept: int | None = None
+    ari_dominant_vs_label_masked: float | None = None
+    perplexity_train_masked: float | None = None
+
+
+class BandMaskCanonicalComparisonResponse(BaseModel):
+    model_config = _PassThroughConfig
+    generated_at: str
+    builder_version: str
+    description: str
+    entries: list[BandMaskCanonicalComparisonEntry] = Field(default_factory=list)
+
+
+class BandMaskSummaryResponse(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    mask_id: str
+    mask_label: str
+    mask_description: str
+    spatial_shape: list[int]
+    topic_count: int
+    document_count: int
+    vocabulary_size: int
+    n_bands_full: int
+    n_bands_kept: int
+    kept_band_indices: list[int]
+    wavelengths_nm_kept_first_last: list[float]
+    wavelengths_nm_kept: list[float]
+    topic_prevalence: list[float]
+    topic_distance_cosine: list[list[float]]
+    top_words_per_topic_lambda_05: list[list[str]]
+    p_label_given_topic_dominant: list[list[BandMaskLabelCell]]
+    docs_per_topic_dominant: list[int]
+    perplexity_train: float
+    ari_dominant_vs_label: float
+    mean_confidence: float
+    lda_config: BandMaskLdaConfig
+    dominant_topic_map: BandMaskDominantTopicMapMeta
+    theta_grid: BandMaskThetaGridMeta
+    generated_at: str
+    builder_version: str
+
+
+class BandMaskHidsagIndexEntry(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    mask_id: str
+    mask_label: str | None = None
+    topic_count: int | None = None
+    n_bands_full: int | None = None
+    n_bands_kept: int | None = None
+    perplexity_train: float | None = None
+    mean_confidence: float | None = None
+    summary_path: str | None = None
+    skipped: bool | None = None
+    reason: str | None = None
+
+
+class BandMasksHidsagIndexResponse(BaseModel):
+    model_config = _PassThroughConfig
+    generated_at: str
+    builder_version: str
+    modality: str
+    mask_definitions: dict[str, BandMaskDefinition]
+    entries: list[BandMaskHidsagIndexEntry] = Field(default_factory=list)
+
+
+class BandMaskHidsagSummaryResponse(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    mask_id: str
+    mask_label: str
+    mask_description: str
+    modality: str
+    topic_count: int
+    document_count: int
+    vocabulary_size: int
+    n_bands_full: int
+    n_bands_kept: int
+    kept_band_indices: list[int]
+    wavelengths_nm_kept_first_last: list[float]
+    wavelengths_nm_kept: list[float]
+    topic_prevalence: list[float]
+    topic_distance_cosine: list[list[float]]
+    top_words_per_topic_lambda_05: list[list[str]]
+    p_covariate_given_topic_dominant: list[list[BandMaskCovariateProbability]]
+    docs_per_topic_dominant: list[int]
+    perplexity_train: float
+    mean_confidence: float
+    doc_names: list[str]
+    sample_names: list[str]
+    covariates: list[str]
+    theta_per_doc: list[list[float]]
+    lda_config: BandMaskLdaConfig
+    generated_at: str
+    builder_version: str

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
+from app.models.band_masks import (
+    BandMaskCanonicalComparisonResponse,
+    BandMaskHidsagSummaryResponse,
+    BandMaskSummaryResponse,
+    BandMasksHidsagIndexResponse,
+    BandMasksIndexResponse,
+)
 from app.models.schemas import (
     AnalysisPayload,
     AppPayload,
@@ -385,11 +392,15 @@ def wordification(scene_id: str, recipe: str, scheme: str, q: int) -> dict:
         ) from exc
 
 
-@router.get("/band-masks")
-def band_masks_index() -> dict:
+@router.get(
+    "/band-masks",
+    response_model=BandMasksIndexResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_index() -> BandMasksIndexResponse:
     from app.services.content import get_band_masks_index
     try:
-        return get_band_masks_index()
+        return BandMasksIndexResponse.model_validate(get_band_masks_index())
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -398,11 +409,17 @@ def band_masks_index() -> dict:
         ) from exc
 
 
-@router.get("/band-masks/canonical-comparison")
-def band_masks_canonical_comparison() -> dict:
+@router.get(
+    "/band-masks/canonical-comparison",
+    response_model=BandMaskCanonicalComparisonResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
     from app.services.content import get_band_masks_canonical_comparison
     try:
-        return get_band_masks_canonical_comparison()
+        return BandMaskCanonicalComparisonResponse.model_validate(
+            get_band_masks_canonical_comparison()
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -411,11 +428,17 @@ def band_masks_canonical_comparison() -> dict:
         ) from exc
 
 
-@router.get("/band-masks/{scene_id}/{mask_id}")
-def band_mask_summary(scene_id: str, mask_id: str) -> dict:
+@router.get(
+    "/band-masks/{scene_id}/{mask_id}",
+    response_model=BandMaskSummaryResponse,
+    response_model_exclude_none=True,
+)
+def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
     from app.services.content import get_band_mask_summary
     try:
-        return get_band_mask_summary(scene_id, mask_id)
+        return BandMaskSummaryResponse.model_validate(
+            get_band_mask_summary(scene_id, mask_id)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -423,11 +446,17 @@ def band_mask_summary(scene_id: str, mask_id: str) -> dict:
         ) from exc
 
 
-@router.get("/band-masks-hidsag")
-def band_masks_hidsag_index() -> dict:
+@router.get(
+    "/band-masks-hidsag",
+    response_model=BandMasksHidsagIndexResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_hidsag_index() -> BandMasksHidsagIndexResponse:
     from app.services.content import get_band_masks_hidsag_index
     try:
-        return get_band_masks_hidsag_index()
+        return BandMasksHidsagIndexResponse.model_validate(
+            get_band_masks_hidsag_index()
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -436,11 +465,19 @@ def band_masks_hidsag_index() -> dict:
         ) from exc
 
 
-@router.get("/band-masks-hidsag/{subset_code}/{mask_id}")
-def band_masks_hidsag_summary(subset_code: str, mask_id: str) -> dict:
+@router.get(
+    "/band-masks-hidsag/{subset_code}/{mask_id}",
+    response_model=BandMaskHidsagSummaryResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_hidsag_summary(
+    subset_code: str, mask_id: str
+) -> BandMaskHidsagSummaryResponse:
     from app.services.content import get_band_masks_hidsag_summary
     try:
-        return get_band_masks_hidsag_summary(subset_code, mask_id)
+        return BandMaskHidsagSummaryResponse.model_validate(
+            get_band_masks_hidsag_summary(subset_code, mask_id)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,


### PR DESCRIPTION
## Summary

Closes one P1 item from issue #440 (\"47 untyped dict response handlers\"):
the five \`/band-masks*\` endpoints now declare Pydantic v2 response
models that mirror the frontend types in \`frontend/src/api/client.ts\`.
That makes them first-class in the auto-generated OpenAPI schema and
unblocks the eventual \`api/client.ts\` auto-gen path.

## Routes covered

| Route | Response model |
|---|---|
| \`/band-masks\` | \`BandMasksIndexResponse\` |
| \`/band-masks/canonical-comparison\` | \`BandMaskCanonicalComparisonResponse\` |
| \`/band-masks/{scene}/{mask}\` | \`BandMaskSummaryResponse\` |
| \`/band-masks-hidsag\` | \`BandMasksHidsagIndexResponse\` |
| \`/band-masks-hidsag/{subset}/{mask}\` | \`BandMaskHidsagSummaryResponse\` |

## Design choices

- \`ConfigDict(extra='allow')\` on every payload so backend JSON drift
  does not silently drop fields under FastAPI's \`response_model\`
  filtering.
- \`response_model_exclude_none=True\` on each route decorator so
  optional fields stay omitted on the wire — keeps the response
  byte-identical to the current \`-> dict\` behaviour.
- Models live in a new \`app/models/band_masks.py\` rather than bloating
  \`schemas.py\` (1093 LOC); the same pattern can carry the next 4
  families (wordifications, topic-views, topic-to-data, ...).

## Test plan

- [x] Pydantic \`.model_validate()\` round-trips against all 5 live JSON
      files.
- [x] FastAPI TestClient on all 5 routes returns 200 + byte-exact
      payload match against the raw JSON under deep field-by-field
      comparison.
- [x] Full smoke harness (109 paths + SPA shell + bundle content)
      passes locally against uvicorn on :8108.

Refs #440 P1 item 1.2.