### PR TITLE
Cycle 241: CORS dev/prod origin split keyed on app_env (#440)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 APP_ENV=development
 APP_HOST=127.0.0.1
 APP_PORT=8105
-ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:8105,https://lda-hsi.fasl-work.com
+# CORS origins are now keyed on APP_ENV:
+#   - APP_ENV=production            -> uses PROD_ORIGINS (defaults below)
+#   - anything else (development)   -> uses DEV_ORIGINS  (defaults below)
+# To force a custom set on a one-off host, set ALLOWED_ORIGINS to a
+# comma-separated list; it takes precedence over both env-keyed lists.
+DEV_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:8105
+PROD_ORIGINS=https://lda-hsi.fasl-work.com
+# ALLOWED_ORIGINS=
 FRONTEND_DIST=frontend/dist
 DATA_DIR=data

--- a/app/config.py
+++ b/app/config.py
@@ -17,10 +17,20 @@ class Settings(BaseSettings):
     app_host: str = "127.0.0.1"
     app_port: int = 8105
 
-    allowed_origins: str = (
-        "http://localhost:5173,http://127.0.0.1:5173,"
-        "http://localhost:8105,https://lda-hsi.fasl-work.com"
+    # Dev origins (vite + uvicorn local). Used when app_env is anything
+    # other than "production".
+    dev_origins: str = (
+        "http://localhost:5173,http://127.0.0.1:5173,http://localhost:8105"
     )
+    # Prod origins. Used when app_env == "production". Locked down to the
+    # public URL so the live API does not advertise CORS access to
+    # localhost.
+    prod_origins: str = "https://lda-hsi.fasl-work.com"
+
+    # Back-compat: if a deployment still sets ALLOWED_ORIGINS, honour it
+    # verbatim instead of the env-keyed split. Leave the default empty
+    # so the new behaviour is opt-out, not opt-in.
+    allowed_origins: str = ""
 
     frontend_dist: str = "frontend/dist"
     data_dir: str = "data"
@@ -33,7 +43,13 @@ class Settings(BaseSettings):
 
     @property
     def origins(self) -> list[str]:
-        return [origin.strip() for origin in self.allowed_origins.split(",") if origin.strip()]
+        if self.allowed_origins.strip():
+            raw = self.allowed_origins
+        elif self.app_env.lower() == "production":
+            raw = self.prod_origins
+        else:
+            raw = self.dev_origins
+        return [origin.strip() for origin in raw.split(",") if origin.strip()]
 
     @property
     def frontend_dist_path(self) -> Path:


### PR DESCRIPTION
## Summary

Closes issue #440 P2 item 1.6. CORS used to allow both localhost
and the prod URL in every environment. Now keyed on \`app_env\`:

- \`dev_origins\` (default: localhost dev servers) when \`APP_ENV != production\`.
- \`prod_origins\` (default: https://lda-hsi.fasl-work.com) when \`APP_ENV = production\`.
- Optional \`allowed_origins\` env var still overrides both for one-off hosts.

## Test plan

- [x] 3 unit checks: dev default excludes prod; prod locks to single origin; ALLOWED_ORIGINS overrides.
- [x] Smoke 109/109 OK locally on :8112.

**Deploy note**: Hetzner systemd unit must set \`APP_ENV=production\`
for the lock-down to take effect; otherwise origins fall back to dev
defaults. Verify in c244 deploy block.

Closes #440 P2 item 1.6.