### PR TITLE
Cycle 240: hoist 56 per-request lazy imports to module top (#440)

### DIFF
--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -49,30 +49,88 @@ from app.models.schemas import (
 from app.services.content import (
     get_analysis,
     get_app_payload,
+    get_band_mask_summary,
+    get_band_masks_canonical_comparison,
+    get_band_masks_hidsag_index,
+    get_band_masks_hidsag_summary,
+    get_band_masks_index,
+    get_bayesian_classification_labelled,
+    get_bayesian_classification_labelled_deep,
+    get_bayesian_comparison,
+    get_classical_seed_stability,
     get_corpus_previews,
     get_corpus_recipes,
+    get_cross_method_agreement,
+    get_cross_scene_transfer,
     get_data_families,
     get_datasets,
+    get_deep_anomaly,
+    get_deep_seed_stability,
     get_demo,
+    get_derived_manifest,
+    get_dmr_lda_hidsag,
+    get_eda_hidsag,
+    get_eda_per_scene,
+    get_embedded_baseline,
+    get_endmember_baseline,
+    get_exploration_views,
+    get_external_validation_hidsag_methods,
+    get_external_validation_literature,
     get_field_samples,
+    get_grouping,
+    get_groupings_index,
     get_hidsag_band_quality,
+    get_hidsag_cross_preprocessing_stability,
     get_hidsag_curated_subset,
     get_hidsag_preprocessing_sensitivity,
     get_hidsag_region_documents,
     get_hidsag_subset_inventory,
     get_interactive_subsets,
+    get_interpretability,
+    get_lda_sweep,
+    get_linear_probe_panel,
+    get_llm_tea_leaves,
     get_local_core_benchmarks,
     get_local_dataset_inventory,
     get_local_validation_matrix,
+    get_method_statistics,
+    get_method_statistics_hidsag,
     get_methodology,
+    get_mutual_information,
+    get_mutual_information_hidsag,
+    get_narratives,
+    get_neural_topic_comparison,
+    get_neural_topic_seed_stability,
+    get_optuna_search,
     get_overview,
+    get_quantization_sensitivity,
+    get_rate_distortion_curve,
     get_real_scenes,
+    get_representation,
+    get_representations_index,
     get_segmentation_baselines,
+    get_spatial_validation,
+    get_spectral_browser_metadata,
+    get_spectral_density_manifest,
     get_spectral_library,
     get_subset_card,
     get_subset_cards_index,
-    get_exploration_views,
-    get_method_statistics,
+    get_super_topics,
+    get_topic_anomaly,
+    get_topic_routed_classifier,
+    get_topic_routed_deep_gate,
+    get_topic_spatial_continuous,
+    get_topic_spatial_full,
+    get_topic_stability,
+    get_topic_to_data,
+    get_topic_to_library,
+    get_topic_to_usgs_v7,
+    get_topic_variant,
+    get_topic_variants_index,
+    get_topic_views,
+    get_validation_blocks,
+    get_wordification,
+    get_wordifications_index,
 )
 
 
@@ -265,7 +323,6 @@ def _typed_or_404(model, loader, *args, hint: str):
 
 @router.get("/manifest")
 def derived_manifest() -> dict:
-    from app.services.content import get_derived_manifest
     return _serve_or_404(
         get_derived_manifest,
         hint="manifest not generated yet; run scripts/local.* curate-for-web",
@@ -274,7 +331,6 @@ def derived_manifest() -> dict:
 
 @router.get("/eda/per-scene/{scene_id}")
 def eda_per_scene(scene_id: str) -> dict:
-    from app.services.content import get_eda_per_scene
     return _serve_or_404(
         get_eda_per_scene,
         scene_id,
@@ -288,7 +344,6 @@ def eda_per_scene(scene_id: str) -> dict:
     response_model_exclude_none=True,
 )
 def topic_views(scene_id: str) -> TopicViewsResponse:
-    from app.services.content import get_topic_views
     return _typed_or_404(
         TopicViewsResponse,
         get_topic_views,
@@ -303,7 +358,6 @@ def topic_views(scene_id: str) -> TopicViewsResponse:
     response_model_exclude_none=True,
 )
 def topic_to_data(scene_id: str) -> TopicToDataResponse:
-    from app.services.content import get_topic_to_data
     return _typed_or_404(
         TopicToDataResponse,
         get_topic_to_data,
@@ -314,7 +368,6 @@ def topic_to_data(scene_id: str) -> TopicToDataResponse:
 
 @router.get("/spectral-browser/{scene_id}")
 def spectral_browser(scene_id: str) -> dict:
-    from app.services.content import get_spectral_browser_metadata
     return _serve_or_404(
         get_spectral_browser_metadata,
         scene_id,
@@ -324,7 +377,6 @@ def spectral_browser(scene_id: str) -> dict:
 
 @router.get("/spectral-density/{scene_id}")
 def spectral_density(scene_id: str) -> dict:
-    from app.services.content import get_spectral_density_manifest
     return _serve_or_404(
         get_spectral_density_manifest,
         scene_id,
@@ -338,7 +390,6 @@ def spectral_density(scene_id: str) -> dict:
     response_model_exclude_none=True,
 )
 def validation_blocks(scene_id: str) -> ValidationBlocksResponse:
-    from app.services.content import get_validation_blocks
     return _typed_or_404(
         ValidationBlocksResponse,
         get_validation_blocks,
@@ -349,7 +400,6 @@ def validation_blocks(scene_id: str) -> ValidationBlocksResponse:
 
 @router.get("/eda/hidsag/{subset_code}")
 def eda_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_eda_hidsag
     return _serve_or_404(
         get_eda_hidsag,
         subset_code,
@@ -359,7 +409,6 @@ def eda_hidsag(subset_code: str) -> dict:
 
 @router.get("/topic-to-library/{scene_id}")
 def topic_to_library(scene_id: str) -> dict:
-    from app.services.content import get_topic_to_library
     return _serve_or_404(
         get_topic_to_library,
         scene_id,
@@ -373,7 +422,6 @@ def topic_to_library(scene_id: str) -> dict:
     response_model_exclude_none=True,
 )
 def spatial_validation(scene_id: str) -> SpatialValidationResponse:
-    from app.services.content import get_spatial_validation
     return _typed_or_404(
         SpatialValidationResponse,
         get_spatial_validation,
@@ -388,7 +436,6 @@ def spatial_validation(scene_id: str) -> SpatialValidationResponse:
     response_model_exclude_none=True,
 )
 def wordifications_index() -> WordificationsIndexResponse:
-    from app.services.content import get_wordifications_index
     return _typed_or_404(
         WordificationsIndexResponse,
         get_wordifications_index,
@@ -404,7 +451,6 @@ def wordifications_index() -> WordificationsIndexResponse:
 def wordification(
     scene_id: str, recipe: str, scheme: str, q: int
 ) -> WordificationResponse:
-    from app.services.content import get_wordification
     return _typed_or_404(
         WordificationResponse,
         get_wordification,
@@ -419,7 +465,6 @@ def wordification(
     response_model_exclude_none=True,
 )
 def band_masks_index() -> BandMasksIndexResponse:
-    from app.services.content import get_band_masks_index
     return _typed_or_404(
         BandMasksIndexResponse,
         get_band_masks_index,
@@ -436,7 +481,6 @@ def band_masks_index() -> BandMasksIndexResponse:
     response_model_exclude_none=True,
 )
 def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
-    from app.services.content import get_band_masks_canonical_comparison
     return _typed_or_404(
         BandMaskCanonicalComparisonResponse,
         get_band_masks_canonical_comparison,
@@ -453,7 +497,6 @@ def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
     response_model_exclude_none=True,
 )
 def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
-    from app.services.content import get_band_mask_summary
     return _typed_or_404(
         BandMaskSummaryResponse,
         get_band_mask_summary,
@@ -468,7 +511,6 @@ def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
     response_model_exclude_none=True,
 )
 def band_masks_hidsag_index() -> BandMasksHidsagIndexResponse:
-    from app.services.content import get_band_masks_hidsag_index
     return _typed_or_404(
         BandMasksHidsagIndexResponse,
         get_band_masks_hidsag_index,
@@ -487,7 +529,6 @@ def band_masks_hidsag_index() -> BandMasksHidsagIndexResponse:
 def band_masks_hidsag_summary(
     subset_code: str, mask_id: str
 ) -> BandMaskHidsagSummaryResponse:
-    from app.services.content import get_band_masks_hidsag_summary
     return _typed_or_404(
         BandMaskHidsagSummaryResponse,
         get_band_masks_hidsag_summary,
@@ -498,7 +539,6 @@ def band_masks_hidsag_summary(
 
 @router.get("/groupings")
 def groupings_index() -> dict:
-    from app.services.content import get_groupings_index
     return _serve_or_404(
         get_groupings_index,
         hint="groupings not generated yet; run scripts/local.* build-groupings",
@@ -507,7 +547,6 @@ def groupings_index() -> dict:
 
 @router.get("/groupings/{method}/{scene_id}")
 def grouping(method: str, scene_id: str) -> dict:
-    from app.services.content import get_grouping
     return _serve_or_404(
         get_grouping, method, scene_id,
         hint=f"grouping {method}/{scene_id} not generated yet",
@@ -516,7 +555,6 @@ def grouping(method: str, scene_id: str) -> dict:
 
 @router.get("/cross-method-agreement/{scene_id}")
 def cross_method_agreement(scene_id: str) -> dict:
-    from app.services.content import get_cross_method_agreement
     return _serve_or_404(
         get_cross_method_agreement, scene_id,
         hint=f"cross-method agreement for '{scene_id}' not generated yet",
@@ -525,7 +563,6 @@ def cross_method_agreement(scene_id: str) -> dict:
 
 @router.get("/method-statistics-hidsag/{subset_code}")
 def method_statistics_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_method_statistics_hidsag
     return _serve_or_404(
         get_method_statistics_hidsag, subset_code,
         hint=f"method statistics for HIDSAG '{subset_code}' not generated yet",
@@ -534,7 +571,6 @@ def method_statistics_hidsag(subset_code: str) -> dict:
 
 @router.get("/external-validation/{scene_id}/literature")
 def external_validation_literature(scene_id: str) -> dict:
-    from app.services.content import get_external_validation_literature
     return _serve_or_404(
         get_external_validation_literature, scene_id,
         hint=f"literature alignment for '{scene_id}' not generated yet",
@@ -543,7 +579,6 @@ def external_validation_literature(scene_id: str) -> dict:
 
 @router.get("/external-validation/hidsag/{subset_code}/methods")
 def external_validation_hidsag_methods(subset_code: str) -> dict:
-    from app.services.content import get_external_validation_hidsag_methods
     return _serve_or_404(
         get_external_validation_hidsag_methods, subset_code,
         hint=f"HIDSAG method summary for '{subset_code}' not generated yet",
@@ -552,7 +587,6 @@ def external_validation_hidsag_methods(subset_code: str) -> dict:
 
 @router.get("/narratives/{scene_id}")
 def narratives(scene_id: str) -> dict:
-    from app.services.content import get_narratives
     return _serve_or_404(
         get_narratives, scene_id,
         hint=f"narrative for '{scene_id}' not generated yet",
@@ -561,7 +595,6 @@ def narratives(scene_id: str) -> dict:
 
 @router.get("/interpretability/{scene_id}/{card_type}")
 def interpretability(scene_id: str, card_type: str) -> dict:
-    from app.services.content import get_interpretability
     if card_type not in ("topic_cards", "band_cards", "document_cards"):
         raise HTTPException(status_code=400, detail="card_type must be topic_cards | band_cards | document_cards")
     return _serve_or_404(
@@ -572,7 +605,6 @@ def interpretability(scene_id: str, card_type: str) -> dict:
 
 @router.get("/quantization-sensitivity/{scene_id}")
 def quantization_sensitivity(scene_id: str) -> dict:
-    from app.services.content import get_quantization_sensitivity
     return _serve_or_404(
         get_quantization_sensitivity, scene_id,
         hint=f"quantization sensitivity for '{scene_id}' not generated yet",
@@ -581,7 +613,6 @@ def quantization_sensitivity(scene_id: str) -> dict:
 
 @router.get("/topic-variants")
 def topic_variants_index() -> dict:
-    from app.services.content import get_topic_variants_index
     return _serve_or_404(
         get_topic_variants_index,
         hint="topic variants not generated yet",
@@ -590,7 +621,6 @@ def topic_variants_index() -> dict:
 
 @router.get("/topic-variants/{variant}/{scene_id}")
 def topic_variant(variant: str, scene_id: str) -> dict:
-    from app.services.content import get_topic_variant
     return _serve_or_404(
         get_topic_variant, variant, scene_id,
         hint=f"topic variant {variant}/{scene_id} not generated yet",
@@ -599,7 +629,6 @@ def topic_variant(variant: str, scene_id: str) -> dict:
 
 @router.get("/lda-sweep/{scene_id}")
 def lda_sweep(scene_id: str) -> dict:
-    from app.services.content import get_lda_sweep
     return _serve_or_404(
         get_lda_sweep, scene_id,
         hint=f"lda_sweep for '{scene_id}' not generated yet",
@@ -608,7 +637,6 @@ def lda_sweep(scene_id: str) -> dict:
 
 @router.get("/representations")
 def representations_index() -> dict:
-    from app.services.content import get_representations_index
     return _serve_or_404(
         get_representations_index,
         hint="representations not generated yet",
@@ -617,7 +645,6 @@ def representations_index() -> dict:
 
 @router.get("/representations/{method}/{scene_id}")
 def representation(method: str, scene_id: str) -> dict:
-    from app.services.content import get_representation
     return _serve_or_404(
         get_representation, method, scene_id,
         hint=f"representation {method}/{scene_id} not generated yet",
@@ -626,7 +653,6 @@ def representation(method: str, scene_id: str) -> dict:
 
 @router.get("/dmr-lda-hidsag/{subset_code}")
 def dmr_lda_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_dmr_lda_hidsag
     return _serve_or_404(
         get_dmr_lda_hidsag, subset_code,
         hint=f"dmr_lda_hidsag for '{subset_code}' not generated yet",
@@ -635,11 +661,6 @@ def dmr_lda_hidsag(subset_code: str) -> dict:
 
 @router.get("/bayesian-comparison/{task_type}")
 def bayesian_comparison(task_type: str) -> dict:
-    from app.services.content import (
-        get_bayesian_classification_labelled,
-        get_bayesian_classification_labelled_deep,
-        get_bayesian_comparison,
-    )
     if task_type == "classification-labelled":
         return _serve_or_404(
             get_bayesian_classification_labelled,
@@ -663,7 +684,6 @@ def bayesian_comparison(task_type: str) -> dict:
 
 @router.get("/optuna-search/{scene_id}")
 def optuna_search(scene_id: str) -> dict:
-    from app.services.content import get_optuna_search
     return _serve_or_404(
         get_optuna_search, scene_id,
         hint=f"optuna_search for '{scene_id}' not generated yet",
@@ -672,7 +692,6 @@ def optuna_search(scene_id: str) -> dict:
 
 @router.get("/linear-probe-panel/{scene_id}")
 def linear_probe_panel(scene_id: str) -> dict:
-    from app.services.content import get_linear_probe_panel
     return _serve_or_404(
         get_linear_probe_panel, scene_id,
         hint=f"linear_probe_panel for '{scene_id}' not generated yet",
@@ -681,7 +700,6 @@ def linear_probe_panel(scene_id: str) -> dict:
 
 @router.get("/mutual-information/{scene_id}")
 def mutual_information(scene_id: str) -> dict:
-    from app.services.content import get_mutual_information
     return _serve_or_404(
         get_mutual_information, scene_id,
         hint=f"mutual_information for '{scene_id}' not generated yet",
@@ -690,7 +708,6 @@ def mutual_information(scene_id: str) -> dict:
 
 @router.get("/mutual-information/hidsag/{subset_code}")
 def mutual_information_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_mutual_information_hidsag
     return _serve_or_404(
         get_mutual_information_hidsag, subset_code,
         hint=f"mutual_information for HIDSAG '{subset_code}' not generated yet",
@@ -699,7 +716,6 @@ def mutual_information_hidsag(subset_code: str) -> dict:
 
 @router.get("/rate-distortion-curve/{scene_id}")
 def rate_distortion_curve(scene_id: str) -> dict:
-    from app.services.content import get_rate_distortion_curve
     return _serve_or_404(
         get_rate_distortion_curve, scene_id,
         hint=f"rate_distortion_curve for '{scene_id}' not generated yet",
@@ -708,7 +724,6 @@ def rate_distortion_curve(scene_id: str) -> dict:
 
 @router.get("/topic-routed-classifier/{scene_id}")
 def topic_routed_classifier(scene_id: str) -> dict:
-    from app.services.content import get_topic_routed_classifier
     return _serve_or_404(
         get_topic_routed_classifier, scene_id,
         hint=f"topic_routed_classifier for '{scene_id}' not generated yet",
@@ -717,7 +732,6 @@ def topic_routed_classifier(scene_id: str) -> dict:
 
 @router.get("/topic-routed-deep-gate/{scene_id}")
 def topic_routed_deep_gate(scene_id: str) -> dict:
-    from app.services.content import get_topic_routed_deep_gate
     return _serve_or_404(
         get_topic_routed_deep_gate, scene_id,
         hint=f"topic_routed_deep_gate for '{scene_id}' not generated yet",
@@ -726,7 +740,6 @@ def topic_routed_deep_gate(scene_id: str) -> dict:
 
 @router.get("/neural-topic-comparison/{scene_id}")
 def neural_topic_comparison(scene_id: str) -> dict:
-    from app.services.content import get_neural_topic_comparison
     return _serve_or_404(
         get_neural_topic_comparison, scene_id,
         hint=f"neural_topic_comparison for '{scene_id}' not generated yet",
@@ -735,7 +748,6 @@ def neural_topic_comparison(scene_id: str) -> dict:
 
 @router.get("/neural-topic-seed-stability/{scene_id}")
 def neural_topic_seed_stability(scene_id: str) -> dict:
-    from app.services.content import get_neural_topic_seed_stability
     return _serve_or_404(
         get_neural_topic_seed_stability, scene_id,
         hint=f"neural_topic_seed_stability for '{scene_id}' not generated yet",
@@ -744,7 +756,6 @@ def neural_topic_seed_stability(scene_id: str) -> dict:
 
 @router.get("/embedded-baseline/{scene_id}")
 def embedded_baseline(scene_id: str) -> dict:
-    from app.services.content import get_embedded_baseline
     return _serve_or_404(
         get_embedded_baseline, scene_id,
         hint=f"embedded_baseline for '{scene_id}' not generated yet",
@@ -753,7 +764,6 @@ def embedded_baseline(scene_id: str) -> dict:
 
 @router.get("/topic-stability/{scene_id}")
 def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
-    from app.services.content import get_topic_stability
     try:
         return get_topic_stability(scene_id, k_offset=k_offset)
     except FileNotFoundError as exc:
@@ -765,7 +775,6 @@ def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
 
 @router.get("/deep-seed-stability/{scene_id}")
 def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 7) -> dict:
-    from app.services.content import get_deep_seed_stability
     try:
         return get_deep_seed_stability(scene_id, method=method, n_seeds=n_seeds)
     except FileNotFoundError as exc:
@@ -777,7 +786,6 @@ def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 
 
 @router.get("/deep-anomaly/{scene_id}")
 def deep_anomaly(scene_id: str) -> dict:
-    from app.services.content import get_deep_anomaly
     return _serve_or_404(
         get_deep_anomaly, scene_id,
         hint=f"deep_anomaly for '{scene_id}' not generated yet",
@@ -786,7 +794,6 @@ def deep_anomaly(scene_id: str) -> dict:
 
 @router.get("/classical-seed-stability/{scene_id}")
 def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
-    from app.services.content import get_classical_seed_stability
     try:
         return get_classical_seed_stability(scene_id, method=method)
     except FileNotFoundError as exc:
@@ -798,7 +805,6 @@ def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
 
 @router.get("/topic-to-usgs-v7/{scene_id}")
 def topic_to_usgs_v7(scene_id: str) -> dict:
-    from app.services.content import get_topic_to_usgs_v7
     return _serve_or_404(
         get_topic_to_usgs_v7, scene_id,
         hint=f"topic_to_usgs_v7 for '{scene_id}' not generated yet",
@@ -807,7 +813,6 @@ def topic_to_usgs_v7(scene_id: str) -> dict:
 
 @router.get("/hidsag-cross-preprocessing-stability/{subset_code}")
 def hidsag_cross_preprocessing_stability(subset_code: str) -> dict:
-    from app.services.content import get_hidsag_cross_preprocessing_stability
     return _serve_or_404(
         get_hidsag_cross_preprocessing_stability, subset_code,
         hint=f"hidsag_cross_preprocessing_stability for '{subset_code}' not generated yet",
@@ -816,7 +821,6 @@ def hidsag_cross_preprocessing_stability(subset_code: str) -> dict:
 
 @router.get("/topic-anomaly/{scene_id}")
 def topic_anomaly(scene_id: str) -> dict:
-    from app.services.content import get_topic_anomaly
     return _serve_or_404(
         get_topic_anomaly, scene_id,
         hint=f"topic_anomaly for '{scene_id}' not generated yet",
@@ -825,7 +829,6 @@ def topic_anomaly(scene_id: str) -> dict:
 
 @router.get("/topic-spatial-continuous/{scene_id}")
 def topic_spatial_continuous(scene_id: str) -> dict:
-    from app.services.content import get_topic_spatial_continuous
     return _serve_or_404(
         get_topic_spatial_continuous, scene_id,
         hint=f"topic_spatial_continuous for '{scene_id}' not generated yet",
@@ -834,7 +837,6 @@ def topic_spatial_continuous(scene_id: str) -> dict:
 
 @router.get("/topic-spatial-full/{scene_id}")
 def topic_spatial_full(scene_id: str) -> dict:
-    from app.services.content import get_topic_spatial_full
     return _serve_or_404(
         get_topic_spatial_full, scene_id,
         hint=f"topic_spatial_full for '{scene_id}' not generated yet",
@@ -843,7 +845,6 @@ def topic_spatial_full(scene_id: str) -> dict:
 
 @router.get("/endmember-baseline/{scene_id}")
 def endmember_baseline(scene_id: str) -> dict:
-    from app.services.content import get_endmember_baseline
     return _serve_or_404(
         get_endmember_baseline, scene_id,
         hint=f"endmember_baseline for '{scene_id}' not generated yet",
@@ -852,7 +853,6 @@ def endmember_baseline(scene_id: str) -> dict:
 
 @router.get("/llm-tea-leaves/{scene_id}")
 def llm_tea_leaves(scene_id: str) -> dict:
-    from app.services.content import get_llm_tea_leaves
     return _serve_or_404(
         get_llm_tea_leaves, scene_id,
         hint=(
@@ -864,7 +864,6 @@ def llm_tea_leaves(scene_id: str) -> dict:
 
 @router.get("/super-topics")
 def super_topics() -> dict:
-    from app.services.content import get_super_topics
     return _serve_or_404(
         get_super_topics,
         hint="super_topics not generated yet",
@@ -873,7 +872,6 @@ def super_topics() -> dict:
 
 @router.get("/cross-scene-transfer")
 def cross_scene_transfer() -> dict:
-    from app.services.content import get_cross_scene_transfer
     return _serve_or_404(
         get_cross_scene_transfer,
         hint="cross_scene_transfer not generated yet",


### PR DESCRIPTION
## Summary

Closes issue #440 P1 item 1.4 (\"Per-request lazy imports inside 50+
handlers\"). \`content.py\` used to perform a fresh
\`from app.services.content import get_xxx\` inside every handler body
— measurable latency per request, and no visibility from linters
or IDEs.

## Refactor

- Consolidate all 56 unique \`get_*\` imports into the existing
  module-top \`from app.services.content import (...)\` block,
  alphabetised.
- Strip the 56 per-handler import statements.

## Test plan

- [x] Smoke harness 109/109 OK locally on :8111.

Closes #440 P1 item 1.4.