### PR TITLE
Deploy cycles 232-236: command palette + axis crosswalk + recently-viewed + Pydantic band-masks family

### DIFF
--- a/app/models/band_masks.py
+++ b/app/models/band_masks.py
@@ -1,0 +1,206 @@
+"""Pydantic response models for the band-masks route family.
+
+Closes one P1 item from issue #440 ("47 untyped dict response handlers"):
+the five `/band-masks*` endpoints in `app/routers/content.py` now declare
+response models that mirror the frontend types in `frontend/src/api/client.ts`
+(BandMaskIndex, BandMaskCanonicalComparison, BandMaskSummary,
+BandMaskHidsagIndex, BandMaskHidsagSummary).
+
+extra='allow' is set on every payload so backend JSON drift does not silently
+drop fields under FastAPI's response_model filtering.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+_PassThroughConfig = ConfigDict(extra="allow")
+
+
+class BandMaskDefinition(BaseModel):
+    model_config = _PassThroughConfig
+    label: str
+    description: str
+
+
+class BandMaskLdaConfig(BaseModel):
+    model_config = _PassThroughConfig
+    method: str
+    max_iter: int
+    doc_topic_prior: float
+    topic_word_prior: float
+    random_state: int
+    wordification: str
+    quantization_scale: int | None = None
+    samples_per_class: int | None = None
+
+
+class BandMaskLabelCell(BaseModel):
+    model_config = _PassThroughConfig
+    label_id: int
+    name: str
+    count: int
+    p: float
+
+
+class BandMaskCovariateProbability(BaseModel):
+    model_config = _PassThroughConfig
+    covariate: str
+    count: int
+    p: float
+
+
+class BandMaskDominantTopicMapMeta(BaseModel):
+    model_config = _PassThroughConfig
+    format: str
+    shape: list[int]
+    sentinel_unlabelled: int
+    served_path: str
+
+
+class BandMaskThetaGridMeta(BaseModel):
+    model_config = _PassThroughConfig
+    format: str
+    shape: list[int]
+    dtype: str
+    sentinel: str
+    byte_order: str | None = None
+    served_path: str
+
+
+class BandMaskIndexEntry(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    mask_id: str
+    mask_label: str | None = None
+    topic_count: int | None = None
+    n_bands_full: int | None = None
+    n_bands_kept: int | None = None
+    perplexity_train: float | None = None
+    ari_dominant_vs_label: float | None = None
+    mean_confidence: float | None = None
+    summary_path: str | None = None
+    skipped: bool | None = None
+    reason: str | None = None
+
+
+class BandMasksIndexResponse(BaseModel):
+    model_config = _PassThroughConfig
+    generated_at: str
+    builder_version: str
+    mask_definitions: dict[str, BandMaskDefinition]
+    entries: list[BandMaskIndexEntry] = Field(default_factory=list)
+
+
+class BandMaskCanonicalComparisonEntry(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    mask_id: str
+    skipped: bool | None = None
+    reason: str | None = None
+    n_paired_pixels: int | None = None
+    paired_ari_dominant_topics: float | None = None
+    swap_rate_under_hungarian_alignment: float | None = None
+    n_topic_swaps: int | None = None
+    kl_p_label_given_topic_mean: float | None = None
+    kl_p_label_given_topic_max: float | None = None
+    hungarian_assignment: dict[str, int] | None = None
+    topic_count_canonical: int | None = None
+    topic_count_masked: int | None = None
+    n_bands_full: int | None = None
+    n_bands_kept: int | None = None
+    ari_dominant_vs_label_masked: float | None = None
+    perplexity_train_masked: float | None = None
+
+
+class BandMaskCanonicalComparisonResponse(BaseModel):
+    model_config = _PassThroughConfig
+    generated_at: str
+    builder_version: str
+    description: str
+    entries: list[BandMaskCanonicalComparisonEntry] = Field(default_factory=list)
+
+
+class BandMaskSummaryResponse(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    mask_id: str
+    mask_label: str
+    mask_description: str
+    spatial_shape: list[int]
+    topic_count: int
+    document_count: int
+    vocabulary_size: int
+    n_bands_full: int
+    n_bands_kept: int
+    kept_band_indices: list[int]
+    wavelengths_nm_kept_first_last: list[float]
+    wavelengths_nm_kept: list[float]
+    topic_prevalence: list[float]
+    topic_distance_cosine: list[list[float]]
+    top_words_per_topic_lambda_05: list[list[str]]
+    p_label_given_topic_dominant: list[list[BandMaskLabelCell]]
+    docs_per_topic_dominant: list[int]
+    perplexity_train: float
+    ari_dominant_vs_label: float
+    mean_confidence: float
+    lda_config: BandMaskLdaConfig
+    dominant_topic_map: BandMaskDominantTopicMapMeta
+    theta_grid: BandMaskThetaGridMeta
+    generated_at: str
+    builder_version: str
+
+
+class BandMaskHidsagIndexEntry(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    mask_id: str
+    mask_label: str | None = None
+    topic_count: int | None = None
+    n_bands_full: int | None = None
+    n_bands_kept: int | None = None
+    perplexity_train: float | None = None
+    mean_confidence: float | None = None
+    summary_path: str | None = None
+    skipped: bool | None = None
+    reason: str | None = None
+
+
+class BandMasksHidsagIndexResponse(BaseModel):
+    model_config = _PassThroughConfig
+    generated_at: str
+    builder_version: str
+    modality: str
+    mask_definitions: dict[str, BandMaskDefinition]
+    entries: list[BandMaskHidsagIndexEntry] = Field(default_factory=list)
+
+
+class BandMaskHidsagSummaryResponse(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    mask_id: str
+    mask_label: str
+    mask_description: str
+    modality: str
+    topic_count: int
+    document_count: int
+    vocabulary_size: int
+    n_bands_full: int
+    n_bands_kept: int
+    kept_band_indices: list[int]
+    wavelengths_nm_kept_first_last: list[float]
+    wavelengths_nm_kept: list[float]
+    topic_prevalence: list[float]
+    topic_distance_cosine: list[list[float]]
+    top_words_per_topic_lambda_05: list[list[str]]
+    p_covariate_given_topic_dominant: list[list[BandMaskCovariateProbability]]
+    docs_per_topic_dominant: list[int]
+    perplexity_train: float
+    mean_confidence: float
+    doc_names: list[str]
+    sample_names: list[str]
+    covariates: list[str]
+    theta_per_doc: list[list[float]]
+    lda_config: BandMaskLdaConfig
+    generated_at: str
+    builder_version: str

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
+from app.models.band_masks import (
+    BandMaskCanonicalComparisonResponse,
+    BandMaskHidsagSummaryResponse,
+    BandMaskSummaryResponse,
+    BandMasksHidsagIndexResponse,
+    BandMasksIndexResponse,
+)
 from app.models.schemas import (
     AnalysisPayload,
     AppPayload,
@@ -385,11 +392,15 @@ def wordification(scene_id: str, recipe: str, scheme: str, q: int) -> dict:
         ) from exc
 
 
-@router.get("/band-masks")
-def band_masks_index() -> dict:
+@router.get(
+    "/band-masks",
+    response_model=BandMasksIndexResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_index() -> BandMasksIndexResponse:
     from app.services.content import get_band_masks_index
     try:
-        return get_band_masks_index()
+        return BandMasksIndexResponse.model_validate(get_band_masks_index())
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -398,11 +409,17 @@ def band_masks_index() -> dict:
         ) from exc
 
 
-@router.get("/band-masks/canonical-comparison")
-def band_masks_canonical_comparison() -> dict:
+@router.get(
+    "/band-masks/canonical-comparison",
+    response_model=BandMaskCanonicalComparisonResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
     from app.services.content import get_band_masks_canonical_comparison
     try:
-        return get_band_masks_canonical_comparison()
+        return BandMaskCanonicalComparisonResponse.model_validate(
+            get_band_masks_canonical_comparison()
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -411,11 +428,17 @@ def band_masks_canonical_comparison() -> dict:
         ) from exc
 
 
-@router.get("/band-masks/{scene_id}/{mask_id}")
-def band_mask_summary(scene_id: str, mask_id: str) -> dict:
+@router.get(
+    "/band-masks/{scene_id}/{mask_id}",
+    response_model=BandMaskSummaryResponse,
+    response_model_exclude_none=True,
+)
+def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
     from app.services.content import get_band_mask_summary
     try:
-        return get_band_mask_summary(scene_id, mask_id)
+        return BandMaskSummaryResponse.model_validate(
+            get_band_mask_summary(scene_id, mask_id)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -423,11 +446,17 @@ def band_mask_summary(scene_id: str, mask_id: str) -> dict:
         ) from exc
 
 
-@router.get("/band-masks-hidsag")
-def band_masks_hidsag_index() -> dict:
+@router.get(
+    "/band-masks-hidsag",
+    response_model=BandMasksHidsagIndexResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_hidsag_index() -> BandMasksHidsagIndexResponse:
     from app.services.content import get_band_masks_hidsag_index
     try:
-        return get_band_masks_hidsag_index()
+        return BandMasksHidsagIndexResponse.model_validate(
+            get_band_masks_hidsag_index()
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -436,11 +465,19 @@ def band_masks_hidsag_index() -> dict:
         ) from exc
 
 
-@router.get("/band-masks-hidsag/{subset_code}/{mask_id}")
-def band_masks_hidsag_summary(subset_code: str, mask_id: str) -> dict:
+@router.get(
+    "/band-masks-hidsag/{subset_code}/{mask_id}",
+    response_model=BandMaskHidsagSummaryResponse,
+    response_model_exclude_none=True,
+)
+def band_masks_hidsag_summary(
+    subset_code: str, mask_id: str
+) -> BandMaskHidsagSummaryResponse:
     from app.services.content import get_band_masks_hidsag_summary
     try:
-        return get_band_masks_hidsag_summary(subset_code, mask_id)
+        return BandMaskHidsagSummaryResponse.model_validate(
+            get_band_masks_hidsag_summary(subset_code, mask_id)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { PageFallback } from "@/components/PageFallback";
+import { CommandPalette } from "@/components/CommandPalette";
 
 const Overview = lazy(() => import("@/pages/Overview"));
 const Methodology = lazy(() => import("@/pages/Methodology"));
@@ -27,6 +28,7 @@ export function App() {
       style={{ backgroundColor: "var(--color-bg)", color: "var(--color-fg)" }}
     >
       <Header />
+      <CommandPalette />
       <main className="flex-1 w-full">
         <Suspense fallback={<PageFallback />}>
           <Routes>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,301 @@
+/**
+ * Global Ctrl+K (⌘K on macOS) command palette over the app surface.
+ *
+ * Indexes:
+ *   - the 5 top-level pages (Overview, Methodology, Databases,
+ *     Workspace, Benchmarks)
+ *   - the 4 Methodology sub-pages
+ *   - the 28 Workspace tabs via EXPLORE_PHASES
+ *   - the 6 labelled scenes (jump straight to /workspace?scene=…)
+ *
+ * The palette is overlay-modal (z-50, fixed inset, dimmed backdrop)
+ * with a fuzzy substring filter and keyboard navigation
+ * (Arrow Up/Down, Enter, Esc). Closing on backdrop click and on
+ * navigation. Accessibility: role=dialog with aria-modal,
+ * aria-labelledby; the input is autofocused.
+ *
+ * Source of truth for the tab list is `pages/workspace/state/tabs.ts`
+ * so the palette stays in sync with the navigation source.
+ */
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate } from "react-router-dom";
+
+import { EXPLORE_PHASES } from "@/pages/workspace/state/tabs";
+
+type CommandItem = {
+  /** Stable id, used as React key. */
+  id: string;
+  /** Short label shown in the list. */
+  label: string;
+  /** Secondary line (e.g. parent page / phase). */
+  group: string;
+  /** Route to push when this item is selected. */
+  href: string;
+};
+
+const LABELLED_SCENES: { id: string; label: string }[] = [
+  { id: "indian-pines-corrected", label: "Indian Pines" },
+  { id: "salinas-corrected", label: "Salinas" },
+  { id: "salinas-a-corrected", label: "Salinas-A" },
+  { id: "pavia-university", label: "Pavia U" },
+  { id: "kennedy-space-center", label: "Kennedy Space Center" },
+  { id: "botswana", label: "Botswana" },
+];
+
+const STATIC_ITEMS: CommandItem[] = [
+  { id: "page-overview", label: "Overview", group: "Page", href: "/" },
+  { id: "page-methodology", label: "Methodology", group: "Page",
+    href: "/methodology" },
+  { id: "page-databases", label: "Databases", group: "Page",
+    href: "/databases" },
+  { id: "page-workspace", label: "Workspace", group: "Page",
+    href: "/workspace" },
+  { id: "page-benchmarks", label: "Benchmarks", group: "Page",
+    href: "/benchmarks" },
+  // Methodology sub-pages (paths inferred from the route tree)
+  { id: "method-theory", label: "Theory", group: "Methodology",
+    href: "/methodology/theory" },
+  { id: "method-representations", label: "Representations",
+    group: "Methodology", href: "/methodology/representations" },
+  { id: "method-pipeline", label: "Pipeline", group: "Methodology",
+    href: "/methodology/pipeline" },
+  { id: "method-application", label: "Application", group: "Methodology",
+    href: "/methodology/application" },
+];
+
+function buildIndex(): CommandItem[] {
+  const items: CommandItem[] = [...STATIC_ITEMS];
+  // Workspace tabs
+  for (const phase of EXPLORE_PHASES) {
+    for (const tab of phase.tabs) {
+      items.push({
+        id: `tab-${tab.id}`,
+        label: tab.labelKey,
+        group: `Workspace › ${phase.label}`,
+        href: `/workspace?tab=${tab.id}`,
+      });
+    }
+  }
+  // Direct scene shortcuts
+  for (const scene of LABELLED_SCENES) {
+    items.push({
+      id: `scene-${scene.id}`,
+      label: `Open ${scene.label}`,
+      group: "Scene",
+      href: `/workspace?scene=${scene.id}`,
+    });
+  }
+  return items;
+}
+
+function fuzzyMatch(item: CommandItem, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    item.label.toLowerCase().includes(q) ||
+    item.group.toLowerCase().includes(q) ||
+    item.href.toLowerCase().includes(q)
+  );
+}
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIdx, setActiveIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const navigate = useNavigate();
+
+  const index = useMemo(() => buildIndex(), []);
+  const results = useMemo(
+    () => index.filter((i) => fuzzyMatch(i, query)),
+    [index, query],
+  );
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setActiveIdx(0);
+  }, []);
+
+  const choose = useCallback(
+    (item: CommandItem | undefined) => {
+      if (!item) return;
+      close();
+      navigate(item.href);
+    },
+    [close, navigate],
+  );
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const tgt = e.target as HTMLElement | null;
+      const inField =
+        tgt &&
+        (tgt.tagName === "INPUT" ||
+          tgt.tagName === "TEXTAREA" ||
+          tgt.tagName === "SELECT" ||
+          tgt.isContentEditable);
+      // Ctrl+K / Cmd+K opens the palette
+      if (
+        (e.key === "k" || e.key === "K") &&
+        (e.ctrlKey || e.metaKey)
+      ) {
+        // Only open when not already in a field — the user pressing
+        // Ctrl+K inside a textarea is editing.
+        if (!inField || open) {
+          e.preventDefault();
+          setOpen((v) => !v);
+        }
+        return;
+      }
+      if (!open) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.min(i + 1, results.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        choose(results[activeIdx]);
+        return;
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, results, activeIdx, choose, close]);
+
+  useEffect(() => {
+    setActiveIdx(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (open) {
+      // micro-defer so the modal mounts before focus
+      const t = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [open]);
+
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cmdk-title"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-24 px-4"
+      onClick={close}
+    >
+      <div
+        className="absolute inset-0"
+        style={{
+          backgroundColor: "color-mix(in srgb, var(--color-bg) 70%, transparent)",
+          backdropFilter: "blur(4px)",
+        }}
+      />
+      <div
+        className="relative rounded-xl border w-full max-w-[640px] overflow-hidden"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.25)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="cmdk-title" className="sr-only">
+          Command palette
+        </h2>
+        <div
+          className="px-4 py-3 border-b"
+          style={{ borderColor: "var(--color-border)" }}
+        >
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Jump to page, tab, or scene…  (Ctrl+K to toggle)"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full bg-transparent outline-none text-sm"
+            style={{ color: "var(--color-fg)" }}
+            aria-label="Search commands"
+          />
+        </div>
+        <ul
+          role="listbox"
+          aria-label="Command results"
+          className="max-h-[360px] overflow-y-auto"
+        >
+          {results.length === 0 && (
+            <li
+              className="px-4 py-3 text-sm"
+              style={{ color: "var(--color-fg-faint)" }}
+            >
+              No matches.
+            </li>
+          )}
+          {results.map((item, idx) => (
+            <li key={item.id}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={idx === activeIdx}
+                onMouseEnter={() => setActiveIdx(idx)}
+                onClick={() => choose(item)}
+                className="w-full text-left px-4 py-2 text-sm flex items-baseline gap-3 transition-colors"
+                style={{
+                  backgroundColor:
+                    idx === activeIdx
+                      ? "var(--color-accent-soft)"
+                      : "transparent",
+                  color: "var(--color-fg)",
+                }}
+              >
+                <span className="font-medium">{item.label}</span>
+                <span
+                  className="text-[11px]"
+                  style={{ color: "var(--color-fg-faint)" }}
+                >
+                  {item.group}
+                </span>
+                <span
+                  className="ml-auto text-[10.5px] font-mono"
+                  style={{ color: "var(--color-fg-faint)" }}
+                >
+                  {item.href}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div
+          className="px-4 py-2 border-t text-[10.5px] flex gap-3"
+          style={{
+            borderColor: "var(--color-border)",
+            color: "var(--color-fg-faint)",
+          }}
+        >
+          <span>↑ ↓ navigate</span>
+          <span>↵ open</span>
+          <span>Esc close</span>
+          <span className="ml-auto">{results.length} item{results.length === 1 ? "" : "s"}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -35,6 +35,10 @@ import {
 import { ExploreNav } from "./workspace/components/ExploreNav";
 import { TabEmpty } from "./workspace/components/TabStates";
 import {
+  RecentlyViewed,
+  useTrackRecentScene,
+} from "./workspace/components/RecentlyViewed";
+import {
   type RoutedPrediction,
   computeRoutedPrediction,
 } from "./workspace/helpers/routedPrediction";
@@ -621,6 +625,10 @@ function ExploreStep({
   );
   const [showHelp, setShowHelp] = useState<boolean>(false);
 
+  // Track (scene, rep) in localStorage so RecentlyViewed can render
+  // jump-back chips on subsequent visits.
+  const recentHistory = useTrackRecentScene(subsetId, rep);
+
   // Reset selectedTopic + tab when the user switches scene or rep.
   // Topic IDs are not portable across scenes (topic 3 on Pavia U is
   // a different cluster than topic 3 on Indian Pines); a stale topic
@@ -973,6 +981,11 @@ function ExploreStep({
           <SceneQuickSwitch
             currentScene={subsetId!}
             onSwitch={(s) => onSwitchScene(s)}
+          />
+          <RecentlyViewed
+            currentScene={subsetId}
+            currentRep={rep}
+            history={recentHistory}
           />
           <SceneBriefingHero subsetId={subsetId!} rep={rep} />
 

--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -200,6 +200,53 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
+      <Section
+        id="axis-crosswalk"
+        title="F-axes (paper) ↔ B-axes (wiki / web app)"
+        lead="The companion paper introduces a twelve-axis Framework (F-1..F-12). This site and the wiki use a different B-1..B-12 taxonomy that predates the paper. The two share three concepts under different ordinals; the crosswalk below makes the mapping explicit."
+      >
+        <p>
+          Both taxonomies are kept on purpose: the wiki's B-axes are the
+          empirical evaluation battery the project ran across ~150
+          iterative cycles; the paper's F-axes are the formal twelve-axis
+          framework that a journal reviewer reads. Pick the taxonomy that
+          fits the audience.
+        </p>
+        <div className="mt-4 overflow-x-auto">
+          <table
+            className="w-full text-sm border-collapse"
+            style={{ borderColor: "var(--color-border)" }}
+          >
+            <thead>
+              <tr style={{ backgroundColor: "var(--color-panel)" }}>
+                <th className="text-left px-3 py-2 border" style={{ borderColor: "var(--color-border)" }}>F (paper)</th>
+                <th className="text-left px-3 py-2 border" style={{ borderColor: "var(--color-border)" }}>Paper axis name</th>
+                <th className="text-left px-3 py-2 border" style={{ borderColor: "var(--color-border)" }}>B (wiki)</th>
+                <th className="text-left px-3 py-2 border" style={{ borderColor: "var(--color-border)" }}>Wiki axis name</th>
+                <th className="text-left px-3 py-2 border" style={{ borderColor: "var(--color-border)" }}>Workspace surface</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-1</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Classification (hierarchical Bayesian)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>B-1</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Linear probe panel</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › probe / Benchmarks</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-2</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Coherence (c_v, NPMI, U-Mass)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(not a B-axis)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › topics (top-words panel)</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-3</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Seed stability</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>B-6</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Seed stability</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › stability / deep</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-4</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Capacity sensitivity (K-sweep)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(not a B-axis)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › qkexplore</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-5</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Band-mask robustness</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(not a B-axis)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › bandmask</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-6</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Cross-method agreement</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(not a B-axis)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › agreement</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-7</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Topic–label coupling</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(not a B-axis)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › topiclabel / interpret</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-8</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Per-topic Hungarian identity</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(not a B-axis)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › bandmask (Hungarian panel)</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-9</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>HIDSAG preprocessing stability</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(not a B-axis)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Benchmarks (HIDSAG cross-prep)</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-10</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Cross-scene topic transfer</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>B-8</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Cross-scene transfer</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › robust</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-11</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Rate–distortion of θ</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>B-2</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Rate-distortion curve</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Workspace › metrics</td></tr>
+              <tr><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>F-12</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>External baseline (literature OA)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>—</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>(deferred in paper Suppl F)</td><td className="px-3 py-1.5 border" style={{ borderColor: "var(--color-border)" }}>Benchmarks (literature panel)</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-4 text-sm" style={{ color: "var(--color-fg-faint)" }}>
+          Wiki-only B-axes not in the paper: B-3 topic-routed classifier, B-4 mutual information, B-5 embedded baseline, B-7 USGS spectral library alignment, B-9 anomaly detection, B-10 spatial coherence, B-11 endmember baseline, B-12 LLM tea-leaves. These remain part of the project's evaluation battery but were not included in the twelve-axis paper framework.
+        </p>
+      </Section>
+
       <Section id="see-also" title="How to continue">
         <p>
           The Workspace lets you <em>apply</em> a model to a specific document

--- a/frontend/src/pages/workspace/components/RecentlyViewed.tsx
+++ b/frontend/src/pages/workspace/components/RecentlyViewed.tsx
@@ -1,0 +1,153 @@
+/**
+ * Recently-viewed-scenes chip strip for the Workspace > Explore step.
+ *
+ * Persists the last 5 (scene, rep) tuples to localStorage and shows
+ * them as small clickable chips below SceneQuickSwitch. Researchers
+ * frequently want to flip back to "the last scene I had open with
+ * topic 4 selected" — this affordance does not yet exist (#442 P1).
+ *
+ * The history is updated by `useTrackRecentScene` which the
+ * ExploreStep wrapper calls with the current (scene, rep) tuple on
+ * mount + on change. The chips render only when the persisted set
+ * is non-empty and contains at least one entry other than the
+ * currently-active scene.
+ */
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const STORAGE_KEY = "caos-lda-hsi.recent-scenes";
+const MAX_ENTRIES = 5;
+
+export type RecentEntry = {
+  scene: string;
+  rep: string;
+  ts: number;
+};
+
+const SCENE_LABEL: Record<string, string> = {
+  "indian-pines-corrected": "Indian Pines",
+  "salinas-corrected": "Salinas",
+  "salinas-a-corrected": "Salinas-A",
+  "pavia-university": "Pavia U",
+  "kennedy-space-center": "KSC",
+  "botswana": "Botswana",
+  GEOMET: "GEOMET",
+  MINERAL1: "MINERAL1",
+  MINERAL2: "MINERAL2",
+  GEOCHEM: "GEOCHEM",
+  PORPHYRY: "PORPHYRY",
+};
+
+function loadHistory(): RecentEntry[] {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is RecentEntry =>
+        typeof e === "object" &&
+        e !== null &&
+        typeof (e as RecentEntry).scene === "string" &&
+        typeof (e as RecentEntry).rep === "string" &&
+        typeof (e as RecentEntry).ts === "number",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(history: RecentEntry[]) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  } catch {
+    /* quota exceeded; silently drop */
+  }
+}
+
+/** Track the active (scene, rep) and push it to the localStorage
+ *  history when it changes. Returns the current history (used by
+ *  RecentlyViewed to render chips). */
+export function useTrackRecentScene(
+  scene: string | null,
+  rep: string | null,
+): RecentEntry[] {
+  const [history, setHistory] = useState<RecentEntry[]>(() => loadHistory());
+
+  useEffect(() => {
+    if (!scene || !rep) return;
+    setHistory((prev) => {
+      const filtered = prev.filter((e) => !(e.scene === scene && e.rep === rep));
+      const next: RecentEntry[] = [
+        { scene, rep, ts: Date.now() },
+        ...filtered,
+      ].slice(0, MAX_ENTRIES);
+      saveHistory(next);
+      return next;
+    });
+  }, [scene, rep]);
+
+  return history;
+}
+
+export function RecentlyViewed({
+  currentScene,
+  currentRep,
+  history,
+}: {
+  currentScene: string | null;
+  currentRep: string | null;
+  history: RecentEntry[];
+}) {
+  const navigate = useNavigate();
+  // Exclude the currently-active tuple — chip list is "things to
+  // jump BACK to", not "you are here".
+  const others = history.filter(
+    (e) => !(e.scene === currentScene && e.rep === currentRep),
+  );
+  if (others.length === 0) return null;
+  return (
+    <div
+      className="rounded-lg border p-2 mb-4 flex items-baseline gap-2 flex-wrap"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+      }}
+      role="group"
+      aria-label="Recently viewed scenes"
+    >
+      <span
+        className="text-[10.5px] uppercase tracking-widest font-semibold pr-2"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Recently viewed
+      </span>
+      {others.map((e) => {
+        const label = SCENE_LABEL[e.scene] ?? e.scene;
+        return (
+          <button
+            key={`${e.scene}|${e.rep}|${e.ts}`}
+            type="button"
+            onClick={() =>
+              navigate(`/workspace?scene=${encodeURIComponent(e.scene)}&rep=${encodeURIComponent(e.rep)}`)
+            }
+            className="rounded border px-2.5 py-1 text-[12px] inline-flex items-baseline gap-1.5 transition-colors hover:opacity-90"
+            style={{
+              borderColor: "var(--color-border)",
+              color: "var(--color-fg-subtle)",
+              backgroundColor: "transparent",
+            }}
+          >
+            <span className="font-mono">{label}</span>
+            <span
+              className="text-[10.5px]"
+              style={{ color: "var(--color-fg-faint)" }}
+            >
+              · {e.rep}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Five cycles since the c224-c231 deploy chain (PR #456):

- **c232** Global \`Ctrl+K\` command palette (#457) — indexes Workspace tabs (6 phases × tabs) + 5 top-level pages + 4 methodology sub-pages + 6 scene shortcuts. Closes a #442 navigation item.
- **c233** F↔B axis crosswalk (#458) — Methodology / Application gains a 12-row mapping table between wiki B-axes and paper F-axes. Closes a #442 documentation item.
- **c234** Recently-viewed scenes chip strip (#459) — localStorage-persisted last-5 (scene, rep) chips below SceneQuickSwitch + \`useTrackRecentScene\` hook. Closes a #442 ergonomics item.
- **c236** Pydantic response models for the band-masks family (#460) — 5 routes (\`/band-masks\`, \`/band-masks/canonical-comparison\`, \`/band-masks/{scene}/{mask}\`, \`/band-masks-hidsag\`, \`/band-masks-hidsag/{subset}/{mask}\`) now ship typed responses; OpenAPI gains 11 new schema components. Closes one P1 item of #440.

## Test plan

- [x] Each task PR independently merged + smoke 109/109 verified locally for c236.
- [ ] \`update.sh\` on Hetzner — pull, install, frontend build, restart service.
- [ ] Service active + RSS healthy.
- [ ] Smoke 109/109 against https://lda-hsi.fasl-work.com.
- [ ] Prod entry bundle contains command-palette + recently-viewed + crosswalk markers.

Closes one item each on #440, #442 (×3); refs none-broken.