### PR TITLE
Cycle 249: Pydantic response models for 19 more routes (#440)

### DIFF
--- a/app/models/precompute.py
+++ b/app/models/precompute.py
@@ -615,3 +615,323 @@ class MutualInformationHidsag(BaseModel):
     framework_axis: str | None = None
     generated_at: str
     builder_version: str
+
+
+# ============================================================================
+# c249: fourth-slice models — agreement, narrative, interpretability,
+# representations, topic-routed, neural-topic, rate-distortion, stability,
+# anomaly, USGS, endmember.
+# ============================================================================
+
+
+class CrossMethodAgreement(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    spatial_shape: list[int]
+    n_compared_pixels: int
+    method_names: list[str]
+    ari_matrix: list[list[float]]
+    nmi_matrix: list[list[float]]
+    v_measure_matrix: list[list[float]] | None = None
+    agreement_vs_label_summary: list[dict[str, Any]] = Field(default_factory=list)
+    agreement_vs_topic_dominant_summary: list[dict[str, Any]] = Field(default_factory=list)
+    generated_at: str
+    builder_version: str
+
+
+class Narratives(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    method_narratives: dict[str, Any] = Field(default_factory=dict)
+    generated_at: str
+    builder_version: str
+
+
+class InterpretabilityCards(BaseModel):
+    """Common envelope for topic_cards / band_cards / document_cards.
+
+    The interior structure differs per card_type so the cards list is
+    typed as dict[str, Any]; the route returns this same envelope for
+    all three card_type variants.
+    """
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    topic_cards: list[dict[str, Any]] | None = None
+    band_cards: list[dict[str, Any]] | None = None
+    document_cards: list[dict[str, Any]] | None = None
+    generated_at: str
+    builder_version: str
+
+
+class RepresentationFitMeta(BaseModel):
+    model_config = _PassThroughConfig
+    explained_variance_ratio: list[float] | None = None
+    explained_variance_total: float | None = None
+    reconstruction_rmse: float | None = None
+
+
+class Representation(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    method: str
+    n_documents: int
+    n_bands_input: int
+    latent_dim: int
+    fit_meta: dict[str, Any] | None = None
+    silhouette_label: dict[str, Any] | None = None
+    downstream_kmeans_vs_label: dict[str, Any] | None = None
+    scatter_pca_3d_explained_variance: list[float] | None = None
+    scatter_2d_3d_subsample: list[dict[str, Any]] | None = None
+    features_local_path: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicRoutedClassifier(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int
+    n_classes: int
+    n_documents: int
+    samples_per_class: int
+    wordification: str
+    quantization_scale: int
+    head: str
+    split: str
+    method_metrics: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    ranking_by_macro_f1_mean: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class NeuralTopicComparison(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    n_documents: int
+    n_classes: int | None = None
+    methods: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    ranking_by_ari: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class NeuralTopicSeedStability(BaseModel):
+    """Per-scene seed stability for ProdLDA / ETM / LDA."""
+    model_config = _PassThroughConfig
+    scene_id: str
+    n_seeds: int | None = None
+    methods: dict[str, dict[str, Any]] | None = None
+    method_metrics: dict[str, dict[str, Any]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class RateDistortionCurve(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K_grid: list[int]
+    doc_term_shape: list[int]
+    train_fraction: float
+    wordification: str
+    quantization_scale: int
+    samples_per_class: int
+    method_curves: dict[str, Any] = Field(default_factory=dict)
+    rmse_test_table_by_K: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicStability(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int
+    seeds: list[int]
+    wordification: str
+    quantization_scale: int
+    samples_per_class: int
+    seed_pair_matched_cosine_mean: list[list[float]]
+    seed_pair_matched_cosine_min: list[list[float]] | None = None
+    seed_pair_matched_cosine_std: list[list[float]] | None = None
+    per_topic_matched_cosine_vs_seed0: list[list[float]] | None = None
+    per_topic_stability_summary: list[dict[str, Any]] | None = None
+    scene_stability_summary: dict[str, Any] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class SeedStability(BaseModel):
+    """Common envelope for classical_seed_stability + deep_seed_stability."""
+    model_config = _PassThroughConfig
+    scene_id: str
+    method: str
+    n_seeds: int
+    latent_dim: int | None = None
+    samples_per_class: int | None = None
+    ari_vs_gt_per_seed: list[float] | None = None
+    nmi_vs_gt_per_seed: list[float] | None = None
+    ari_mean: float | None = None
+    ari_std: float | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class DeepAnomaly(BaseModel):
+    """Per-method anomaly-indicator block. Methods like cae_1d_8 and
+    beta_vae_8 appear as top-level keys with method-specific payloads.
+    """
+    model_config = _PassThroughConfig
+    scene_id: str
+    n_documents: int
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicAnomaly(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    n_documents: int
+    indicators: dict[str, Any]
+    anomaly_to_misclassification_correlation: dict[str, Any]
+    per_class_summary: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicSpatialContinuous(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    spatial_shape: list[int]
+    n_sampled_pixels: int
+    per_topic_continuous_spatial: list[dict[str, Any]] = Field(default_factory=list)
+    aggregated_morans_I_mean_over_topics: float | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicSpatialFull(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int | None = None
+    spatial_shape: list[int] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicToUsgsV7(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    library_subset: str
+    library_sample_count: int
+    library_chapter_counts: dict[str, int] | None = None
+    top_n_per_topic: list[list[dict[str, Any]]]
+    generated_at: str
+    builder_version: str
+
+
+class EndmemberBaseline(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    n_pixels_used: int | None = None
+    n_bands: int | None = None
+    endmember_extractors: list[str] | dict[str, Any] | None = None
+    unmixing_method: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class HidsagCrossPreprocessingStability(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str | None = None
+    methods: list[str] | None = None
+    matched_jaccard_top15: list[list[float]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicRoutedDeepGate(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    n_classes: int | None = None
+    n_documents: int | None = None
+    method_metrics: dict[str, dict[str, Any]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class EmbeddedBaseline(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    n_classes: int | None = None
+    n_documents: int | None = None
+    method_metrics: dict[str, dict[str, Any]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class OptunaSearch(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    trials: list[dict[str, Any]] | None = None
+    best_trial: dict[str, Any] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class DmrLdaHidsag(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    K: int | None = None
+    covariates: list[str] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class ExternalValidationLiterature(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    entries: list[dict[str, Any]] | None = None
+    methods: list[dict[str, Any]] | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None
+
+
+class ExternalValidationHidsagMethods(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    methods: list[dict[str, Any]] | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None
+
+
+class MethodStatisticsHidsag(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str | None = None
+    dataset_id: str | None = None
+    dataset_name: str | None = None
+    methods: dict[str, dict[str, Any]] | None = None
+    paired_comparisons: dict[str, Any] | None = None
+    ranking: dict[str, Any] | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -11,20 +11,44 @@ from app.models.band_masks import (
     BandMasksIndexResponse,
 )
 from app.models.precompute import (
+    CrossMethodAgreement,
     CrossSceneTransfer,
+    DeepAnomaly,
+    DmrLdaHidsag,
     EdaHidsag,
     EdaPerScene,
+    EmbeddedBaseline,
+    EndmemberBaseline,
+    ExternalValidationHidsagMethods,
+    ExternalValidationLiterature,
+    HidsagCrossPreprocessingStability,
+    InterpretabilityCards,
     LdaSweep,
     LinearProbePanel,
+    MethodStatisticsHidsag,
     MutualInformation,
     MutualInformationHidsag,
+    Narratives,
+    NeuralTopicComparison,
+    NeuralTopicSeedStability,
+    OptunaSearch,
     QuantizationSensitivity,
+    RateDistortionCurve,
+    Representation,
+    SeedStability,
     SpatialValidationResponse,
     SpectralBrowserMetadata,
     SpectralDensityManifest,
     SuperTopics,
+    TopicAnomaly,
+    TopicRoutedClassifier,
+    TopicRoutedDeepGate,
+    TopicSpatialContinuous,
+    TopicSpatialFull,
+    TopicStability,
     TopicToDataResponse,
     TopicToLibrary,
+    TopicToUsgsV7,
     TopicViewsResponse,
     ValidationBlocksResponse,
     WordificationResponse,
@@ -590,52 +614,76 @@ def grouping(method: str, scene_id: str) -> dict:
     )
 
 
-@router.get("/cross-method-agreement/{scene_id}")
-def cross_method_agreement(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_cross_method_agreement, scene_id,
+@router.get(
+    "/cross-method-agreement/{scene_id}",
+    response_model=CrossMethodAgreement,
+    response_model_exclude_none=True,
+)
+def cross_method_agreement(scene_id: str) -> CrossMethodAgreement:
+    return _typed_or_404(
+        CrossMethodAgreement, get_cross_method_agreement, scene_id,
         hint=f"cross-method agreement for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/method-statistics-hidsag/{subset_code}")
-def method_statistics_hidsag(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_method_statistics_hidsag, subset_code,
+@router.get(
+    "/method-statistics-hidsag/{subset_code}",
+    response_model=MethodStatisticsHidsag,
+    response_model_exclude_none=True,
+)
+def method_statistics_hidsag(subset_code: str) -> MethodStatisticsHidsag:
+    return _typed_or_404(
+        MethodStatisticsHidsag, get_method_statistics_hidsag, subset_code,
         hint=f"method statistics for HIDSAG '{subset_code}' not generated yet",
     )
 
 
-@router.get("/external-validation/{scene_id}/literature")
-def external_validation_literature(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_external_validation_literature, scene_id,
+@router.get(
+    "/external-validation/{scene_id}/literature",
+    response_model=ExternalValidationLiterature,
+    response_model_exclude_none=True,
+)
+def external_validation_literature(scene_id: str) -> ExternalValidationLiterature:
+    return _typed_or_404(
+        ExternalValidationLiterature, get_external_validation_literature, scene_id,
         hint=f"literature alignment for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/external-validation/hidsag/{subset_code}/methods")
-def external_validation_hidsag_methods(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_external_validation_hidsag_methods, subset_code,
+@router.get(
+    "/external-validation/hidsag/{subset_code}/methods",
+    response_model=ExternalValidationHidsagMethods,
+    response_model_exclude_none=True,
+)
+def external_validation_hidsag_methods(subset_code: str) -> ExternalValidationHidsagMethods:
+    return _typed_or_404(
+        ExternalValidationHidsagMethods, get_external_validation_hidsag_methods, subset_code,
         hint=f"HIDSAG method summary for '{subset_code}' not generated yet",
     )
 
 
-@router.get("/narratives/{scene_id}")
-def narratives(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_narratives, scene_id,
+@router.get(
+    "/narratives/{scene_id}",
+    response_model=Narratives,
+    response_model_exclude_none=True,
+)
+def narratives(scene_id: str) -> Narratives:
+    return _typed_or_404(
+        Narratives, get_narratives, scene_id,
         hint=f"narrative for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/interpretability/{scene_id}/{card_type}")
-def interpretability(scene_id: str, card_type: str) -> dict:
+@router.get(
+    "/interpretability/{scene_id}/{card_type}",
+    response_model=InterpretabilityCards,
+    response_model_exclude_none=True,
+)
+def interpretability(scene_id: str, card_type: str) -> InterpretabilityCards:
     if card_type not in ("topic_cards", "band_cards", "document_cards"):
         raise HTTPException(status_code=400, detail="card_type must be topic_cards | band_cards | document_cards")
-    return _serve_or_404(
-        get_interpretability, scene_id, card_type,
+    return _typed_or_404(
+        InterpretabilityCards, get_interpretability, scene_id, card_type,
         hint=f"interpretability {card_type} for '{scene_id}' not generated yet",
     )
 
@@ -688,18 +736,26 @@ def representations_index() -> dict:
     )
 
 
-@router.get("/representations/{method}/{scene_id}")
-def representation(method: str, scene_id: str) -> dict:
-    return _serve_or_404(
-        get_representation, method, scene_id,
+@router.get(
+    "/representations/{method}/{scene_id}",
+    response_model=Representation,
+    response_model_exclude_none=True,
+)
+def representation(method: str, scene_id: str) -> Representation:
+    return _typed_or_404(
+        Representation, get_representation, method, scene_id,
         hint=f"representation {method}/{scene_id} not generated yet",
     )
 
 
-@router.get("/dmr-lda-hidsag/{subset_code}")
-def dmr_lda_hidsag(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_dmr_lda_hidsag, subset_code,
+@router.get(
+    "/dmr-lda-hidsag/{subset_code}",
+    response_model=DmrLdaHidsag,
+    response_model_exclude_none=True,
+)
+def dmr_lda_hidsag(subset_code: str) -> DmrLdaHidsag:
+    return _typed_or_404(
+        DmrLdaHidsag, get_dmr_lda_hidsag, subset_code,
         hint=f"dmr_lda_hidsag for '{subset_code}' not generated yet",
     )
 
@@ -727,10 +783,14 @@ def bayesian_comparison(task_type: str) -> dict:
     )
 
 
-@router.get("/optuna-search/{scene_id}")
-def optuna_search(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_optuna_search, scene_id,
+@router.get(
+    "/optuna-search/{scene_id}",
+    response_model=OptunaSearch,
+    response_model_exclude_none=True,
+)
+def optuna_search(scene_id: str) -> OptunaSearch:
+    return _typed_or_404(
+        OptunaSearch, get_optuna_search, scene_id,
         hint=f"optuna_search for '{scene_id}' not generated yet",
     )
 
@@ -771,58 +831,88 @@ def mutual_information_hidsag(subset_code: str) -> MutualInformationHidsag:
     )
 
 
-@router.get("/rate-distortion-curve/{scene_id}")
-def rate_distortion_curve(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_rate_distortion_curve, scene_id,
+@router.get(
+    "/rate-distortion-curve/{scene_id}",
+    response_model=RateDistortionCurve,
+    response_model_exclude_none=True,
+)
+def rate_distortion_curve(scene_id: str) -> RateDistortionCurve:
+    return _typed_or_404(
+        RateDistortionCurve, get_rate_distortion_curve, scene_id,
         hint=f"rate_distortion_curve for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-routed-classifier/{scene_id}")
-def topic_routed_classifier(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_routed_classifier, scene_id,
+@router.get(
+    "/topic-routed-classifier/{scene_id}",
+    response_model=TopicRoutedClassifier,
+    response_model_exclude_none=True,
+)
+def topic_routed_classifier(scene_id: str) -> TopicRoutedClassifier:
+    return _typed_or_404(
+        TopicRoutedClassifier, get_topic_routed_classifier, scene_id,
         hint=f"topic_routed_classifier for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-routed-deep-gate/{scene_id}")
-def topic_routed_deep_gate(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_routed_deep_gate, scene_id,
+@router.get(
+    "/topic-routed-deep-gate/{scene_id}",
+    response_model=TopicRoutedDeepGate,
+    response_model_exclude_none=True,
+)
+def topic_routed_deep_gate(scene_id: str) -> TopicRoutedDeepGate:
+    return _typed_or_404(
+        TopicRoutedDeepGate, get_topic_routed_deep_gate, scene_id,
         hint=f"topic_routed_deep_gate for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/neural-topic-comparison/{scene_id}")
-def neural_topic_comparison(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_neural_topic_comparison, scene_id,
+@router.get(
+    "/neural-topic-comparison/{scene_id}",
+    response_model=NeuralTopicComparison,
+    response_model_exclude_none=True,
+)
+def neural_topic_comparison(scene_id: str) -> NeuralTopicComparison:
+    return _typed_or_404(
+        NeuralTopicComparison, get_neural_topic_comparison, scene_id,
         hint=f"neural_topic_comparison for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/neural-topic-seed-stability/{scene_id}")
-def neural_topic_seed_stability(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_neural_topic_seed_stability, scene_id,
+@router.get(
+    "/neural-topic-seed-stability/{scene_id}",
+    response_model=NeuralTopicSeedStability,
+    response_model_exclude_none=True,
+)
+def neural_topic_seed_stability(scene_id: str) -> NeuralTopicSeedStability:
+    return _typed_or_404(
+        NeuralTopicSeedStability, get_neural_topic_seed_stability, scene_id,
         hint=f"neural_topic_seed_stability for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/embedded-baseline/{scene_id}")
-def embedded_baseline(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_embedded_baseline, scene_id,
+@router.get(
+    "/embedded-baseline/{scene_id}",
+    response_model=EmbeddedBaseline,
+    response_model_exclude_none=True,
+)
+def embedded_baseline(scene_id: str) -> EmbeddedBaseline:
+    return _typed_or_404(
+        EmbeddedBaseline, get_embedded_baseline, scene_id,
         hint=f"embedded_baseline for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-stability/{scene_id}")
-def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
+@router.get(
+    "/topic-stability/{scene_id}",
+    response_model=TopicStability,
+    response_model_exclude_none=True,
+)
+def topic_stability(scene_id: str, k_offset: int = 0) -> TopicStability:
     try:
-        return get_topic_stability(scene_id, k_offset=k_offset)
+        return TopicStability.model_validate(
+            get_topic_stability(scene_id, k_offset=k_offset)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -830,10 +920,18 @@ def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
         ) from exc
 
 
-@router.get("/deep-seed-stability/{scene_id}")
-def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 7) -> dict:
+@router.get(
+    "/deep-seed-stability/{scene_id}",
+    response_model=SeedStability,
+    response_model_exclude_none=True,
+)
+def deep_seed_stability(
+    scene_id: str, method: str = "cae_1d_8", n_seeds: int = 7
+) -> SeedStability:
     try:
-        return get_deep_seed_stability(scene_id, method=method, n_seeds=n_seeds)
+        return SeedStability.model_validate(
+            get_deep_seed_stability(scene_id, method=method, n_seeds=n_seeds)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -841,18 +939,28 @@ def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 
         ) from exc
 
 
-@router.get("/deep-anomaly/{scene_id}")
-def deep_anomaly(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_deep_anomaly, scene_id,
+@router.get(
+    "/deep-anomaly/{scene_id}",
+    response_model=DeepAnomaly,
+    response_model_exclude_none=True,
+)
+def deep_anomaly(scene_id: str) -> DeepAnomaly:
+    return _typed_or_404(
+        DeepAnomaly, get_deep_anomaly, scene_id,
         hint=f"deep_anomaly for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/classical-seed-stability/{scene_id}")
-def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
+@router.get(
+    "/classical-seed-stability/{scene_id}",
+    response_model=SeedStability,
+    response_model_exclude_none=True,
+)
+def classical_seed_stability(scene_id: str, method: str = "pca_8") -> SeedStability:
     try:
-        return get_classical_seed_stability(scene_id, method=method)
+        return SeedStability.model_validate(
+            get_classical_seed_stability(scene_id, method=method)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -860,50 +968,74 @@ def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
         ) from exc
 
 
-@router.get("/topic-to-usgs-v7/{scene_id}")
-def topic_to_usgs_v7(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_to_usgs_v7, scene_id,
+@router.get(
+    "/topic-to-usgs-v7/{scene_id}",
+    response_model=TopicToUsgsV7,
+    response_model_exclude_none=True,
+)
+def topic_to_usgs_v7(scene_id: str) -> TopicToUsgsV7:
+    return _typed_or_404(
+        TopicToUsgsV7, get_topic_to_usgs_v7, scene_id,
         hint=f"topic_to_usgs_v7 for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/hidsag-cross-preprocessing-stability/{subset_code}")
-def hidsag_cross_preprocessing_stability(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_hidsag_cross_preprocessing_stability, subset_code,
+@router.get(
+    "/hidsag-cross-preprocessing-stability/{subset_code}",
+    response_model=HidsagCrossPreprocessingStability,
+    response_model_exclude_none=True,
+)
+def hidsag_cross_preprocessing_stability(subset_code: str) -> HidsagCrossPreprocessingStability:
+    return _typed_or_404(
+        HidsagCrossPreprocessingStability, get_hidsag_cross_preprocessing_stability, subset_code,
         hint=f"hidsag_cross_preprocessing_stability for '{subset_code}' not generated yet",
     )
 
 
-@router.get("/topic-anomaly/{scene_id}")
-def topic_anomaly(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_anomaly, scene_id,
+@router.get(
+    "/topic-anomaly/{scene_id}",
+    response_model=TopicAnomaly,
+    response_model_exclude_none=True,
+)
+def topic_anomaly(scene_id: str) -> TopicAnomaly:
+    return _typed_or_404(
+        TopicAnomaly, get_topic_anomaly, scene_id,
         hint=f"topic_anomaly for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-spatial-continuous/{scene_id}")
-def topic_spatial_continuous(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_spatial_continuous, scene_id,
+@router.get(
+    "/topic-spatial-continuous/{scene_id}",
+    response_model=TopicSpatialContinuous,
+    response_model_exclude_none=True,
+)
+def topic_spatial_continuous(scene_id: str) -> TopicSpatialContinuous:
+    return _typed_or_404(
+        TopicSpatialContinuous, get_topic_spatial_continuous, scene_id,
         hint=f"topic_spatial_continuous for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-spatial-full/{scene_id}")
-def topic_spatial_full(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_spatial_full, scene_id,
+@router.get(
+    "/topic-spatial-full/{scene_id}",
+    response_model=TopicSpatialFull,
+    response_model_exclude_none=True,
+)
+def topic_spatial_full(scene_id: str) -> TopicSpatialFull:
+    return _typed_or_404(
+        TopicSpatialFull, get_topic_spatial_full, scene_id,
         hint=f"topic_spatial_full for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/endmember-baseline/{scene_id}")
-def endmember_baseline(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_endmember_baseline, scene_id,
+@router.get(
+    "/endmember-baseline/{scene_id}",
+    response_model=EndmemberBaseline,
+    response_model_exclude_none=True,
+)
+def endmember_baseline(scene_id: str) -> EndmemberBaseline:
+    return _typed_or_404(
+        EndmemberBaseline, get_endmember_baseline, scene_id,
         hint=f"endmember_baseline for '{scene_id}' not generated yet",
     )
 


### PR DESCRIPTION
## Summary

Fourth slice of issue #440 P1 item 1.2. Cumulative coverage:
**74 routes typed / 8 remaining untyped (~90% of total handlers)**.

## Routes covered

19 new routes spanning agreement matrices, narratives, interpretability
cards, representations, topic-routed classifier + deep gate, neural-
topic comparison + seed stability, rate-distortion, topic stability,
classical & deep seed stability (shared envelope), deep + topic
anomaly, spatial continuous & full, USGS mapping, HIDSAG cross-
preprocessing stability, endmember baseline, external validation
(literature + HIDSAG methods), DMR-LDA-HIDSAG, optuna-search,
method-statistics-HIDSAG.

## Remaining untyped (8 routes)

\`/manifest\`, \`/groupings\`, \`/groupings/{method}/{scene}\`,
\`/topic-variants\`, \`/topic-variants/{variant}/{scene}\`,
\`/bayesian-comparison/{task_type}\` (polymorphic),
\`/llm-tea-leaves/{scene}\`, \`/quantization-sensitivity\` follow-on.

## Test plan

- [x] model_validate against 268 JSON files (6 scenes × per-scene
      families + 5 HIDSAG subsets + 30+ representation methods).
- [x] Smoke harness 109/109 OK locally on :8114.
- [x] pytest tests/ -v → 24 passed.

Refs #440 P1 item 1.2 (slice 4/N).