### PR TITLE
Deploy cycles 245-246: Pydantic third slice + a11y micro-fixes (#440 + #442)

### DIFF
--- a/app/models/precompute.py
+++ b/app/models/precompute.py
@@ -268,3 +268,350 @@ class ValidationBlocksResponse(BaseModel):
     blocks: list[ValidationBlock] = Field(default_factory=list)
     generated_at: str
     builder_version: str
+
+
+# ---------------- eda per-scene ----------------
+
+
+class EdaClassDistributionRow(BaseModel):
+    model_config = _PassThroughConfig
+    label_id: int
+    name: str | None = None
+    count: int
+    p: float | None = None
+    color: str | None = None
+
+
+class EdaPerScene(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    scene_name: str
+    sensor: str | None = None
+    family_id: str | None = None
+    spatial_shape: list[int]
+    n_pixels: int
+    n_labelled_pixels: int
+    n_classes: int
+    imbalance_gini: float
+    wavelengths_nm: list[float]
+    class_distribution: list[EdaClassDistributionRow]
+    # Builder ships per-label spectrum stats as a dict keyed by label_id;
+    # value is {mean: [...], std: [...], ...}, not just the mean vector.
+    class_mean_spectra: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    class_distance_cosine: dict[str, Any] = Field(default_factory=dict)
+    class_distance_sam_radians: dict[str, Any] = Field(default_factory=dict)
+    band_discriminative: list[dict[str, Any]] = Field(default_factory=list)
+    silhouette_label_as_cluster_cosine: dict[str, Any] = Field(default_factory=dict)
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- eda hidsag ----------------
+
+
+class EdaHidsag(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    sample_count: int
+    measurement_count_total: int
+    numeric_variable_names: list[str]
+    numeric_variables: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    dominant_targets_by_mean: list[dict[str, Any]] = Field(default_factory=list)
+    correlation_pearson: dict[str, Any] = Field(default_factory=dict)
+    correlation_spearman: dict[str, Any] = Field(default_factory=dict)
+    modality_band_counts: dict[str, int] = Field(default_factory=dict)
+    measurement_tags_top: list[Any] = Field(default_factory=list)
+    spectrum_axis: list[dict[str, Any]] = Field(default_factory=list)
+    mean_spectrum_by_measurement: list[dict[str, Any]] = Field(default_factory=list)
+    mean_spectrum_by_measurement_stratum: list[Any] = Field(default_factory=list)
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- spectral browser ----------------
+
+
+class SpectralBrowserMetadata(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    scene_name: str
+    spatial_shape: list[int]
+    sampling_strategy: str
+    random_state: int
+    N: int
+    B: int
+    format: str
+    spectra_path: str
+    wavelengths_nm: list[float]
+    rows: list[dict[str, Any]]
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- spectral density ----------------
+
+
+class SpectralDensityBinPath(BaseModel):
+    model_config = _PassThroughConfig
+    path: str
+    n_pixels_sampled: int | None = None
+
+
+class SpectralDensityByLabel(BaseModel):
+    model_config = _PassThroughConfig
+    label_id: int
+    path: str
+    n_pixels_sampled: int | None = None
+
+
+class SpectralDensityByTopic(BaseModel):
+    model_config = _PassThroughConfig
+    topic_k: int
+    path: str
+    n_pixels_sampled: int | None = None
+
+
+class SpectralDensityManifest(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    scene_name: str
+    B: int
+    R_bins: int
+    reflectance_range: list[float]
+    wavelengths_nm: list[float]
+    format: str
+    shape_per_file: list[int]
+    density_global: SpectralDensityBinPath
+    density_by_label: list[dict[str, Any]] = Field(default_factory=list)
+    density_by_topic: list[dict[str, Any]] = Field(default_factory=list)
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- topic-to-library ----------------
+
+
+class TopicToLibrary(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    library_sensor_subset: str
+    library_sample_names: list[str]
+    library_sample_groups: list[str]
+    library_sample_count: int
+    topic_x_library_cosine: list[list[float]]
+    topic_x_library_sam_radians: list[list[float]]
+    top_n_per_topic: list[list[dict[str, Any]]]
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- quantization sensitivity ----------------
+
+
+class QuantizationProbe(BaseModel):
+    model_config = _PassThroughConfig
+    recipe: str | None = None
+    scheme: str | None = None
+    Q: int | None = None
+    matched_cosine_mean: float | None = None
+    ari: float | None = None
+
+
+class QuantizationSummary(BaseModel):
+    model_config = _PassThroughConfig
+    n_configs_compared: int
+    matched_cosine_mean_overall_mean: float
+    matched_cosine_mean_overall_min: float
+    ari_overall_mean: float
+    ari_overall_min: float
+    verdict: str | None = None
+
+
+class QuantizationSensitivity(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    canonical_recipe: str
+    canonical_scheme: str
+    canonical_Q: int
+    probes: list[dict[str, Any]] = Field(default_factory=list)
+    summary: QuantizationSummary
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- super-topics ----------------
+
+
+class SuperTopicMember(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str | None = None
+    topic_k: int | None = None
+    leaf_index: int | None = None
+
+
+class SuperTopicCut(BaseModel):
+    model_config = _PassThroughConfig
+    K_super: int | None = None
+    assignments: list[int] | None = None
+    cluster_sizes: list[int] | None = None
+
+
+class SuperTopics(BaseModel):
+    model_config = _PassThroughConfig
+    n_topics_total: int
+    n_scenes: int
+    scenes: list[str]
+    common_grid: dict[str, Any]
+    linkage_method: str
+    distance: str
+    linkage_matrix_round6: list[list[float]]
+    cuts: list[dict[str, Any]] = Field(default_factory=list)
+    scene_pair_super_topic_overlap_at_cut8: dict[str, Any] = Field(default_factory=dict)
+    members: list[dict[str, Any]] = Field(default_factory=list)
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- cross-scene transfer ----------------
+
+
+class CrossSceneTransferPair(BaseModel):
+    model_config = _PassThroughConfig
+    source_scene: str | None = None
+    target_scene: str | None = None
+    macro_f1: float | None = None
+
+
+class CrossSceneTransfer(BaseModel):
+    model_config = _PassThroughConfig
+    scene_order: list[str]
+    common_wavelength_grid: dict[str, Any]
+    wordification: str
+    quantization_scale: int
+    samples_per_class: int
+    split: str
+    head: str
+    transfer_matrix_macro_f1: list[list[float]]
+    transfer_pairs: list[dict[str, Any]]
+    scene_meta: list[dict[str, Any]]
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- lda sweep ----------------
+
+
+class LdaSweepGridEntry(BaseModel):
+    model_config = _PassThroughConfig
+    K: int | None = None
+    perplexity_test_norm: float | None = None
+    npmi_mean: float | None = None
+    matched_cosine_mean: float | None = None
+    score: float | None = None
+
+
+class LdaSweep(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K_grid: list[int]
+    seeds: list[int]
+    samples_per_class: int
+    wordification: str
+    quantization_scale: int
+    train_fraction: float
+    grid: list[dict[str, Any]]
+    recommended_K: int
+    recommendation_method: str
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- linear probe panel ----------------
+
+
+class LinearProbeMethodMetrics(BaseModel):
+    model_config = _PassThroughConfig
+    accuracy: float | None = None
+    balanced_accuracy: float | None = None
+    macro_f1: float | None = None
+    latent_dim: int | None = None
+
+
+class LinearProbePairwiseHolm(BaseModel):
+    model_config = _PassThroughConfig
+    method: str | None = None
+    delta_macro_f1: float | None = None
+    p_holm: float | None = None
+    significant: bool | None = None
+
+
+class LinearProbeRanking(BaseModel):
+    model_config = _PassThroughConfig
+    method: str
+    macro_f1_mean: float | None = None
+    macro_f1_std: float | None = None
+    rank: int | None = None
+
+
+class LinearProbePanel(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    n_classes: int
+    n_documents: int
+    head: str
+    split: str
+    metric: str
+    method_metrics: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    pairwise_vs_theta_holm: list[dict[str, Any]] = Field(default_factory=list)
+    ranking_by_macro_f1_mean: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+# ---------------- mutual information ----------------
+
+
+class MutualInformationRanking(BaseModel):
+    model_config = _PassThroughConfig
+    method: str
+    joint_mi: float | None = None
+    rank: int | None = None
+
+
+class MutualInformation(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    n_documents: int
+    label_entropy_nats: float
+    label_entropy_bits: float
+    method_mi: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    ranking_by_joint_mi: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class MutualInformationHidsagRanking(BaseModel):
+    model_config = _PassThroughConfig
+    target: str | None = None
+    max_mi: float | None = None
+    rank: int | None = None
+
+
+class MutualInformationHidsag(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    topic_count: int
+    document_count: int
+    covariates_in_dmr: list[str]
+    target_mi_against_theta: dict[str, Any] = Field(default_factory=dict)
+    ranking_by_max_mi: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -11,8 +11,20 @@ from app.models.band_masks import (
     BandMasksIndexResponse,
 )
 from app.models.precompute import (
+    CrossSceneTransfer,
+    EdaHidsag,
+    EdaPerScene,
+    LdaSweep,
+    LinearProbePanel,
+    MutualInformation,
+    MutualInformationHidsag,
+    QuantizationSensitivity,
     SpatialValidationResponse,
+    SpectralBrowserMetadata,
+    SpectralDensityManifest,
+    SuperTopics,
     TopicToDataResponse,
+    TopicToLibrary,
     TopicViewsResponse,
     ValidationBlocksResponse,
     WordificationResponse,
@@ -329,9 +341,14 @@ def derived_manifest() -> dict:
     )
 
 
-@router.get("/eda/per-scene/{scene_id}")
-def eda_per_scene(scene_id: str) -> dict:
-    return _serve_or_404(
+@router.get(
+    "/eda/per-scene/{scene_id}",
+    response_model=EdaPerScene,
+    response_model_exclude_none=True,
+)
+def eda_per_scene(scene_id: str) -> EdaPerScene:
+    return _typed_or_404(
+        EdaPerScene,
         get_eda_per_scene,
         scene_id,
         hint=f"eda views for '{scene_id}' not generated yet; run scripts/local.* build-eda-per-scene",
@@ -366,18 +383,28 @@ def topic_to_data(scene_id: str) -> TopicToDataResponse:
     )
 
 
-@router.get("/spectral-browser/{scene_id}")
-def spectral_browser(scene_id: str) -> dict:
-    return _serve_or_404(
+@router.get(
+    "/spectral-browser/{scene_id}",
+    response_model=SpectralBrowserMetadata,
+    response_model_exclude_none=True,
+)
+def spectral_browser(scene_id: str) -> SpectralBrowserMetadata:
+    return _typed_or_404(
+        SpectralBrowserMetadata,
         get_spectral_browser_metadata,
         scene_id,
         hint=f"spectral browser for '{scene_id}' not generated yet; run scripts/local.* build-spectral-browser",
     )
 
 
-@router.get("/spectral-density/{scene_id}")
-def spectral_density(scene_id: str) -> dict:
-    return _serve_or_404(
+@router.get(
+    "/spectral-density/{scene_id}",
+    response_model=SpectralDensityManifest,
+    response_model_exclude_none=True,
+)
+def spectral_density(scene_id: str) -> SpectralDensityManifest:
+    return _typed_or_404(
+        SpectralDensityManifest,
         get_spectral_density_manifest,
         scene_id,
         hint=f"spectral density for '{scene_id}' not generated yet; run scripts/local.* build-spectral-density",
@@ -398,18 +425,28 @@ def validation_blocks(scene_id: str) -> ValidationBlocksResponse:
     )
 
 
-@router.get("/eda/hidsag/{subset_code}")
-def eda_hidsag(subset_code: str) -> dict:
-    return _serve_or_404(
+@router.get(
+    "/eda/hidsag/{subset_code}",
+    response_model=EdaHidsag,
+    response_model_exclude_none=True,
+)
+def eda_hidsag(subset_code: str) -> EdaHidsag:
+    return _typed_or_404(
+        EdaHidsag,
         get_eda_hidsag,
         subset_code,
         hint=f"HIDSAG EDA for '{subset_code}' not generated yet; run scripts/local.* build-eda-hidsag",
     )
 
 
-@router.get("/topic-to-library/{scene_id}")
-def topic_to_library(scene_id: str) -> dict:
-    return _serve_or_404(
+@router.get(
+    "/topic-to-library/{scene_id}",
+    response_model=TopicToLibrary,
+    response_model_exclude_none=True,
+)
+def topic_to_library(scene_id: str) -> TopicToLibrary:
+    return _typed_or_404(
+        TopicToLibrary,
         get_topic_to_library,
         scene_id,
         hint=f"topic-to-library for '{scene_id}' not generated yet; run scripts/local.* build-topic-to-library",
@@ -603,10 +640,14 @@ def interpretability(scene_id: str, card_type: str) -> dict:
     )
 
 
-@router.get("/quantization-sensitivity/{scene_id}")
-def quantization_sensitivity(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_quantization_sensitivity, scene_id,
+@router.get(
+    "/quantization-sensitivity/{scene_id}",
+    response_model=QuantizationSensitivity,
+    response_model_exclude_none=True,
+)
+def quantization_sensitivity(scene_id: str) -> QuantizationSensitivity:
+    return _typed_or_404(
+        QuantizationSensitivity, get_quantization_sensitivity, scene_id,
         hint=f"quantization sensitivity for '{scene_id}' not generated yet",
     )
 
@@ -627,10 +668,14 @@ def topic_variant(variant: str, scene_id: str) -> dict:
     )
 
 
-@router.get("/lda-sweep/{scene_id}")
-def lda_sweep(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_lda_sweep, scene_id,
+@router.get(
+    "/lda-sweep/{scene_id}",
+    response_model=LdaSweep,
+    response_model_exclude_none=True,
+)
+def lda_sweep(scene_id: str) -> LdaSweep:
+    return _typed_or_404(
+        LdaSweep, get_lda_sweep, scene_id,
         hint=f"lda_sweep for '{scene_id}' not generated yet",
     )
 
@@ -690,26 +735,38 @@ def optuna_search(scene_id: str) -> dict:
     )
 
 
-@router.get("/linear-probe-panel/{scene_id}")
-def linear_probe_panel(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_linear_probe_panel, scene_id,
+@router.get(
+    "/linear-probe-panel/{scene_id}",
+    response_model=LinearProbePanel,
+    response_model_exclude_none=True,
+)
+def linear_probe_panel(scene_id: str) -> LinearProbePanel:
+    return _typed_or_404(
+        LinearProbePanel, get_linear_probe_panel, scene_id,
         hint=f"linear_probe_panel for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/mutual-information/{scene_id}")
-def mutual_information(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_mutual_information, scene_id,
+@router.get(
+    "/mutual-information/{scene_id}",
+    response_model=MutualInformation,
+    response_model_exclude_none=True,
+)
+def mutual_information(scene_id: str) -> MutualInformation:
+    return _typed_or_404(
+        MutualInformation, get_mutual_information, scene_id,
         hint=f"mutual_information for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/mutual-information/hidsag/{subset_code}")
-def mutual_information_hidsag(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_mutual_information_hidsag, subset_code,
+@router.get(
+    "/mutual-information/hidsag/{subset_code}",
+    response_model=MutualInformationHidsag,
+    response_model_exclude_none=True,
+)
+def mutual_information_hidsag(subset_code: str) -> MutualInformationHidsag:
+    return _typed_or_404(
+        MutualInformationHidsag, get_mutual_information_hidsag, subset_code,
         hint=f"mutual_information for HIDSAG '{subset_code}' not generated yet",
     )
 
@@ -862,17 +919,25 @@ def llm_tea_leaves(scene_id: str) -> dict:
     )
 
 
-@router.get("/super-topics")
-def super_topics() -> dict:
-    return _serve_or_404(
-        get_super_topics,
+@router.get(
+    "/super-topics",
+    response_model=SuperTopics,
+    response_model_exclude_none=True,
+)
+def super_topics() -> SuperTopics:
+    return _typed_or_404(
+        SuperTopics, get_super_topics,
         hint="super_topics not generated yet",
     )
 
 
-@router.get("/cross-scene-transfer")
-def cross_scene_transfer() -> dict:
-    return _serve_or_404(
-        get_cross_scene_transfer,
+@router.get(
+    "/cross-scene-transfer",
+    response_model=CrossSceneTransfer,
+    response_model_exclude_none=True,
+)
+def cross_scene_transfer() -> CrossSceneTransfer:
+    return _typed_or_404(
+        CrossSceneTransfer, get_cross_scene_transfer,
         hint="cross_scene_transfer not generated yet",
     )

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -253,8 +253,18 @@ function HeroSpectralViz({ scenes }: { scenes: (ScenePeek | null)[] | null }) {
             viewBox={`0 0 ${W} ${H}`}
             className="w-full h-auto"
             role="img"
-            aria-label="Class mean spectra of Indian Pines"
+            aria-labelledby="hero-spectra-title hero-spectra-desc"
           >
+            <title id="hero-spectra-title">
+              Class mean spectra of Indian Pines, {series.length} classes overlaid
+            </title>
+            <desc id="hero-spectra-desc">
+              {series.length === 0
+                ? "Reflectance loading — wavelength axis 400 to 2500 nm."
+                : `Reflectance curves of the ${series.length} Indian Pines land-cover ` +
+                  `classes plotted against wavelength 400 to 2500 nm. Top three by ` +
+                  `prevalence: ${series.slice(0, 3).map((s) => s.name).join(", ")}.`}
+            </desc>
             {/* axis grid */}
             {[0.0, 0.25, 0.5, 0.75, 1.0].map((g) => (
               <line

--- a/frontend/src/pages/workspace/components/ExploreNav.tsx
+++ b/frontend/src/pages/workspace/components/ExploreNav.tsx
@@ -48,21 +48,33 @@ export function ExploreNav({
         {EXPLORE_PHASES.map((phase) => {
           const isActive = phase.id === activePhaseId;
           const isContainingCurrent = phase.id === currentPhase.id;
+          const containsActiveSuffix = isContainingCurrent && !isActive ? " — contains active tab" : "";
           return (
             <button
               key={phase.id}
               type="button"
               role="tab"
+              id={`phase-tab-${phase.id}`}
+              aria-controls={`phase-panel-${phase.id}`}
               aria-selected={isActive}
-              aria-label={`${phase.label} (${phase.tabs.length} tabs)`}
+              aria-label={`${phase.label} (${phase.tabs.length} tabs)${containsActiveSuffix}`}
               onClick={() => setActivePhaseId(phase.id)}
-              title={phase.description}
+              title={phase.description + (isContainingCurrent && !isActive ? " (contains the active tab)" : "")}
               className={cn(
-                "rounded-md border px-3.5 py-2 text-[13px] font-semibold transition-all inline-flex items-center gap-2",
+                "rounded-md border-l-4 border-y border-r px-3.5 py-2 text-[13px] font-semibold transition-all inline-flex items-center gap-2",
                 isActive ? "shadow-sm" : "opacity-70 hover:opacity-100",
               )}
               style={{
-                borderColor: isActive ? phase.color : "var(--color-border)",
+                // Left-border in phase color gives a non-color-only signal
+                // for phases that contain the active tab (WCAG 1.4.1).
+                borderLeftColor: isContainingCurrent
+                  ? phase.color
+                  : isActive
+                    ? phase.color
+                    : "var(--color-border)",
+                borderTopColor: isActive ? phase.color : "var(--color-border)",
+                borderBottomColor: isActive ? phase.color : "var(--color-border)",
+                borderRightColor: isActive ? phase.color : "var(--color-border)",
                 backgroundColor: isActive
                   ? "var(--color-accent-soft)"
                   : "var(--color-panel)",
@@ -84,59 +96,65 @@ export function ExploreNav({
               </span>
               {isContainingCurrent && !isActive && (
                 <span
-                  aria-hidden
-                  className="inline-block w-1.5 h-1.5 rounded-full"
-                  style={{ backgroundColor: phase.color }}
-                  title="contains the active tab"
-                />
+                  className="text-[10.5px] font-normal italic"
+                  style={{ color: "var(--color-fg-faint)" }}
+                >
+                  · active
+                </span>
               )}
             </button>
           );
         })}
       </div>
-      <p
-        className="text-[11.5px] italic"
-        style={{ color: "var(--color-fg-faint)" }}
-      >
-        {activePhase.description}
-      </p>
       <div
-        role="tablist"
-        aria-label={`${activePhase.label} panels`}
-        className="flex flex-wrap gap-1.5"
+        role="tabpanel"
+        id={`phase-panel-${activePhase.id}`}
+        aria-labelledby={`phase-tab-${activePhase.id}`}
       >
-        {activePhase.tabs.map((opt) => {
-          const isActive = tab === opt.id;
-          const label = t(
-            `pages:workspace.tabs.${opt.labelKey}` as never,
-          ) as string;
-          return (
-            <button
-              key={opt.id}
-              role="tab"
-              aria-selected={isActive}
-              type="button"
-              onClick={() => setTab(opt.id)}
-              className={cn(
-                "rounded-md border px-3 py-1.5 text-[13px] transition-all",
-                isActive
-                  ? "font-semibold shadow-sm"
-                  : "opacity-80 hover:opacity-100",
-              )}
-              style={{
-                borderColor: isActive
-                  ? activePhase.color
-                  : "var(--color-border)",
-                backgroundColor: isActive
-                  ? "var(--color-accent-soft)"
-                  : "var(--color-panel)",
-                color: isActive ? activePhase.color : "var(--color-fg)",
-              }}
-            >
-              {label}
-            </button>
-          );
-        })}
+        <p
+          className="text-[11.5px] italic mb-2.5"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {activePhase.description}
+        </p>
+        <div
+          role="tablist"
+          aria-label={`${activePhase.label} panels`}
+          className="flex flex-wrap gap-1.5"
+        >
+          {activePhase.tabs.map((opt) => {
+            const isActive = tab === opt.id;
+            const label = t(
+              `pages:workspace.tabs.${opt.labelKey}` as never,
+            ) as string;
+            return (
+              <button
+                key={opt.id}
+                role="tab"
+                aria-selected={isActive}
+                type="button"
+                onClick={() => setTab(opt.id)}
+                className={cn(
+                  "rounded-md border px-3 py-1.5 text-[13px] transition-all",
+                  isActive
+                    ? "font-semibold shadow-sm"
+                    : "opacity-80 hover:opacity-100",
+                )}
+                style={{
+                  borderColor: isActive
+                    ? activePhase.color
+                    : "var(--color-border)",
+                  backgroundColor: isActive
+                    ? "var(--color-accent-soft)"
+                    : "var(--color-panel)",
+                  color: isActive ? activePhase.color : "var(--color-fg)",
+                }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Two code-side cycles since the c238-242 deploy (PR #467):

- **c245** (#468): Pydantic response models for 12 more precompute
  routes — eda (per-scene + hidsag), spectral browser/density,
  topic-to-library, quantisation sensitivity, super-topics,
  cross-scene transfer, lda-sweep, linear-probe-panel, mutual-
  information (labelled + HIDSAG). Cumulative Pydantic-typed
  coverage: **23 of 56 untyped handlers (~41%)**.

- **c246** (#469): Frontend a11y micro-fixes — HeroSpectralViz now
  ships <title>+<desc> via aria-labelledby (data-driven; tracks the
  loaded scene); ExploreNav phase chip \"contains active tab\" signal
  upgraded from color-only dot (WCAG 1.4.1) to left-border in phase
  color + italic \"· active\" suffix; nested-tablists ARIA fixed via
  id/aria-controls/aria-labelledby/role=tabpanel wiring.

Paper repo cycle c247 (PR #11, develop only) lands a permutation null
+ bootstrap 95% CI on paired ARI across all 24 (scene, mask) tuples
— Salinas-A SWIR 0.766 CI [0.735, 0.800]; KSC ≈ 0.01 CI doesn't cross
zero but stays band-fragile vs every other scene. Closes another item
on paper #7.

## Test plan

- [x] Each task PR's smoke harness 109/109 verified.
- [x] \`pytest tests/ -v\` → 24 passed.
- [x] Frontend \`vite build\` clean.
- [ ] \`update.sh\` on Hetzner.
- [ ] Smoke 109/109 against https://lda-hsi.fasl-work.com.
- [ ] OpenAPI schema count monotonic ≥ 133.

Refs #440, #442.