### PR TITLE
Deploy cycles 238-242: backend hardening sweep (5 cycles, issue #440 mostly closed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 APP_ENV=development
 APP_HOST=127.0.0.1
 APP_PORT=8105
-ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:8105,https://lda-hsi.fasl-work.com
+# CORS origins are now keyed on APP_ENV:
+#   - APP_ENV=production            -> uses PROD_ORIGINS (defaults below)
+#   - anything else (development)   -> uses DEV_ORIGINS  (defaults below)
+# To force a custom set on a one-off host, set ALLOWED_ORIGINS to a
+# comma-separated list; it takes precedence over both env-keyed lists.
+DEV_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:8105
+PROD_ORIGINS=https://lda-hsi.fasl-work.com
+# ALLOWED_ORIGINS=
 FRONTEND_DIST=frontend/dist
 DATA_DIR=data

--- a/app/config.py
+++ b/app/config.py
@@ -17,10 +17,20 @@ class Settings(BaseSettings):
     app_host: str = "127.0.0.1"
     app_port: int = 8105
 
-    allowed_origins: str = (
-        "http://localhost:5173,http://127.0.0.1:5173,"
-        "http://localhost:8105,https://lda-hsi.fasl-work.com"
+    # Dev origins (vite + uvicorn local). Used when app_env is anything
+    # other than "production".
+    dev_origins: str = (
+        "http://localhost:5173,http://127.0.0.1:5173,http://localhost:8105"
     )
+    # Prod origins. Used when app_env == "production". Locked down to the
+    # public URL so the live API does not advertise CORS access to
+    # localhost.
+    prod_origins: str = "https://lda-hsi.fasl-work.com"
+
+    # Back-compat: if a deployment still sets ALLOWED_ORIGINS, honour it
+    # verbatim instead of the env-keyed split. Leave the default empty
+    # so the new behaviour is opt-out, not opt-in.
+    allowed_origins: str = ""
 
     frontend_dist: str = "frontend/dist"
     data_dir: str = "data"
@@ -33,7 +43,13 @@ class Settings(BaseSettings):
 
     @property
     def origins(self) -> list[str]:
-        return [origin.strip() for origin in self.allowed_origins.split(",") if origin.strip()]
+        if self.allowed_origins.strip():
+            raw = self.allowed_origins
+        elif self.app_env.lower() == "production":
+            raw = self.prod_origins
+        else:
+            raw = self.dev_origins
+        return [origin.strip() for origin in raw.split(",") if origin.strip()]
 
     @property
     def frontend_dist_path(self) -> Path:

--- a/app/models/precompute.py
+++ b/app/models/precompute.py
@@ -1,0 +1,270 @@
+"""Pydantic response models for the second slice of precompute routes.
+
+Mirrors the frontend types in `frontend/src/api/client.ts` for 6 routes
+(continues issue #440 P1 item 1.2 after the band-masks family in c236):
+
+- /wordifications                         WordificationsIndexResponse
+- /wordifications/{scene}/{recipe}/...    WordificationResponse
+- /topic-views/{scene}                    TopicViewsResponse
+- /topic-to-data/{scene}                  TopicToDataResponse
+- /spatial/{scene}                        SpatialValidationResponse
+- /validation-blocks/{scene}              ValidationBlocksResponse
+
+Conventions inherited from app/models/band_masks.py:
+- ConfigDict(extra='allow') so backend JSON drift does not silently
+  drop fields under FastAPI's response_model filtering.
+- Deeply-nested or variable-shape areas (top_words_per_topic by
+  λ-variant; topic_pair_log_odds keyed by 'i->j'; etc) stay as
+  dict[str, Any] / list[Any] to keep the OpenAPI surface readable
+  without locking down every interior shape.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+_PassThroughConfig = ConfigDict(extra="allow")
+
+
+# ---------------- shared atoms ----------------
+
+
+class LdaConfig(BaseModel):
+    model_config = _PassThroughConfig
+    method: str
+    max_iter: int
+    doc_topic_prior: float
+    topic_word_prior: float
+    random_state: int
+    wordification: str
+    quantization_scale: int | None = None
+    samples_per_class: int | None = None
+
+
+class DocLengthDistribution(BaseModel):
+    model_config = _PassThroughConfig
+    mean: float
+    std: float
+    min: int
+    p25: float
+    p50: float
+    p75: float
+    max: int
+
+
+class DominantTopicMapMeta(BaseModel):
+    model_config = _PassThroughConfig
+    format: str
+    shape: list[int]
+    sentinel_unlabelled: int
+    path: str | None = None
+    served_path: str | None = None
+
+
+class ThetaGridMeta(BaseModel):
+    model_config = _PassThroughConfig
+    format: str
+    shape: list[int]
+    dtype: str
+    sentinel: str
+    byte_order: str | None = None
+    path: str | None = None
+    served_path: str | None = None
+
+
+# ---------------- wordifications ----------------
+
+
+class WordificationsIndexItem(BaseModel):
+    model_config = _PassThroughConfig
+    id: str
+    path: str
+    bytes: int
+
+
+class WordificationsIndexResponse(BaseModel):
+    model_config = _PassThroughConfig
+    count: int
+    items: list[WordificationsIndexItem] = Field(default_factory=list)
+
+
+class WordificationTopToken(BaseModel):
+    model_config = _PassThroughConfig
+    token: str
+    count: int
+    p_global: float
+
+
+class WordificationResponse(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    recipe: str
+    scheme: str
+    Q: int
+    B: int
+    D: int
+    V_full: int
+    V_actual: int
+    doc_length_distribution: DocLengthDistribution
+    zero_token_doc_rate: float
+    corpus_marginal_entropy_bits: float
+    top_tokens_by_count: list[WordificationTopToken]
+    wavelengths_nm_first_last: list[float]
+    local_doc_term_path: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- topic-views ----------------
+
+
+class TopicViewsResponse(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    scene_name: str
+    topic_count: int
+    vocabulary_size: int
+    document_count: int
+    wavelengths_nm: list[float]
+    vocabulary: list[str]
+    corpus_marginal: list[float] | None = None
+    topic_prevalence: list[float]
+    topic_band_profiles: list[list[float]]
+    topic_distance_cosine: list[list[float]]
+    topic_distance_js: list[list[float]] | None = None
+    topic_distance_hellinger: list[list[float]] | None = None
+    topic_word_jaccard_top15: list[list[float]] | None = None
+    topic_intertopic_2d_js: list[list[float]]
+    topic_intertopic_3d_js: list[list[float]]
+    # keyed by λ-variant ("lambda_0.0", "lambda_0.3", ...) -> [topic][rank] -> word obj
+    top_words_per_topic: dict[str, list[list[dict[str, Any]]]]
+    topic_pair_log_odds: dict[str, list[dict[str, Any]]] | None = None
+    lda_config: LdaConfig | None = None
+    perplexity: float | None = None
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- topic-to-data ----------------
+
+
+class TopicLabelCell(BaseModel):
+    model_config = _PassThroughConfig
+    label_id: int
+    name: str
+    count: int
+    p: float
+
+
+class TopDocumentForTopic(BaseModel):
+    model_config = _PassThroughConfig
+    doc_id: str
+    theta_k: float
+    label_id: int | None = None
+    label_name: str | None = None
+    xy: list[int]
+    theta_full: list[float]
+
+
+class ThetaEmbeddingPoint2D(BaseModel):
+    model_config = _PassThroughConfig
+    doc_id: int
+    x: float
+    y: float
+    label_id: int | None = None
+    dominant_topic_k: int | None = None
+    confidence: float | None = None
+
+
+class ThetaEmbeddingPoint3D(ThetaEmbeddingPoint2D):
+    z: float
+
+
+class TopicToDataResponse(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    scene_name: str
+    topic_count: int
+    document_count: int
+    spatial_shape: list[int]
+    p_label_given_topic_dominant: list[list[TopicLabelCell]]
+    p_label_given_topic_strict_theta_gt_0_5: list[list[TopicLabelCell]] | None = None
+    docs_per_topic_dominant: list[int]
+    docs_per_topic_strict: list[int] | None = None
+    kl_to_label_prior_per_topic: list[float] | None = None
+    top_documents_per_topic: list[list[TopDocumentForTopic]] | None = None
+    dominant_topic_map: DominantTopicMapMeta | None = None
+    theta_grid: ThetaGridMeta | None = None
+    theta_embedding_pca_2d: list[ThetaEmbeddingPoint2D] | None = None
+    theta_embedding_pca_3d: list[ThetaEmbeddingPoint3D] | None = None
+    theta_embedding_explained_variance: list[float] | None = None
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- spatial ----------------
+
+
+class SpatialConnectedComponents(BaseModel):
+    model_config = _PassThroughConfig
+    n_components: int
+    support: int
+    size_p50: float
+    size_p95: float
+    size_max: int
+
+
+class SpatialTopicLabelIoU(BaseModel):
+    model_config = _PassThroughConfig
+    topic_k: int
+    best_label_id: int | None = None
+    best_label_name: str | None = None
+    best_iou: float
+    iou_per_label: dict[str, float] = Field(default_factory=dict)
+
+
+class SpatialBestIouSummary(BaseModel):
+    model_config = _PassThroughConfig
+    max_iou_overall: float
+    mean_best_iou: float
+
+
+class SpatialValidationResponse(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    spatial_shape: list[int]
+    topic_count: int
+    n_assigned_pixels: int
+    morans_I_weighted_by_topic_support: float
+    connected_components_per_topic: dict[str, SpatialConnectedComponents]
+    topic_label_iou: list[SpatialTopicLabelIoU]
+    best_iou_summary: SpatialBestIouSummary
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- validation-blocks ----------------
+
+
+class ValidationBlock(BaseModel):
+    """A single validation block (e.g. corpus-integrity, topic-distinctness).
+
+    Schema varies across blocks — metrics shape depends on block_id.
+    Keeping metrics as dict[str, Any] preserves that flexibility while
+    making the OpenAPI envelope explicit.
+    """
+    model_config = _PassThroughConfig
+    block_id: str
+    status: str
+    metrics: dict[str, Any] = Field(default_factory=dict)
+
+
+class ValidationBlocksResponse(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    scene_name: str
+    blocks: list[ValidationBlock] = Field(default_factory=list)
+    generated_at: str
+    builder_version: str

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -240,44 +240,46 @@ def app_data() -> AppPayload:
 # ============================================================================
 
 
-def _serve_or_404(loader, scene_id: str | None, hint: str):
-    from app.services.content import (
-        get_eda_per_scene,
-        get_topic_views,
-        get_topic_to_data,
-        get_spectral_browser_metadata,
-        get_spectral_density_manifest,
-        get_validation_blocks,
-        get_derived_manifest,
-    )
+def _serve_or_404(loader, *args, hint: str):
+    """Invoke `loader(*args)` and translate FileNotFoundError to 404.
+
+    Closes the dead-helper finding from issue #440 (1.1 + 1.3) — the
+    previous body imported six callables it never used and only worked
+    for the (loader, scene_id) shape. The new signature accepts any
+    positional args, so handlers that take 0, 1, 2 or 4 path params all
+    use the same helper.
+    """
     try:
-        return loader(scene_id) if scene_id else loader()
+        return loader(*args)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=hint) from exc
+
+
+def _typed_or_404(model, loader, *args, hint: str):
+    """`_serve_or_404` + Pydantic `model_validate` in one call.
+
+    Lets a typed route body collapse to a single statement.
+    """
+    return model.model_validate(_serve_or_404(loader, *args, hint=hint))
 
 
 @router.get("/manifest")
 def derived_manifest() -> dict:
     from app.services.content import get_derived_manifest
-    try:
-        return get_derived_manifest()
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="manifest not generated yet; run scripts/local.* curate-for-web",
-        ) from exc
+    return _serve_or_404(
+        get_derived_manifest,
+        hint="manifest not generated yet; run scripts/local.* curate-for-web",
+    )
 
 
 @router.get("/eda/per-scene/{scene_id}")
 def eda_per_scene(scene_id: str) -> dict:
     from app.services.content import get_eda_per_scene
-    try:
-        return get_eda_per_scene(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"eda views for '{scene_id}' not generated yet; run scripts/local.* build-eda-per-scene",
-        ) from exc
+    return _serve_or_404(
+        get_eda_per_scene,
+        scene_id,
+        hint=f"eda views for '{scene_id}' not generated yet; run scripts/local.* build-eda-per-scene",
+    )
 
 
 @router.get(
@@ -287,13 +289,12 @@ def eda_per_scene(scene_id: str) -> dict:
 )
 def topic_views(scene_id: str) -> TopicViewsResponse:
     from app.services.content import get_topic_views
-    try:
-        return TopicViewsResponse.model_validate(get_topic_views(scene_id))
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"topic views for '{scene_id}' not generated yet; run scripts/local.* build-topic-views",
-        ) from exc
+    return _typed_or_404(
+        TopicViewsResponse,
+        get_topic_views,
+        scene_id,
+        hint=f"topic views for '{scene_id}' not generated yet; run scripts/local.* build-topic-views",
+    )
 
 
 @router.get(
@@ -303,37 +304,32 @@ def topic_views(scene_id: str) -> TopicViewsResponse:
 )
 def topic_to_data(scene_id: str) -> TopicToDataResponse:
     from app.services.content import get_topic_to_data
-    try:
-        return TopicToDataResponse.model_validate(get_topic_to_data(scene_id))
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"topic-to-data for '{scene_id}' not generated yet; run scripts/local.* build-topic-to-data",
-        ) from exc
+    return _typed_or_404(
+        TopicToDataResponse,
+        get_topic_to_data,
+        scene_id,
+        hint=f"topic-to-data for '{scene_id}' not generated yet; run scripts/local.* build-topic-to-data",
+    )
 
 
 @router.get("/spectral-browser/{scene_id}")
 def spectral_browser(scene_id: str) -> dict:
     from app.services.content import get_spectral_browser_metadata
-    try:
-        return get_spectral_browser_metadata(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"spectral browser for '{scene_id}' not generated yet; run scripts/local.* build-spectral-browser",
-        ) from exc
+    return _serve_or_404(
+        get_spectral_browser_metadata,
+        scene_id,
+        hint=f"spectral browser for '{scene_id}' not generated yet; run scripts/local.* build-spectral-browser",
+    )
 
 
 @router.get("/spectral-density/{scene_id}")
 def spectral_density(scene_id: str) -> dict:
     from app.services.content import get_spectral_density_manifest
-    try:
-        return get_spectral_density_manifest(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"spectral density for '{scene_id}' not generated yet; run scripts/local.* build-spectral-density",
-        ) from exc
+    return _serve_or_404(
+        get_spectral_density_manifest,
+        scene_id,
+        hint=f"spectral density for '{scene_id}' not generated yet; run scripts/local.* build-spectral-density",
+    )
 
 
 @router.get(
@@ -343,37 +339,32 @@ def spectral_density(scene_id: str) -> dict:
 )
 def validation_blocks(scene_id: str) -> ValidationBlocksResponse:
     from app.services.content import get_validation_blocks
-    try:
-        return ValidationBlocksResponse.model_validate(get_validation_blocks(scene_id))
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"validation blocks for '{scene_id}' not generated yet; run scripts/local.* build-validation-blocks",
-        ) from exc
+    return _typed_or_404(
+        ValidationBlocksResponse,
+        get_validation_blocks,
+        scene_id,
+        hint=f"validation blocks for '{scene_id}' not generated yet; run scripts/local.* build-validation-blocks",
+    )
 
 
 @router.get("/eda/hidsag/{subset_code}")
 def eda_hidsag(subset_code: str) -> dict:
     from app.services.content import get_eda_hidsag
-    try:
-        return get_eda_hidsag(subset_code)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"HIDSAG EDA for '{subset_code}' not generated yet; run scripts/local.* build-eda-hidsag",
-        ) from exc
+    return _serve_or_404(
+        get_eda_hidsag,
+        subset_code,
+        hint=f"HIDSAG EDA for '{subset_code}' not generated yet; run scripts/local.* build-eda-hidsag",
+    )
 
 
 @router.get("/topic-to-library/{scene_id}")
 def topic_to_library(scene_id: str) -> dict:
     from app.services.content import get_topic_to_library
-    try:
-        return get_topic_to_library(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"topic-to-library for '{scene_id}' not generated yet; run scripts/local.* build-topic-to-library",
-        ) from exc
+    return _serve_or_404(
+        get_topic_to_library,
+        scene_id,
+        hint=f"topic-to-library for '{scene_id}' not generated yet; run scripts/local.* build-topic-to-library",
+    )
 
 
 @router.get(
@@ -383,13 +374,12 @@ def topic_to_library(scene_id: str) -> dict:
 )
 def spatial_validation(scene_id: str) -> SpatialValidationResponse:
     from app.services.content import get_spatial_validation
-    try:
-        return SpatialValidationResponse.model_validate(get_spatial_validation(scene_id))
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"spatial validation for '{scene_id}' not generated yet; run scripts/local.* build-spatial-validation",
-        ) from exc
+    return _typed_or_404(
+        SpatialValidationResponse,
+        get_spatial_validation,
+        scene_id,
+        hint=f"spatial validation for '{scene_id}' not generated yet; run scripts/local.* build-spatial-validation",
+    )
 
 
 @router.get(
@@ -399,13 +389,11 @@ def spatial_validation(scene_id: str) -> SpatialValidationResponse:
 )
 def wordifications_index() -> WordificationsIndexResponse:
     from app.services.content import get_wordifications_index
-    try:
-        return WordificationsIndexResponse.model_validate(get_wordifications_index())
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="wordifications not generated yet; run scripts/local.* build-wordifications",
-        ) from exc
+    return _typed_or_404(
+        WordificationsIndexResponse,
+        get_wordifications_index,
+        hint="wordifications not generated yet; run scripts/local.* build-wordifications",
+    )
 
 
 @router.get(
@@ -417,15 +405,12 @@ def wordification(
     scene_id: str, recipe: str, scheme: str, q: int
 ) -> WordificationResponse:
     from app.services.content import get_wordification
-    try:
-        return WordificationResponse.model_validate(
-            get_wordification(scene_id, recipe, scheme, q)
-        )
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"wordification {scene_id}/{recipe}/{scheme}/Q{q} not generated yet",
-        ) from exc
+    return _typed_or_404(
+        WordificationResponse,
+        get_wordification,
+        scene_id, recipe, scheme, q,
+        hint=f"wordification {scene_id}/{recipe}/{scheme}/Q{q} not generated yet",
+    )
 
 
 @router.get(
@@ -435,14 +420,14 @@ def wordification(
 )
 def band_masks_index() -> BandMasksIndexResponse:
     from app.services.content import get_band_masks_index
-    try:
-        return BandMasksIndexResponse.model_validate(get_band_masks_index())
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="band_masks index not generated yet; run "
-            "scripts/local.* build-band-masked-topic-models",
-        ) from exc
+    return _typed_or_404(
+        BandMasksIndexResponse,
+        get_band_masks_index,
+        hint=(
+            "band_masks index not generated yet; run "
+            "scripts/local.* build-band-masked-topic-models"
+        ),
+    )
 
 
 @router.get(
@@ -452,16 +437,14 @@ def band_masks_index() -> BandMasksIndexResponse:
 )
 def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
     from app.services.content import get_band_masks_canonical_comparison
-    try:
-        return BandMaskCanonicalComparisonResponse.model_validate(
-            get_band_masks_canonical_comparison()
-        )
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="band_masks canonical_comparison not generated yet; run "
-            "scripts/local.* build-band-mask-canonical-comparison",
-        ) from exc
+    return _typed_or_404(
+        BandMaskCanonicalComparisonResponse,
+        get_band_masks_canonical_comparison,
+        hint=(
+            "band_masks canonical_comparison not generated yet; run "
+            "scripts/local.* build-band-mask-canonical-comparison"
+        ),
+    )
 
 
 @router.get(
@@ -471,15 +454,12 @@ def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
 )
 def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
     from app.services.content import get_band_mask_summary
-    try:
-        return BandMaskSummaryResponse.model_validate(
-            get_band_mask_summary(scene_id, mask_id)
-        )
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"band_mask {scene_id}/{mask_id} not generated yet",
-        ) from exc
+    return _typed_or_404(
+        BandMaskSummaryResponse,
+        get_band_mask_summary,
+        scene_id, mask_id,
+        hint=f"band_mask {scene_id}/{mask_id} not generated yet",
+    )
 
 
 @router.get(
@@ -489,16 +469,14 @@ def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
 )
 def band_masks_hidsag_index() -> BandMasksHidsagIndexResponse:
     from app.services.content import get_band_masks_hidsag_index
-    try:
-        return BandMasksHidsagIndexResponse.model_validate(
-            get_band_masks_hidsag_index()
-        )
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="band_masks_hidsag index not generated yet; run "
-            "scripts/local.* build-band-masked-topic-models-hidsag",
-        ) from exc
+    return _typed_or_404(
+        BandMasksHidsagIndexResponse,
+        get_band_masks_hidsag_index,
+        hint=(
+            "band_masks_hidsag index not generated yet; run "
+            "scripts/local.* build-band-masked-topic-models-hidsag"
+        ),
+    )
 
 
 @router.get(
@@ -510,99 +488,75 @@ def band_masks_hidsag_summary(
     subset_code: str, mask_id: str
 ) -> BandMaskHidsagSummaryResponse:
     from app.services.content import get_band_masks_hidsag_summary
-    try:
-        return BandMaskHidsagSummaryResponse.model_validate(
-            get_band_masks_hidsag_summary(subset_code, mask_id)
-        )
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"band_masks_hidsag {subset_code}/{mask_id} not generated yet",
-        ) from exc
+    return _typed_or_404(
+        BandMaskHidsagSummaryResponse,
+        get_band_masks_hidsag_summary,
+        subset_code, mask_id,
+        hint=f"band_masks_hidsag {subset_code}/{mask_id} not generated yet",
+    )
 
 
 @router.get("/groupings")
 def groupings_index() -> dict:
     from app.services.content import get_groupings_index
-    try:
-        return get_groupings_index()
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="groupings not generated yet; run scripts/local.* build-groupings",
-        ) from exc
+    return _serve_or_404(
+        get_groupings_index,
+        hint="groupings not generated yet; run scripts/local.* build-groupings",
+    )
 
 
 @router.get("/groupings/{method}/{scene_id}")
 def grouping(method: str, scene_id: str) -> dict:
     from app.services.content import get_grouping
-    try:
-        return get_grouping(method, scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"grouping {method}/{scene_id} not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_grouping, method, scene_id,
+        hint=f"grouping {method}/{scene_id} not generated yet",
+    )
 
 
 @router.get("/cross-method-agreement/{scene_id}")
 def cross_method_agreement(scene_id: str) -> dict:
     from app.services.content import get_cross_method_agreement
-    try:
-        return get_cross_method_agreement(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"cross-method agreement for '{scene_id}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_cross_method_agreement, scene_id,
+        hint=f"cross-method agreement for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/method-statistics-hidsag/{subset_code}")
 def method_statistics_hidsag(subset_code: str) -> dict:
     from app.services.content import get_method_statistics_hidsag
-    try:
-        return get_method_statistics_hidsag(subset_code)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"method statistics for HIDSAG '{subset_code}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_method_statistics_hidsag, subset_code,
+        hint=f"method statistics for HIDSAG '{subset_code}' not generated yet",
+    )
 
 
 @router.get("/external-validation/{scene_id}/literature")
 def external_validation_literature(scene_id: str) -> dict:
     from app.services.content import get_external_validation_literature
-    try:
-        return get_external_validation_literature(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"literature alignment for '{scene_id}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_external_validation_literature, scene_id,
+        hint=f"literature alignment for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/external-validation/hidsag/{subset_code}/methods")
 def external_validation_hidsag_methods(subset_code: str) -> dict:
     from app.services.content import get_external_validation_hidsag_methods
-    try:
-        return get_external_validation_hidsag_methods(subset_code)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"HIDSAG method summary for '{subset_code}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_external_validation_hidsag_methods, subset_code,
+        hint=f"HIDSAG method summary for '{subset_code}' not generated yet",
+    )
 
 
 @router.get("/narratives/{scene_id}")
 def narratives(scene_id: str) -> dict:
     from app.services.content import get_narratives
-    try:
-        return get_narratives(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"narrative for '{scene_id}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_narratives, scene_id,
+        hint=f"narrative for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/interpretability/{scene_id}/{card_type}")
@@ -610,85 +564,73 @@ def interpretability(scene_id: str, card_type: str) -> dict:
     from app.services.content import get_interpretability
     if card_type not in ("topic_cards", "band_cards", "document_cards"):
         raise HTTPException(status_code=400, detail="card_type must be topic_cards | band_cards | document_cards")
-    try:
-        return get_interpretability(scene_id, card_type)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"interpretability {card_type} for '{scene_id}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_interpretability, scene_id, card_type,
+        hint=f"interpretability {card_type} for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/quantization-sensitivity/{scene_id}")
 def quantization_sensitivity(scene_id: str) -> dict:
     from app.services.content import get_quantization_sensitivity
-    try:
-        return get_quantization_sensitivity(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"quantization sensitivity for '{scene_id}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_quantization_sensitivity, scene_id,
+        hint=f"quantization sensitivity for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/topic-variants")
 def topic_variants_index() -> dict:
     from app.services.content import get_topic_variants_index
-    try:
-        return get_topic_variants_index()
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="topic variants not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_topic_variants_index,
+        hint="topic variants not generated yet",
+    )
 
 
 @router.get("/topic-variants/{variant}/{scene_id}")
 def topic_variant(variant: str, scene_id: str) -> dict:
     from app.services.content import get_topic_variant
-    try:
-        return get_topic_variant(variant, scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"topic variant {variant}/{scene_id} not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_topic_variant, variant, scene_id,
+        hint=f"topic variant {variant}/{scene_id} not generated yet",
+    )
 
 
 @router.get("/lda-sweep/{scene_id}")
 def lda_sweep(scene_id: str) -> dict:
     from app.services.content import get_lda_sweep
-    try:
-        return get_lda_sweep(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"lda_sweep for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_lda_sweep, scene_id,
+        hint=f"lda_sweep for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/representations")
 def representations_index() -> dict:
     from app.services.content import get_representations_index
-    try:
-        return get_representations_index()
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="representations not generated yet") from exc
+    return _serve_or_404(
+        get_representations_index,
+        hint="representations not generated yet",
+    )
 
 
 @router.get("/representations/{method}/{scene_id}")
 def representation(method: str, scene_id: str) -> dict:
     from app.services.content import get_representation
-    try:
-        return get_representation(method, scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"representation {method}/{scene_id} not generated yet") from exc
+    return _serve_or_404(
+        get_representation, method, scene_id,
+        hint=f"representation {method}/{scene_id} not generated yet",
+    )
 
 
 @router.get("/dmr-lda-hidsag/{subset_code}")
 def dmr_lda_hidsag(subset_code: str) -> dict:
     from app.services.content import get_dmr_lda_hidsag
-    try:
-        return get_dmr_lda_hidsag(subset_code)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"dmr_lda_hidsag for '{subset_code}' not generated yet") from exc
+    return _serve_or_404(
+        get_dmr_lda_hidsag, subset_code,
+        hint=f"dmr_lda_hidsag for '{subset_code}' not generated yet",
+    )
 
 
 @router.get("/bayesian-comparison/{task_type}")
@@ -699,114 +641,114 @@ def bayesian_comparison(task_type: str) -> dict:
         get_bayesian_comparison,
     )
     if task_type == "classification-labelled":
-        try:
-            return get_bayesian_classification_labelled()
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail="bayesian_comparison labelled-classification not generated yet") from exc
+        return _serve_or_404(
+            get_bayesian_classification_labelled,
+            hint="bayesian_comparison labelled-classification not generated yet",
+        )
     if task_type == "classification-labelled-deep":
-        try:
-            return get_bayesian_classification_labelled_deep()
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail="bayesian_comparison labelled-classification-deep not generated yet") from exc
+        return _serve_or_404(
+            get_bayesian_classification_labelled_deep,
+            hint="bayesian_comparison labelled-classification-deep not generated yet",
+        )
     if task_type not in ("regression", "classification"):
         raise HTTPException(
             status_code=400,
             detail="task_type must be regression | classification | classification-labelled | classification-labelled-deep",
         )
-    try:
-        return get_bayesian_comparison(task_type)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"bayesian_comparison for '{task_type}' not generated yet") from exc
+    return _serve_or_404(
+        get_bayesian_comparison, task_type,
+        hint=f"bayesian_comparison for '{task_type}' not generated yet",
+    )
 
 
 @router.get("/optuna-search/{scene_id}")
 def optuna_search(scene_id: str) -> dict:
     from app.services.content import get_optuna_search
-    try:
-        return get_optuna_search(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"optuna_search for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_optuna_search, scene_id,
+        hint=f"optuna_search for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/linear-probe-panel/{scene_id}")
 def linear_probe_panel(scene_id: str) -> dict:
     from app.services.content import get_linear_probe_panel
-    try:
-        return get_linear_probe_panel(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"linear_probe_panel for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_linear_probe_panel, scene_id,
+        hint=f"linear_probe_panel for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/mutual-information/{scene_id}")
 def mutual_information(scene_id: str) -> dict:
     from app.services.content import get_mutual_information
-    try:
-        return get_mutual_information(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"mutual_information for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_mutual_information, scene_id,
+        hint=f"mutual_information for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/mutual-information/hidsag/{subset_code}")
 def mutual_information_hidsag(subset_code: str) -> dict:
     from app.services.content import get_mutual_information_hidsag
-    try:
-        return get_mutual_information_hidsag(subset_code)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"mutual_information for HIDSAG '{subset_code}' not generated yet") from exc
+    return _serve_or_404(
+        get_mutual_information_hidsag, subset_code,
+        hint=f"mutual_information for HIDSAG '{subset_code}' not generated yet",
+    )
 
 
 @router.get("/rate-distortion-curve/{scene_id}")
 def rate_distortion_curve(scene_id: str) -> dict:
     from app.services.content import get_rate_distortion_curve
-    try:
-        return get_rate_distortion_curve(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"rate_distortion_curve for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_rate_distortion_curve, scene_id,
+        hint=f"rate_distortion_curve for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/topic-routed-classifier/{scene_id}")
 def topic_routed_classifier(scene_id: str) -> dict:
     from app.services.content import get_topic_routed_classifier
-    try:
-        return get_topic_routed_classifier(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"topic_routed_classifier for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_topic_routed_classifier, scene_id,
+        hint=f"topic_routed_classifier for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/topic-routed-deep-gate/{scene_id}")
 def topic_routed_deep_gate(scene_id: str) -> dict:
     from app.services.content import get_topic_routed_deep_gate
-    try:
-        return get_topic_routed_deep_gate(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"topic_routed_deep_gate for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_topic_routed_deep_gate, scene_id,
+        hint=f"topic_routed_deep_gate for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/neural-topic-comparison/{scene_id}")
 def neural_topic_comparison(scene_id: str) -> dict:
     from app.services.content import get_neural_topic_comparison
-    try:
-        return get_neural_topic_comparison(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"neural_topic_comparison for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_neural_topic_comparison, scene_id,
+        hint=f"neural_topic_comparison for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/neural-topic-seed-stability/{scene_id}")
 def neural_topic_seed_stability(scene_id: str) -> dict:
     from app.services.content import get_neural_topic_seed_stability
-    try:
-        return get_neural_topic_seed_stability(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"neural_topic_seed_stability for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_neural_topic_seed_stability, scene_id,
+        hint=f"neural_topic_seed_stability for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/embedded-baseline/{scene_id}")
 def embedded_baseline(scene_id: str) -> dict:
     from app.services.content import get_embedded_baseline
-    try:
-        return get_embedded_baseline(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"embedded_baseline for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_embedded_baseline, scene_id,
+        hint=f"embedded_baseline for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/topic-stability/{scene_id}")
@@ -815,7 +757,10 @@ def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
     try:
         return get_topic_stability(scene_id, k_offset=k_offset)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"topic_stability for '{scene_id}' k_offset={k_offset} not generated yet") from exc
+        raise HTTPException(
+            status_code=404,
+            detail=f"topic_stability for '{scene_id}' k_offset={k_offset} not generated yet",
+        ) from exc
 
 
 @router.get("/deep-seed-stability/{scene_id}")
@@ -824,16 +769,19 @@ def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 
     try:
         return get_deep_seed_stability(scene_id, method=method, n_seeds=n_seeds)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"deep_seed_stability for '{scene_id}' method '{method}' n_seeds={n_seeds} not generated yet") from exc
+        raise HTTPException(
+            status_code=404,
+            detail=f"deep_seed_stability for '{scene_id}' method '{method}' n_seeds={n_seeds} not generated yet",
+        ) from exc
 
 
 @router.get("/deep-anomaly/{scene_id}")
 def deep_anomaly(scene_id: str) -> dict:
     from app.services.content import get_deep_anomaly
-    try:
-        return get_deep_anomaly(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"deep_anomaly for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_deep_anomaly, scene_id,
+        hint=f"deep_anomaly for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/classical-seed-stability/{scene_id}")
@@ -842,88 +790,91 @@ def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
     try:
         return get_classical_seed_stability(scene_id, method=method)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"classical_seed_stability for '{scene_id}' method '{method}' not generated yet") from exc
+        raise HTTPException(
+            status_code=404,
+            detail=f"classical_seed_stability for '{scene_id}' method '{method}' not generated yet",
+        ) from exc
 
 
 @router.get("/topic-to-usgs-v7/{scene_id}")
 def topic_to_usgs_v7(scene_id: str) -> dict:
     from app.services.content import get_topic_to_usgs_v7
-    try:
-        return get_topic_to_usgs_v7(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"topic_to_usgs_v7 for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_topic_to_usgs_v7, scene_id,
+        hint=f"topic_to_usgs_v7 for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/hidsag-cross-preprocessing-stability/{subset_code}")
 def hidsag_cross_preprocessing_stability(subset_code: str) -> dict:
     from app.services.content import get_hidsag_cross_preprocessing_stability
-    try:
-        return get_hidsag_cross_preprocessing_stability(subset_code)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"hidsag_cross_preprocessing_stability for '{subset_code}' not generated yet",
-        ) from exc
+    return _serve_or_404(
+        get_hidsag_cross_preprocessing_stability, subset_code,
+        hint=f"hidsag_cross_preprocessing_stability for '{subset_code}' not generated yet",
+    )
 
 
 @router.get("/topic-anomaly/{scene_id}")
 def topic_anomaly(scene_id: str) -> dict:
     from app.services.content import get_topic_anomaly
-    try:
-        return get_topic_anomaly(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"topic_anomaly for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_topic_anomaly, scene_id,
+        hint=f"topic_anomaly for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/topic-spatial-continuous/{scene_id}")
 def topic_spatial_continuous(scene_id: str) -> dict:
     from app.services.content import get_topic_spatial_continuous
-    try:
-        return get_topic_spatial_continuous(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"topic_spatial_continuous for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_topic_spatial_continuous, scene_id,
+        hint=f"topic_spatial_continuous for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/topic-spatial-full/{scene_id}")
 def topic_spatial_full(scene_id: str) -> dict:
     from app.services.content import get_topic_spatial_full
-    try:
-        return get_topic_spatial_full(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"topic_spatial_full for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_topic_spatial_full, scene_id,
+        hint=f"topic_spatial_full for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/endmember-baseline/{scene_id}")
 def endmember_baseline(scene_id: str) -> dict:
     from app.services.content import get_endmember_baseline
-    try:
-        return get_endmember_baseline(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"endmember_baseline for '{scene_id}' not generated yet") from exc
+    return _serve_or_404(
+        get_endmember_baseline, scene_id,
+        hint=f"endmember_baseline for '{scene_id}' not generated yet",
+    )
 
 
 @router.get("/llm-tea-leaves/{scene_id}")
 def llm_tea_leaves(scene_id: str) -> dict:
     from app.services.content import get_llm_tea_leaves
-    try:
-        return get_llm_tea_leaves(scene_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail=f"llm_tea_leaves for '{scene_id}' not generated yet (set ANTHROPIC_API_KEY and run build_b12_llm_tea_leaves)") from exc
+    return _serve_or_404(
+        get_llm_tea_leaves, scene_id,
+        hint=(
+            f"llm_tea_leaves for '{scene_id}' not generated yet "
+            "(set ANTHROPIC_API_KEY and run build_b12_llm_tea_leaves)"
+        ),
+    )
 
 
 @router.get("/super-topics")
 def super_topics() -> dict:
     from app.services.content import get_super_topics
-    try:
-        return get_super_topics()
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="super_topics not generated yet") from exc
+    return _serve_or_404(
+        get_super_topics,
+        hint="super_topics not generated yet",
+    )
 
 
 @router.get("/cross-scene-transfer")
 def cross_scene_transfer() -> dict:
     from app.services.content import get_cross_scene_transfer
-    try:
-        return get_cross_scene_transfer()
-    except FileNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="cross_scene_transfer not generated yet") from exc
+    return _serve_or_404(
+        get_cross_scene_transfer,
+        hint="cross_scene_transfer not generated yet",
+    )

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -49,30 +49,88 @@ from app.models.schemas import (
 from app.services.content import (
     get_analysis,
     get_app_payload,
+    get_band_mask_summary,
+    get_band_masks_canonical_comparison,
+    get_band_masks_hidsag_index,
+    get_band_masks_hidsag_summary,
+    get_band_masks_index,
+    get_bayesian_classification_labelled,
+    get_bayesian_classification_labelled_deep,
+    get_bayesian_comparison,
+    get_classical_seed_stability,
     get_corpus_previews,
     get_corpus_recipes,
+    get_cross_method_agreement,
+    get_cross_scene_transfer,
     get_data_families,
     get_datasets,
+    get_deep_anomaly,
+    get_deep_seed_stability,
     get_demo,
+    get_derived_manifest,
+    get_dmr_lda_hidsag,
+    get_eda_hidsag,
+    get_eda_per_scene,
+    get_embedded_baseline,
+    get_endmember_baseline,
+    get_exploration_views,
+    get_external_validation_hidsag_methods,
+    get_external_validation_literature,
     get_field_samples,
+    get_grouping,
+    get_groupings_index,
     get_hidsag_band_quality,
+    get_hidsag_cross_preprocessing_stability,
     get_hidsag_curated_subset,
     get_hidsag_preprocessing_sensitivity,
     get_hidsag_region_documents,
     get_hidsag_subset_inventory,
     get_interactive_subsets,
+    get_interpretability,
+    get_lda_sweep,
+    get_linear_probe_panel,
+    get_llm_tea_leaves,
     get_local_core_benchmarks,
     get_local_dataset_inventory,
     get_local_validation_matrix,
+    get_method_statistics,
+    get_method_statistics_hidsag,
     get_methodology,
+    get_mutual_information,
+    get_mutual_information_hidsag,
+    get_narratives,
+    get_neural_topic_comparison,
+    get_neural_topic_seed_stability,
+    get_optuna_search,
     get_overview,
+    get_quantization_sensitivity,
+    get_rate_distortion_curve,
     get_real_scenes,
+    get_representation,
+    get_representations_index,
     get_segmentation_baselines,
+    get_spatial_validation,
+    get_spectral_browser_metadata,
+    get_spectral_density_manifest,
     get_spectral_library,
     get_subset_card,
     get_subset_cards_index,
-    get_exploration_views,
-    get_method_statistics,
+    get_super_topics,
+    get_topic_anomaly,
+    get_topic_routed_classifier,
+    get_topic_routed_deep_gate,
+    get_topic_spatial_continuous,
+    get_topic_spatial_full,
+    get_topic_stability,
+    get_topic_to_data,
+    get_topic_to_library,
+    get_topic_to_usgs_v7,
+    get_topic_variant,
+    get_topic_variants_index,
+    get_topic_views,
+    get_validation_blocks,
+    get_wordification,
+    get_wordifications_index,
 )
 
 
@@ -265,7 +323,6 @@ def _typed_or_404(model, loader, *args, hint: str):
 
 @router.get("/manifest")
 def derived_manifest() -> dict:
-    from app.services.content import get_derived_manifest
     return _serve_or_404(
         get_derived_manifest,
         hint="manifest not generated yet; run scripts/local.* curate-for-web",
@@ -274,7 +331,6 @@ def derived_manifest() -> dict:
 
 @router.get("/eda/per-scene/{scene_id}")
 def eda_per_scene(scene_id: str) -> dict:
-    from app.services.content import get_eda_per_scene
     return _serve_or_404(
         get_eda_per_scene,
         scene_id,
@@ -288,7 +344,6 @@ def eda_per_scene(scene_id: str) -> dict:
     response_model_exclude_none=True,
 )
 def topic_views(scene_id: str) -> TopicViewsResponse:
-    from app.services.content import get_topic_views
     return _typed_or_404(
         TopicViewsResponse,
         get_topic_views,
@@ -303,7 +358,6 @@ def topic_views(scene_id: str) -> TopicViewsResponse:
     response_model_exclude_none=True,
 )
 def topic_to_data(scene_id: str) -> TopicToDataResponse:
-    from app.services.content import get_topic_to_data
     return _typed_or_404(
         TopicToDataResponse,
         get_topic_to_data,
@@ -314,7 +368,6 @@ def topic_to_data(scene_id: str) -> TopicToDataResponse:
 
 @router.get("/spectral-browser/{scene_id}")
 def spectral_browser(scene_id: str) -> dict:
-    from app.services.content import get_spectral_browser_metadata
     return _serve_or_404(
         get_spectral_browser_metadata,
         scene_id,
@@ -324,7 +377,6 @@ def spectral_browser(scene_id: str) -> dict:
 
 @router.get("/spectral-density/{scene_id}")
 def spectral_density(scene_id: str) -> dict:
-    from app.services.content import get_spectral_density_manifest
     return _serve_or_404(
         get_spectral_density_manifest,
         scene_id,
@@ -338,7 +390,6 @@ def spectral_density(scene_id: str) -> dict:
     response_model_exclude_none=True,
 )
 def validation_blocks(scene_id: str) -> ValidationBlocksResponse:
-    from app.services.content import get_validation_blocks
     return _typed_or_404(
         ValidationBlocksResponse,
         get_validation_blocks,
@@ -349,7 +400,6 @@ def validation_blocks(scene_id: str) -> ValidationBlocksResponse:
 
 @router.get("/eda/hidsag/{subset_code}")
 def eda_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_eda_hidsag
     return _serve_or_404(
         get_eda_hidsag,
         subset_code,
@@ -359,7 +409,6 @@ def eda_hidsag(subset_code: str) -> dict:
 
 @router.get("/topic-to-library/{scene_id}")
 def topic_to_library(scene_id: str) -> dict:
-    from app.services.content import get_topic_to_library
     return _serve_or_404(
         get_topic_to_library,
         scene_id,
@@ -373,7 +422,6 @@ def topic_to_library(scene_id: str) -> dict:
     response_model_exclude_none=True,
 )
 def spatial_validation(scene_id: str) -> SpatialValidationResponse:
-    from app.services.content import get_spatial_validation
     return _typed_or_404(
         SpatialValidationResponse,
         get_spatial_validation,
@@ -388,7 +436,6 @@ def spatial_validation(scene_id: str) -> SpatialValidationResponse:
     response_model_exclude_none=True,
 )
 def wordifications_index() -> WordificationsIndexResponse:
-    from app.services.content import get_wordifications_index
     return _typed_or_404(
         WordificationsIndexResponse,
         get_wordifications_index,
@@ -404,7 +451,6 @@ def wordifications_index() -> WordificationsIndexResponse:
 def wordification(
     scene_id: str, recipe: str, scheme: str, q: int
 ) -> WordificationResponse:
-    from app.services.content import get_wordification
     return _typed_or_404(
         WordificationResponse,
         get_wordification,
@@ -419,7 +465,6 @@ def wordification(
     response_model_exclude_none=True,
 )
 def band_masks_index() -> BandMasksIndexResponse:
-    from app.services.content import get_band_masks_index
     return _typed_or_404(
         BandMasksIndexResponse,
         get_band_masks_index,
@@ -436,7 +481,6 @@ def band_masks_index() -> BandMasksIndexResponse:
     response_model_exclude_none=True,
 )
 def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
-    from app.services.content import get_band_masks_canonical_comparison
     return _typed_or_404(
         BandMaskCanonicalComparisonResponse,
         get_band_masks_canonical_comparison,
@@ -453,7 +497,6 @@ def band_masks_canonical_comparison() -> BandMaskCanonicalComparisonResponse:
     response_model_exclude_none=True,
 )
 def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
-    from app.services.content import get_band_mask_summary
     return _typed_or_404(
         BandMaskSummaryResponse,
         get_band_mask_summary,
@@ -468,7 +511,6 @@ def band_mask_summary(scene_id: str, mask_id: str) -> BandMaskSummaryResponse:
     response_model_exclude_none=True,
 )
 def band_masks_hidsag_index() -> BandMasksHidsagIndexResponse:
-    from app.services.content import get_band_masks_hidsag_index
     return _typed_or_404(
         BandMasksHidsagIndexResponse,
         get_band_masks_hidsag_index,
@@ -487,7 +529,6 @@ def band_masks_hidsag_index() -> BandMasksHidsagIndexResponse:
 def band_masks_hidsag_summary(
     subset_code: str, mask_id: str
 ) -> BandMaskHidsagSummaryResponse:
-    from app.services.content import get_band_masks_hidsag_summary
     return _typed_or_404(
         BandMaskHidsagSummaryResponse,
         get_band_masks_hidsag_summary,
@@ -498,7 +539,6 @@ def band_masks_hidsag_summary(
 
 @router.get("/groupings")
 def groupings_index() -> dict:
-    from app.services.content import get_groupings_index
     return _serve_or_404(
         get_groupings_index,
         hint="groupings not generated yet; run scripts/local.* build-groupings",
@@ -507,7 +547,6 @@ def groupings_index() -> dict:
 
 @router.get("/groupings/{method}/{scene_id}")
 def grouping(method: str, scene_id: str) -> dict:
-    from app.services.content import get_grouping
     return _serve_or_404(
         get_grouping, method, scene_id,
         hint=f"grouping {method}/{scene_id} not generated yet",
@@ -516,7 +555,6 @@ def grouping(method: str, scene_id: str) -> dict:
 
 @router.get("/cross-method-agreement/{scene_id}")
 def cross_method_agreement(scene_id: str) -> dict:
-    from app.services.content import get_cross_method_agreement
     return _serve_or_404(
         get_cross_method_agreement, scene_id,
         hint=f"cross-method agreement for '{scene_id}' not generated yet",
@@ -525,7 +563,6 @@ def cross_method_agreement(scene_id: str) -> dict:
 
 @router.get("/method-statistics-hidsag/{subset_code}")
 def method_statistics_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_method_statistics_hidsag
     return _serve_or_404(
         get_method_statistics_hidsag, subset_code,
         hint=f"method statistics for HIDSAG '{subset_code}' not generated yet",
@@ -534,7 +571,6 @@ def method_statistics_hidsag(subset_code: str) -> dict:
 
 @router.get("/external-validation/{scene_id}/literature")
 def external_validation_literature(scene_id: str) -> dict:
-    from app.services.content import get_external_validation_literature
     return _serve_or_404(
         get_external_validation_literature, scene_id,
         hint=f"literature alignment for '{scene_id}' not generated yet",
@@ -543,7 +579,6 @@ def external_validation_literature(scene_id: str) -> dict:
 
 @router.get("/external-validation/hidsag/{subset_code}/methods")
 def external_validation_hidsag_methods(subset_code: str) -> dict:
-    from app.services.content import get_external_validation_hidsag_methods
     return _serve_or_404(
         get_external_validation_hidsag_methods, subset_code,
         hint=f"HIDSAG method summary for '{subset_code}' not generated yet",
@@ -552,7 +587,6 @@ def external_validation_hidsag_methods(subset_code: str) -> dict:
 
 @router.get("/narratives/{scene_id}")
 def narratives(scene_id: str) -> dict:
-    from app.services.content import get_narratives
     return _serve_or_404(
         get_narratives, scene_id,
         hint=f"narrative for '{scene_id}' not generated yet",
@@ -561,7 +595,6 @@ def narratives(scene_id: str) -> dict:
 
 @router.get("/interpretability/{scene_id}/{card_type}")
 def interpretability(scene_id: str, card_type: str) -> dict:
-    from app.services.content import get_interpretability
     if card_type not in ("topic_cards", "band_cards", "document_cards"):
         raise HTTPException(status_code=400, detail="card_type must be topic_cards | band_cards | document_cards")
     return _serve_or_404(
@@ -572,7 +605,6 @@ def interpretability(scene_id: str, card_type: str) -> dict:
 
 @router.get("/quantization-sensitivity/{scene_id}")
 def quantization_sensitivity(scene_id: str) -> dict:
-    from app.services.content import get_quantization_sensitivity
     return _serve_or_404(
         get_quantization_sensitivity, scene_id,
         hint=f"quantization sensitivity for '{scene_id}' not generated yet",
@@ -581,7 +613,6 @@ def quantization_sensitivity(scene_id: str) -> dict:
 
 @router.get("/topic-variants")
 def topic_variants_index() -> dict:
-    from app.services.content import get_topic_variants_index
     return _serve_or_404(
         get_topic_variants_index,
         hint="topic variants not generated yet",
@@ -590,7 +621,6 @@ def topic_variants_index() -> dict:
 
 @router.get("/topic-variants/{variant}/{scene_id}")
 def topic_variant(variant: str, scene_id: str) -> dict:
-    from app.services.content import get_topic_variant
     return _serve_or_404(
         get_topic_variant, variant, scene_id,
         hint=f"topic variant {variant}/{scene_id} not generated yet",
@@ -599,7 +629,6 @@ def topic_variant(variant: str, scene_id: str) -> dict:
 
 @router.get("/lda-sweep/{scene_id}")
 def lda_sweep(scene_id: str) -> dict:
-    from app.services.content import get_lda_sweep
     return _serve_or_404(
         get_lda_sweep, scene_id,
         hint=f"lda_sweep for '{scene_id}' not generated yet",
@@ -608,7 +637,6 @@ def lda_sweep(scene_id: str) -> dict:
 
 @router.get("/representations")
 def representations_index() -> dict:
-    from app.services.content import get_representations_index
     return _serve_or_404(
         get_representations_index,
         hint="representations not generated yet",
@@ -617,7 +645,6 @@ def representations_index() -> dict:
 
 @router.get("/representations/{method}/{scene_id}")
 def representation(method: str, scene_id: str) -> dict:
-    from app.services.content import get_representation
     return _serve_or_404(
         get_representation, method, scene_id,
         hint=f"representation {method}/{scene_id} not generated yet",
@@ -626,7 +653,6 @@ def representation(method: str, scene_id: str) -> dict:
 
 @router.get("/dmr-lda-hidsag/{subset_code}")
 def dmr_lda_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_dmr_lda_hidsag
     return _serve_or_404(
         get_dmr_lda_hidsag, subset_code,
         hint=f"dmr_lda_hidsag for '{subset_code}' not generated yet",
@@ -635,11 +661,6 @@ def dmr_lda_hidsag(subset_code: str) -> dict:
 
 @router.get("/bayesian-comparison/{task_type}")
 def bayesian_comparison(task_type: str) -> dict:
-    from app.services.content import (
-        get_bayesian_classification_labelled,
-        get_bayesian_classification_labelled_deep,
-        get_bayesian_comparison,
-    )
     if task_type == "classification-labelled":
         return _serve_or_404(
             get_bayesian_classification_labelled,
@@ -663,7 +684,6 @@ def bayesian_comparison(task_type: str) -> dict:
 
 @router.get("/optuna-search/{scene_id}")
 def optuna_search(scene_id: str) -> dict:
-    from app.services.content import get_optuna_search
     return _serve_or_404(
         get_optuna_search, scene_id,
         hint=f"optuna_search for '{scene_id}' not generated yet",
@@ -672,7 +692,6 @@ def optuna_search(scene_id: str) -> dict:
 
 @router.get("/linear-probe-panel/{scene_id}")
 def linear_probe_panel(scene_id: str) -> dict:
-    from app.services.content import get_linear_probe_panel
     return _serve_or_404(
         get_linear_probe_panel, scene_id,
         hint=f"linear_probe_panel for '{scene_id}' not generated yet",
@@ -681,7 +700,6 @@ def linear_probe_panel(scene_id: str) -> dict:
 
 @router.get("/mutual-information/{scene_id}")
 def mutual_information(scene_id: str) -> dict:
-    from app.services.content import get_mutual_information
     return _serve_or_404(
         get_mutual_information, scene_id,
         hint=f"mutual_information for '{scene_id}' not generated yet",
@@ -690,7 +708,6 @@ def mutual_information(scene_id: str) -> dict:
 
 @router.get("/mutual-information/hidsag/{subset_code}")
 def mutual_information_hidsag(subset_code: str) -> dict:
-    from app.services.content import get_mutual_information_hidsag
     return _serve_or_404(
         get_mutual_information_hidsag, subset_code,
         hint=f"mutual_information for HIDSAG '{subset_code}' not generated yet",
@@ -699,7 +716,6 @@ def mutual_information_hidsag(subset_code: str) -> dict:
 
 @router.get("/rate-distortion-curve/{scene_id}")
 def rate_distortion_curve(scene_id: str) -> dict:
-    from app.services.content import get_rate_distortion_curve
     return _serve_or_404(
         get_rate_distortion_curve, scene_id,
         hint=f"rate_distortion_curve for '{scene_id}' not generated yet",
@@ -708,7 +724,6 @@ def rate_distortion_curve(scene_id: str) -> dict:
 
 @router.get("/topic-routed-classifier/{scene_id}")
 def topic_routed_classifier(scene_id: str) -> dict:
-    from app.services.content import get_topic_routed_classifier
     return _serve_or_404(
         get_topic_routed_classifier, scene_id,
         hint=f"topic_routed_classifier for '{scene_id}' not generated yet",
@@ -717,7 +732,6 @@ def topic_routed_classifier(scene_id: str) -> dict:
 
 @router.get("/topic-routed-deep-gate/{scene_id}")
 def topic_routed_deep_gate(scene_id: str) -> dict:
-    from app.services.content import get_topic_routed_deep_gate
     return _serve_or_404(
         get_topic_routed_deep_gate, scene_id,
         hint=f"topic_routed_deep_gate for '{scene_id}' not generated yet",
@@ -726,7 +740,6 @@ def topic_routed_deep_gate(scene_id: str) -> dict:
 
 @router.get("/neural-topic-comparison/{scene_id}")
 def neural_topic_comparison(scene_id: str) -> dict:
-    from app.services.content import get_neural_topic_comparison
     return _serve_or_404(
         get_neural_topic_comparison, scene_id,
         hint=f"neural_topic_comparison for '{scene_id}' not generated yet",
@@ -735,7 +748,6 @@ def neural_topic_comparison(scene_id: str) -> dict:
 
 @router.get("/neural-topic-seed-stability/{scene_id}")
 def neural_topic_seed_stability(scene_id: str) -> dict:
-    from app.services.content import get_neural_topic_seed_stability
     return _serve_or_404(
         get_neural_topic_seed_stability, scene_id,
         hint=f"neural_topic_seed_stability for '{scene_id}' not generated yet",
@@ -744,7 +756,6 @@ def neural_topic_seed_stability(scene_id: str) -> dict:
 
 @router.get("/embedded-baseline/{scene_id}")
 def embedded_baseline(scene_id: str) -> dict:
-    from app.services.content import get_embedded_baseline
     return _serve_or_404(
         get_embedded_baseline, scene_id,
         hint=f"embedded_baseline for '{scene_id}' not generated yet",
@@ -753,7 +764,6 @@ def embedded_baseline(scene_id: str) -> dict:
 
 @router.get("/topic-stability/{scene_id}")
 def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
-    from app.services.content import get_topic_stability
     try:
         return get_topic_stability(scene_id, k_offset=k_offset)
     except FileNotFoundError as exc:
@@ -765,7 +775,6 @@ def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
 
 @router.get("/deep-seed-stability/{scene_id}")
 def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 7) -> dict:
-    from app.services.content import get_deep_seed_stability
     try:
         return get_deep_seed_stability(scene_id, method=method, n_seeds=n_seeds)
     except FileNotFoundError as exc:
@@ -777,7 +786,6 @@ def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 
 
 @router.get("/deep-anomaly/{scene_id}")
 def deep_anomaly(scene_id: str) -> dict:
-    from app.services.content import get_deep_anomaly
     return _serve_or_404(
         get_deep_anomaly, scene_id,
         hint=f"deep_anomaly for '{scene_id}' not generated yet",
@@ -786,7 +794,6 @@ def deep_anomaly(scene_id: str) -> dict:
 
 @router.get("/classical-seed-stability/{scene_id}")
 def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
-    from app.services.content import get_classical_seed_stability
     try:
         return get_classical_seed_stability(scene_id, method=method)
     except FileNotFoundError as exc:
@@ -798,7 +805,6 @@ def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
 
 @router.get("/topic-to-usgs-v7/{scene_id}")
 def topic_to_usgs_v7(scene_id: str) -> dict:
-    from app.services.content import get_topic_to_usgs_v7
     return _serve_or_404(
         get_topic_to_usgs_v7, scene_id,
         hint=f"topic_to_usgs_v7 for '{scene_id}' not generated yet",
@@ -807,7 +813,6 @@ def topic_to_usgs_v7(scene_id: str) -> dict:
 
 @router.get("/hidsag-cross-preprocessing-stability/{subset_code}")
 def hidsag_cross_preprocessing_stability(subset_code: str) -> dict:
-    from app.services.content import get_hidsag_cross_preprocessing_stability
     return _serve_or_404(
         get_hidsag_cross_preprocessing_stability, subset_code,
         hint=f"hidsag_cross_preprocessing_stability for '{subset_code}' not generated yet",
@@ -816,7 +821,6 @@ def hidsag_cross_preprocessing_stability(subset_code: str) -> dict:
 
 @router.get("/topic-anomaly/{scene_id}")
 def topic_anomaly(scene_id: str) -> dict:
-    from app.services.content import get_topic_anomaly
     return _serve_or_404(
         get_topic_anomaly, scene_id,
         hint=f"topic_anomaly for '{scene_id}' not generated yet",
@@ -825,7 +829,6 @@ def topic_anomaly(scene_id: str) -> dict:
 
 @router.get("/topic-spatial-continuous/{scene_id}")
 def topic_spatial_continuous(scene_id: str) -> dict:
-    from app.services.content import get_topic_spatial_continuous
     return _serve_or_404(
         get_topic_spatial_continuous, scene_id,
         hint=f"topic_spatial_continuous for '{scene_id}' not generated yet",
@@ -834,7 +837,6 @@ def topic_spatial_continuous(scene_id: str) -> dict:
 
 @router.get("/topic-spatial-full/{scene_id}")
 def topic_spatial_full(scene_id: str) -> dict:
-    from app.services.content import get_topic_spatial_full
     return _serve_or_404(
         get_topic_spatial_full, scene_id,
         hint=f"topic_spatial_full for '{scene_id}' not generated yet",
@@ -843,7 +845,6 @@ def topic_spatial_full(scene_id: str) -> dict:
 
 @router.get("/endmember-baseline/{scene_id}")
 def endmember_baseline(scene_id: str) -> dict:
-    from app.services.content import get_endmember_baseline
     return _serve_or_404(
         get_endmember_baseline, scene_id,
         hint=f"endmember_baseline for '{scene_id}' not generated yet",
@@ -852,7 +853,6 @@ def endmember_baseline(scene_id: str) -> dict:
 
 @router.get("/llm-tea-leaves/{scene_id}")
 def llm_tea_leaves(scene_id: str) -> dict:
-    from app.services.content import get_llm_tea_leaves
     return _serve_or_404(
         get_llm_tea_leaves, scene_id,
         hint=(
@@ -864,7 +864,6 @@ def llm_tea_leaves(scene_id: str) -> dict:
 
 @router.get("/super-topics")
 def super_topics() -> dict:
-    from app.services.content import get_super_topics
     return _serve_or_404(
         get_super_topics,
         hint="super_topics not generated yet",
@@ -873,7 +872,6 @@ def super_topics() -> dict:
 
 @router.get("/cross-scene-transfer")
 def cross_scene_transfer() -> dict:
-    from app.services.content import get_cross_scene_transfer
     return _serve_or_404(
         get_cross_scene_transfer,
         hint="cross_scene_transfer not generated yet",

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -10,6 +10,14 @@ from app.models.band_masks import (
     BandMasksHidsagIndexResponse,
     BandMasksIndexResponse,
 )
+from app.models.precompute import (
+    SpatialValidationResponse,
+    TopicToDataResponse,
+    TopicViewsResponse,
+    ValidationBlocksResponse,
+    WordificationResponse,
+    WordificationsIndexResponse,
+)
 from app.models.schemas import (
     AnalysisPayload,
     AppPayload,
@@ -272,11 +280,15 @@ def eda_per_scene(scene_id: str) -> dict:
         ) from exc
 
 
-@router.get("/topic-views/{scene_id}")
-def topic_views(scene_id: str) -> dict:
+@router.get(
+    "/topic-views/{scene_id}",
+    response_model=TopicViewsResponse,
+    response_model_exclude_none=True,
+)
+def topic_views(scene_id: str) -> TopicViewsResponse:
     from app.services.content import get_topic_views
     try:
-        return get_topic_views(scene_id)
+        return TopicViewsResponse.model_validate(get_topic_views(scene_id))
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -284,11 +296,15 @@ def topic_views(scene_id: str) -> dict:
         ) from exc
 
 
-@router.get("/topic-to-data/{scene_id}")
-def topic_to_data(scene_id: str) -> dict:
+@router.get(
+    "/topic-to-data/{scene_id}",
+    response_model=TopicToDataResponse,
+    response_model_exclude_none=True,
+)
+def topic_to_data(scene_id: str) -> TopicToDataResponse:
     from app.services.content import get_topic_to_data
     try:
-        return get_topic_to_data(scene_id)
+        return TopicToDataResponse.model_validate(get_topic_to_data(scene_id))
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -320,11 +336,15 @@ def spectral_density(scene_id: str) -> dict:
         ) from exc
 
 
-@router.get("/validation-blocks/{scene_id}")
-def validation_blocks(scene_id: str) -> dict:
+@router.get(
+    "/validation-blocks/{scene_id}",
+    response_model=ValidationBlocksResponse,
+    response_model_exclude_none=True,
+)
+def validation_blocks(scene_id: str) -> ValidationBlocksResponse:
     from app.services.content import get_validation_blocks
     try:
-        return get_validation_blocks(scene_id)
+        return ValidationBlocksResponse.model_validate(get_validation_blocks(scene_id))
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -356,11 +376,15 @@ def topic_to_library(scene_id: str) -> dict:
         ) from exc
 
 
-@router.get("/spatial/{scene_id}")
-def spatial_validation(scene_id: str) -> dict:
+@router.get(
+    "/spatial/{scene_id}",
+    response_model=SpatialValidationResponse,
+    response_model_exclude_none=True,
+)
+def spatial_validation(scene_id: str) -> SpatialValidationResponse:
     from app.services.content import get_spatial_validation
     try:
-        return get_spatial_validation(scene_id)
+        return SpatialValidationResponse.model_validate(get_spatial_validation(scene_id))
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -368,11 +392,15 @@ def spatial_validation(scene_id: str) -> dict:
         ) from exc
 
 
-@router.get("/wordifications")
-def wordifications_index() -> dict:
+@router.get(
+    "/wordifications",
+    response_model=WordificationsIndexResponse,
+    response_model_exclude_none=True,
+)
+def wordifications_index() -> WordificationsIndexResponse:
     from app.services.content import get_wordifications_index
     try:
-        return get_wordifications_index()
+        return WordificationsIndexResponse.model_validate(get_wordifications_index())
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -380,11 +408,19 @@ def wordifications_index() -> dict:
         ) from exc
 
 
-@router.get("/wordifications/{scene_id}/{recipe}/{scheme}/{q}")
-def wordification(scene_id: str, recipe: str, scheme: str, q: int) -> dict:
+@router.get(
+    "/wordifications/{scene_id}/{recipe}/{scheme}/{q}",
+    response_model=WordificationResponse,
+    response_model_exclude_none=True,
+)
+def wordification(
+    scene_id: str, recipe: str, scheme: str, q: int
+) -> WordificationResponse:
     from app.services.content import get_wordification
     try:
-        return get_wordification(scene_id, recipe, scheme, q)
+        return WordificationResponse.model_validate(
+            get_wordification(scene_id, recipe, scheme, q)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+# Pinned dev-only deps for the backend test suite (closes #440 P1
+# item 1.7). Keep in sync with the versions installed in the
+# developer venv; the prod systemd unit on Hetzner only installs
+# requirements.txt.
+pytest==8.4.2
+httpx==0.27.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for the backend test suite.
+
+Tests reuse the real `data/derived/*.json` artefacts produced by the
+pipeline — the smoke harness already proves they exist on a working
+deploy, and the test suite asserts router behaviour (status codes,
+response shapes) without recreating those payloads.
+
+This keeps the scaffold zero-config: `pytest` against a clean checkout
+of a developer machine that has run `bash scripts/local.sh build-*`
+once will pass.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="session")
+def client() -> TestClient:
+    """FastAPI TestClient bound to the live ASGI app.
+
+    Session-scoped so we pay the app-import cost once across the suite.
+    """
+    from app.main import app
+    return TestClient(app)

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -1,0 +1,46 @@
+"""Happy-path tests for the band-masks route family (c236 + c239)."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_band_masks_index_returns_24_entries(client: TestClient) -> None:
+    res = client.get("/api/band-masks")
+    assert res.status_code == 200
+    body = res.json()
+    assert "entries" in body
+    assert len(body["entries"]) == 24
+    assert "mask_definitions" in body
+    assert {"vnir", "swir", "no_water", "top_50_fisher"}.issubset(body["mask_definitions"].keys())
+
+
+def test_band_masks_canonical_comparison_has_24_entries(client: TestClient) -> None:
+    res = client.get("/api/band-masks/canonical-comparison")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["entries"]) == 24
+    sample = body["entries"][0]
+    assert "paired_ari_dominant_topics" in sample or "skipped" in sample
+
+
+def test_band_mask_summary_indian_pines_vnir(client: TestClient) -> None:
+    res = client.get("/api/band-masks/indian-pines-corrected/vnir")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == "indian-pines-corrected"
+    assert body["mask_id"] == "vnir"
+    assert body["topic_count"] == 12
+    assert body["n_bands_kept"] == 67
+
+
+def test_band_masks_hidsag_index(client: TestClient) -> None:
+    res = client.get("/api/band-masks-hidsag")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["modality"] == "swir_low"
+    assert len(body["entries"]) == 20
+
+
+def test_band_mask_unknown_returns_404(client: TestClient) -> None:
+    res = client.get("/api/band-masks/nonexistent-scene/vnir")
+    assert res.status_code == 404

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,25 @@
+"""Regression tests for security-sensitive behaviour (#440 P0)."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_spa_fallback_blocks_path_traversal(client: TestClient) -> None:
+    """c224 (PR #449) added a path-traversal guard to the SPA fallback.
+
+    A request whose path resolves outside the frontend dist must fall
+    through to index.html rather than serve the targeted file.
+    """
+    # The bypass attempt: ask for a file in the app/ package via traversal.
+    res = client.get("/../app/config.py")
+    assert res.status_code == 200
+    # Body must be the SPA shell, not the Python source.
+    body = res.text
+    assert "<!doctype html" in body.lower() or "<!DOCTYPE html" in body
+    assert "Settings(BaseSettings)" not in body, "path traversal must NOT leak app/config.py"
+
+
+def test_unknown_spa_path_serves_index(client: TestClient) -> None:
+    res = client.get("/some/non-existing/path")
+    assert res.status_code == 200
+    assert "<!doctype html" in res.text.lower() or "<!DOCTYPE html" in res.text

--- a/tests/test_topic_views.py
+++ b/tests/test_topic_views.py
@@ -1,0 +1,55 @@
+"""Happy-path tests for the typed topic-views / topic-to-data /
+spatial / validation-blocks routes (c238)."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+LABELLED_SCENES = [
+    "indian-pines-corrected",
+    "salinas-corrected",
+    "salinas-a-corrected",
+    "pavia-university",
+    "kennedy-space-center",
+    "botswana",
+]
+
+
+@pytest.mark.parametrize("scene", LABELLED_SCENES)
+def test_topic_views_per_scene(client: TestClient, scene: str) -> None:
+    res = client.get(f"/api/topic-views/{scene}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == scene
+    assert body["topic_count"] >= 4
+    assert isinstance(body["wavelengths_nm"], list)
+    assert "top_words_per_topic" in body
+    assert "lambda_0.5" in body["top_words_per_topic"]
+
+
+@pytest.mark.parametrize("scene", LABELLED_SCENES)
+def test_topic_to_data_per_scene(client: TestClient, scene: str) -> None:
+    res = client.get(f"/api/topic-to-data/{scene}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == scene
+    assert "p_label_given_topic_dominant" in body
+    assert "spatial_shape" in body
+
+
+def test_spatial_indian_pines(client: TestClient) -> None:
+    res = client.get("/api/spatial/indian-pines-corrected")
+    assert res.status_code == 200
+    body = res.json()
+    assert "morans_I_weighted_by_topic_support" in body
+    assert 0.0 <= body["morans_I_weighted_by_topic_support"] <= 1.0
+
+
+def test_validation_blocks_indian_pines(client: TestClient) -> None:
+    res = client.get("/api/validation-blocks/indian-pines-corrected")
+    assert res.status_code == 200
+    body = res.json()
+    assert "blocks" in body
+    block_ids = {b["block_id"] for b in body["blocks"]}
+    assert "corpus-integrity" in block_ids

--- a/tests/test_wordifications.py
+++ b/tests/test_wordifications.py
@@ -1,0 +1,28 @@
+"""Happy-path tests for the wordifications routes (c238)."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_wordifications_index(client: TestClient) -> None:
+    res = client.get("/api/wordifications")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["count"] > 0
+    assert len(body["items"]) == body["count"]
+
+
+def test_wordification_botswana_v10(client: TestClient) -> None:
+    res = client.get("/api/wordifications/botswana/V10/lloyd_max/16")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["scene_id"] == "botswana"
+    assert body["recipe"] == "V10"
+    assert body["scheme"] == "lloyd_max"
+    assert body["Q"] == 16
+    assert "doc_length_distribution" in body
+
+
+def test_wordification_unknown_returns_404(client: TestClient) -> None:
+    res = client.get("/api/wordifications/no-such-scene/V10/lloyd_max/16")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary

Five backend cycles since the c232-c236 deploy (PR #461), all closing
items off issue #440:

- **c238** (#462): Pydantic response models for 6 more precompute routes —
  wordifications x2, topic-views, topic-to-data, spatial, validation-blocks.
  Cumulative typed-handler coverage: 11 of 56.
- **c239** (#463): wire up \`_serve_or_404\` + \`_typed_or_404\` helpers
  across 40+ handlers. HTTPException raise count: 65 → 10. -49 LOC.
- **c240** (#464): hoist 56 per-request lazy imports to module top.
  -62 LOC.
- **c241** (#465): CORS dev/prod origin split keyed on \`app_env\`.
  Prod no longer advertises CORS to localhost.
- **c242** (#466): bootstrap pytest scaffold + 24 happy-path tests
  (band-masks 5 + topic-views/topic-to-data/spatial/validation-blocks
  14 + wordifications 3 + security 2). \`pytest tests/ -v\` runs in 1.1s.

Closes on #440:
- P0 1.5 (c224, already deployed)
- P1 1.1 + 1.3 (c239, this batch)
- P1 1.2 partial (c236 + c238, this batch)
- P1 1.4 (c240, this batch)
- P1 1.7 (c242, this batch)
- P2 1.6 (c241, this batch)

Remaining open on #440: continue P1 1.2 across the other 45
untyped handlers (mechanical follow-on cycles).

## Deploy note

This batch is backend-only — no frontend changes. The new
\`response_model_exclude_none=True\` keeps the wire format
byte-identical to the previous \`-> dict\` returns, verified locally
via deep field-by-field comparison.

For c241 to take effect in prod, the systemd unit must set
\`APP_ENV=production\`. To be verified during deploy.

## Test plan

- [x] Each task PR's local smoke harness 109/109 verified.
- [x] \`pytest tests/ -v\` → 24 passed locally.
- [ ] \`update.sh\` on Hetzner — pull, install, restart.
- [ ] \`systemctl show fasl-lda-hsi -p Environment\` confirms \`APP_ENV=production\`.
- [ ] Smoke 109/109 against https://lda-hsi.fasl-work.com.
- [ ] OpenAPI schema count monotonic ≥ 113.

Closes #440 except for P1 1.2 follow-on.