### PR TITLE
Cycle 242: bootstrap pytest scaffold + 24 happy-path tests (#440)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+# Pinned dev-only deps for the backend test suite (closes #440 P1
+# item 1.7). Keep in sync with the versions installed in the
+# developer venv; the prod systemd unit on Hetzner only installs
+# requirements.txt.
+pytest==8.4.2
+httpx==0.27.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for the backend test suite.
+
+Tests reuse the real `data/derived/*.json` artefacts produced by the
+pipeline — the smoke harness already proves they exist on a working
+deploy, and the test suite asserts router behaviour (status codes,
+response shapes) without recreating those payloads.
+
+This keeps the scaffold zero-config: `pytest` against a clean checkout
+of a developer machine that has run `bash scripts/local.sh build-*`
+once will pass.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="session")
+def client() -> TestClient:
+    """FastAPI TestClient bound to the live ASGI app.
+
+    Session-scoped so we pay the app-import cost once across the suite.
+    """
+    from app.main import app
+    return TestClient(app)

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -1,0 +1,46 @@
+"""Happy-path tests for the band-masks route family (c236 + c239)."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_band_masks_index_returns_24_entries(client: TestClient) -> None:
+    res = client.get("/api/band-masks")
+    assert res.status_code == 200
+    body = res.json()
+    assert "entries" in body
+    assert len(body["entries"]) == 24
+    assert "mask_definitions" in body
+    assert {"vnir", "swir", "no_water", "top_50_fisher"}.issubset(body["mask_definitions"].keys())
+
+
+def test_band_masks_canonical_comparison_has_24_entries(client: TestClient) -> None:
+    res = client.get("/api/band-masks/canonical-comparison")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["entries"]) == 24
+    sample = body["entries"][0]
+    assert "paired_ari_dominant_topics" in sample or "skipped" in sample
+
+
+def test_band_mask_summary_indian_pines_vnir(client: TestClient) -> None:
+    res = client.get("/api/band-masks/indian-pines-corrected/vnir")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == "indian-pines-corrected"
+    assert body["mask_id"] == "vnir"
+    assert body["topic_count"] == 12
+    assert body["n_bands_kept"] == 67
+
+
+def test_band_masks_hidsag_index(client: TestClient) -> None:
+    res = client.get("/api/band-masks-hidsag")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["modality"] == "swir_low"
+    assert len(body["entries"]) == 20
+
+
+def test_band_mask_unknown_returns_404(client: TestClient) -> None:
+    res = client.get("/api/band-masks/nonexistent-scene/vnir")
+    assert res.status_code == 404

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,25 @@
+"""Regression tests for security-sensitive behaviour (#440 P0)."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_spa_fallback_blocks_path_traversal(client: TestClient) -> None:
+    """c224 (PR #449) added a path-traversal guard to the SPA fallback.
+
+    A request whose path resolves outside the frontend dist must fall
+    through to index.html rather than serve the targeted file.
+    """
+    # The bypass attempt: ask for a file in the app/ package via traversal.
+    res = client.get("/../app/config.py")
+    assert res.status_code == 200
+    # Body must be the SPA shell, not the Python source.
+    body = res.text
+    assert "<!doctype html" in body.lower() or "<!DOCTYPE html" in body
+    assert "Settings(BaseSettings)" not in body, "path traversal must NOT leak app/config.py"
+
+
+def test_unknown_spa_path_serves_index(client: TestClient) -> None:
+    res = client.get("/some/non-existing/path")
+    assert res.status_code == 200
+    assert "<!doctype html" in res.text.lower() or "<!DOCTYPE html" in res.text

--- a/tests/test_topic_views.py
+++ b/tests/test_topic_views.py
@@ -1,0 +1,55 @@
+"""Happy-path tests for the typed topic-views / topic-to-data /
+spatial / validation-blocks routes (c238)."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+LABELLED_SCENES = [
+    "indian-pines-corrected",
+    "salinas-corrected",
+    "salinas-a-corrected",
+    "pavia-university",
+    "kennedy-space-center",
+    "botswana",
+]
+
+
+@pytest.mark.parametrize("scene", LABELLED_SCENES)
+def test_topic_views_per_scene(client: TestClient, scene: str) -> None:
+    res = client.get(f"/api/topic-views/{scene}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == scene
+    assert body["topic_count"] >= 4
+    assert isinstance(body["wavelengths_nm"], list)
+    assert "top_words_per_topic" in body
+    assert "lambda_0.5" in body["top_words_per_topic"]
+
+
+@pytest.mark.parametrize("scene", LABELLED_SCENES)
+def test_topic_to_data_per_scene(client: TestClient, scene: str) -> None:
+    res = client.get(f"/api/topic-to-data/{scene}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == scene
+    assert "p_label_given_topic_dominant" in body
+    assert "spatial_shape" in body
+
+
+def test_spatial_indian_pines(client: TestClient) -> None:
+    res = client.get("/api/spatial/indian-pines-corrected")
+    assert res.status_code == 200
+    body = res.json()
+    assert "morans_I_weighted_by_topic_support" in body
+    assert 0.0 <= body["morans_I_weighted_by_topic_support"] <= 1.0
+
+
+def test_validation_blocks_indian_pines(client: TestClient) -> None:
+    res = client.get("/api/validation-blocks/indian-pines-corrected")
+    assert res.status_code == 200
+    body = res.json()
+    assert "blocks" in body
+    block_ids = {b["block_id"] for b in body["blocks"]}
+    assert "corpus-integrity" in block_ids

--- a/tests/test_wordifications.py
+++ b/tests/test_wordifications.py
@@ -1,0 +1,28 @@
+"""Happy-path tests for the wordifications routes (c238)."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_wordifications_index(client: TestClient) -> None:
+    res = client.get("/api/wordifications")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["count"] > 0
+    assert len(body["items"]) == body["count"]
+
+
+def test_wordification_botswana_v10(client: TestClient) -> None:
+    res = client.get("/api/wordifications/botswana/V10/lloyd_max/16")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == "botswana"
+    assert body["recipe"] == "V10"
+    assert body["scheme"] == "lloyd_max"
+    assert body["Q"] == 16
+    assert "doc_length_distribution" in body
+
+
+def test_wordification_unknown_returns_404(client: TestClient) -> None:
+    res = client.get("/api/wordifications/no-such-scene/V10/lloyd_max/16")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary

Closes issue #440 P1 item 1.7 (\"Zero backend tests\"). Scaffolds a
pytest suite that exercises the FastAPI app via TestClient against the
real \`data/derived\` artefacts on disk — no synthetic fixtures, no
mocking. If the smoke harness passes, so does the test suite.

## Added

- \`dev-requirements.txt\` — pytest 8.4.2 + httpx 0.27.2
- \`tests/conftest.py\` — session-scoped TestClient fixture
- \`tests/test_band_masks.py\` — 5 tests (c236 family)
- \`tests/test_topic_views.py\` — 14 parametrised tests across 6 scenes (c238 family)
- \`tests/test_wordifications.py\` — 3 tests (c238 family)
- \`tests/test_security.py\` — 2 regression tests pinning c224 path-traversal guard

## Test plan

- [x] \`pytest tests/ -v\` → **24 passed, 1.1s wall-clock**

Closes #440 P1 item 1.7.