### PR TITLE
Deploy cycles 249-250: Pydantic ~90% coverage + Vitest scaffold (#440 + #441)

### DIFF
--- a/app/models/precompute.py
+++ b/app/models/precompute.py
@@ -615,3 +615,323 @@ class MutualInformationHidsag(BaseModel):
     framework_axis: str | None = None
     generated_at: str
     builder_version: str
+
+
+# ============================================================================
+# c249: fourth-slice models — agreement, narrative, interpretability,
+# representations, topic-routed, neural-topic, rate-distortion, stability,
+# anomaly, USGS, endmember.
+# ============================================================================
+
+
+class CrossMethodAgreement(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    spatial_shape: list[int]
+    n_compared_pixels: int
+    method_names: list[str]
+    ari_matrix: list[list[float]]
+    nmi_matrix: list[list[float]]
+    v_measure_matrix: list[list[float]] | None = None
+    agreement_vs_label_summary: list[dict[str, Any]] = Field(default_factory=list)
+    agreement_vs_topic_dominant_summary: list[dict[str, Any]] = Field(default_factory=list)
+    generated_at: str
+    builder_version: str
+
+
+class Narratives(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    method_narratives: dict[str, Any] = Field(default_factory=dict)
+    generated_at: str
+    builder_version: str
+
+
+class InterpretabilityCards(BaseModel):
+    """Common envelope for topic_cards / band_cards / document_cards.
+
+    The interior structure differs per card_type so the cards list is
+    typed as dict[str, Any]; the route returns this same envelope for
+    all three card_type variants.
+    """
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    topic_cards: list[dict[str, Any]] | None = None
+    band_cards: list[dict[str, Any]] | None = None
+    document_cards: list[dict[str, Any]] | None = None
+    generated_at: str
+    builder_version: str
+
+
+class RepresentationFitMeta(BaseModel):
+    model_config = _PassThroughConfig
+    explained_variance_ratio: list[float] | None = None
+    explained_variance_total: float | None = None
+    reconstruction_rmse: float | None = None
+
+
+class Representation(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    method: str
+    n_documents: int
+    n_bands_input: int
+    latent_dim: int
+    fit_meta: dict[str, Any] | None = None
+    silhouette_label: dict[str, Any] | None = None
+    downstream_kmeans_vs_label: dict[str, Any] | None = None
+    scatter_pca_3d_explained_variance: list[float] | None = None
+    scatter_2d_3d_subsample: list[dict[str, Any]] | None = None
+    features_local_path: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicRoutedClassifier(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int
+    n_classes: int
+    n_documents: int
+    samples_per_class: int
+    wordification: str
+    quantization_scale: int
+    head: str
+    split: str
+    method_metrics: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    ranking_by_macro_f1_mean: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class NeuralTopicComparison(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    n_documents: int
+    n_classes: int | None = None
+    methods: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    ranking_by_ari: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class NeuralTopicSeedStability(BaseModel):
+    """Per-scene seed stability for ProdLDA / ETM / LDA."""
+    model_config = _PassThroughConfig
+    scene_id: str
+    n_seeds: int | None = None
+    methods: dict[str, dict[str, Any]] | None = None
+    method_metrics: dict[str, dict[str, Any]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class RateDistortionCurve(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K_grid: list[int]
+    doc_term_shape: list[int]
+    train_fraction: float
+    wordification: str
+    quantization_scale: int
+    samples_per_class: int
+    method_curves: dict[str, Any] = Field(default_factory=dict)
+    rmse_test_table_by_K: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicStability(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int
+    seeds: list[int]
+    wordification: str
+    quantization_scale: int
+    samples_per_class: int
+    seed_pair_matched_cosine_mean: list[list[float]]
+    seed_pair_matched_cosine_min: list[list[float]] | None = None
+    seed_pair_matched_cosine_std: list[list[float]] | None = None
+    per_topic_matched_cosine_vs_seed0: list[list[float]] | None = None
+    per_topic_stability_summary: list[dict[str, Any]] | None = None
+    scene_stability_summary: dict[str, Any] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class SeedStability(BaseModel):
+    """Common envelope for classical_seed_stability + deep_seed_stability."""
+    model_config = _PassThroughConfig
+    scene_id: str
+    method: str
+    n_seeds: int
+    latent_dim: int | None = None
+    samples_per_class: int | None = None
+    ari_vs_gt_per_seed: list[float] | None = None
+    nmi_vs_gt_per_seed: list[float] | None = None
+    ari_mean: float | None = None
+    ari_std: float | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class DeepAnomaly(BaseModel):
+    """Per-method anomaly-indicator block. Methods like cae_1d_8 and
+    beta_vae_8 appear as top-level keys with method-specific payloads.
+    """
+    model_config = _PassThroughConfig
+    scene_id: str
+    n_documents: int
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicAnomaly(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    n_documents: int
+    indicators: dict[str, Any]
+    anomaly_to_misclassification_correlation: dict[str, Any]
+    per_class_summary: list[dict[str, Any]] = Field(default_factory=list)
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicSpatialContinuous(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    spatial_shape: list[int]
+    n_sampled_pixels: int
+    per_topic_continuous_spatial: list[dict[str, Any]] = Field(default_factory=list)
+    aggregated_morans_I_mean_over_topics: float | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicSpatialFull(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int | None = None
+    spatial_shape: list[int] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicToUsgsV7(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    topic_count: int
+    library_subset: str
+    library_sample_count: int
+    library_chapter_counts: dict[str, int] | None = None
+    top_n_per_topic: list[list[dict[str, Any]]]
+    generated_at: str
+    builder_version: str
+
+
+class EndmemberBaseline(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    n_pixels_used: int | None = None
+    n_bands: int | None = None
+    endmember_extractors: list[str] | dict[str, Any] | None = None
+    unmixing_method: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class HidsagCrossPreprocessingStability(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str | None = None
+    methods: list[str] | None = None
+    matched_jaccard_top15: list[list[float]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class TopicRoutedDeepGate(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    n_classes: int | None = None
+    n_documents: int | None = None
+    method_metrics: dict[str, dict[str, Any]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class EmbeddedBaseline(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    K: int | None = None
+    n_classes: int | None = None
+    n_documents: int | None = None
+    method_metrics: dict[str, dict[str, Any]] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class OptunaSearch(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    trials: list[dict[str, Any]] | None = None
+    best_trial: dict[str, Any] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class DmrLdaHidsag(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    K: int | None = None
+    covariates: list[str] | None = None
+    framework_axis: str | None = None
+    generated_at: str
+    builder_version: str
+
+
+class ExternalValidationLiterature(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    entries: list[dict[str, Any]] | None = None
+    methods: list[dict[str, Any]] | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None
+
+
+class ExternalValidationHidsagMethods(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str
+    methods: list[dict[str, Any]] | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None
+
+
+class MethodStatisticsHidsag(BaseModel):
+    model_config = _PassThroughConfig
+    subset_code: str | None = None
+    dataset_id: str | None = None
+    dataset_name: str | None = None
+    methods: dict[str, dict[str, Any]] | None = None
+    paired_comparisons: dict[str, Any] | None = None
+    ranking: dict[str, Any] | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -11,20 +11,44 @@ from app.models.band_masks import (
     BandMasksIndexResponse,
 )
 from app.models.precompute import (
+    CrossMethodAgreement,
     CrossSceneTransfer,
+    DeepAnomaly,
+    DmrLdaHidsag,
     EdaHidsag,
     EdaPerScene,
+    EmbeddedBaseline,
+    EndmemberBaseline,
+    ExternalValidationHidsagMethods,
+    ExternalValidationLiterature,
+    HidsagCrossPreprocessingStability,
+    InterpretabilityCards,
     LdaSweep,
     LinearProbePanel,
+    MethodStatisticsHidsag,
     MutualInformation,
     MutualInformationHidsag,
+    Narratives,
+    NeuralTopicComparison,
+    NeuralTopicSeedStability,
+    OptunaSearch,
     QuantizationSensitivity,
+    RateDistortionCurve,
+    Representation,
+    SeedStability,
     SpatialValidationResponse,
     SpectralBrowserMetadata,
     SpectralDensityManifest,
     SuperTopics,
+    TopicAnomaly,
+    TopicRoutedClassifier,
+    TopicRoutedDeepGate,
+    TopicSpatialContinuous,
+    TopicSpatialFull,
+    TopicStability,
     TopicToDataResponse,
     TopicToLibrary,
+    TopicToUsgsV7,
     TopicViewsResponse,
     ValidationBlocksResponse,
     WordificationResponse,
@@ -590,52 +614,76 @@ def grouping(method: str, scene_id: str) -> dict:
     )
 
 
-@router.get("/cross-method-agreement/{scene_id}")
-def cross_method_agreement(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_cross_method_agreement, scene_id,
+@router.get(
+    "/cross-method-agreement/{scene_id}",
+    response_model=CrossMethodAgreement,
+    response_model_exclude_none=True,
+)
+def cross_method_agreement(scene_id: str) -> CrossMethodAgreement:
+    return _typed_or_404(
+        CrossMethodAgreement, get_cross_method_agreement, scene_id,
         hint=f"cross-method agreement for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/method-statistics-hidsag/{subset_code}")
-def method_statistics_hidsag(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_method_statistics_hidsag, subset_code,
+@router.get(
+    "/method-statistics-hidsag/{subset_code}",
+    response_model=MethodStatisticsHidsag,
+    response_model_exclude_none=True,
+)
+def method_statistics_hidsag(subset_code: str) -> MethodStatisticsHidsag:
+    return _typed_or_404(
+        MethodStatisticsHidsag, get_method_statistics_hidsag, subset_code,
         hint=f"method statistics for HIDSAG '{subset_code}' not generated yet",
     )
 
 
-@router.get("/external-validation/{scene_id}/literature")
-def external_validation_literature(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_external_validation_literature, scene_id,
+@router.get(
+    "/external-validation/{scene_id}/literature",
+    response_model=ExternalValidationLiterature,
+    response_model_exclude_none=True,
+)
+def external_validation_literature(scene_id: str) -> ExternalValidationLiterature:
+    return _typed_or_404(
+        ExternalValidationLiterature, get_external_validation_literature, scene_id,
         hint=f"literature alignment for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/external-validation/hidsag/{subset_code}/methods")
-def external_validation_hidsag_methods(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_external_validation_hidsag_methods, subset_code,
+@router.get(
+    "/external-validation/hidsag/{subset_code}/methods",
+    response_model=ExternalValidationHidsagMethods,
+    response_model_exclude_none=True,
+)
+def external_validation_hidsag_methods(subset_code: str) -> ExternalValidationHidsagMethods:
+    return _typed_or_404(
+        ExternalValidationHidsagMethods, get_external_validation_hidsag_methods, subset_code,
         hint=f"HIDSAG method summary for '{subset_code}' not generated yet",
     )
 
 
-@router.get("/narratives/{scene_id}")
-def narratives(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_narratives, scene_id,
+@router.get(
+    "/narratives/{scene_id}",
+    response_model=Narratives,
+    response_model_exclude_none=True,
+)
+def narratives(scene_id: str) -> Narratives:
+    return _typed_or_404(
+        Narratives, get_narratives, scene_id,
         hint=f"narrative for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/interpretability/{scene_id}/{card_type}")
-def interpretability(scene_id: str, card_type: str) -> dict:
+@router.get(
+    "/interpretability/{scene_id}/{card_type}",
+    response_model=InterpretabilityCards,
+    response_model_exclude_none=True,
+)
+def interpretability(scene_id: str, card_type: str) -> InterpretabilityCards:
     if card_type not in ("topic_cards", "band_cards", "document_cards"):
         raise HTTPException(status_code=400, detail="card_type must be topic_cards | band_cards | document_cards")
-    return _serve_or_404(
-        get_interpretability, scene_id, card_type,
+    return _typed_or_404(
+        InterpretabilityCards, get_interpretability, scene_id, card_type,
         hint=f"interpretability {card_type} for '{scene_id}' not generated yet",
     )
 
@@ -688,18 +736,26 @@ def representations_index() -> dict:
     )
 
 
-@router.get("/representations/{method}/{scene_id}")
-def representation(method: str, scene_id: str) -> dict:
-    return _serve_or_404(
-        get_representation, method, scene_id,
+@router.get(
+    "/representations/{method}/{scene_id}",
+    response_model=Representation,
+    response_model_exclude_none=True,
+)
+def representation(method: str, scene_id: str) -> Representation:
+    return _typed_or_404(
+        Representation, get_representation, method, scene_id,
         hint=f"representation {method}/{scene_id} not generated yet",
     )
 
 
-@router.get("/dmr-lda-hidsag/{subset_code}")
-def dmr_lda_hidsag(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_dmr_lda_hidsag, subset_code,
+@router.get(
+    "/dmr-lda-hidsag/{subset_code}",
+    response_model=DmrLdaHidsag,
+    response_model_exclude_none=True,
+)
+def dmr_lda_hidsag(subset_code: str) -> DmrLdaHidsag:
+    return _typed_or_404(
+        DmrLdaHidsag, get_dmr_lda_hidsag, subset_code,
         hint=f"dmr_lda_hidsag for '{subset_code}' not generated yet",
     )
 
@@ -727,10 +783,14 @@ def bayesian_comparison(task_type: str) -> dict:
     )
 
 
-@router.get("/optuna-search/{scene_id}")
-def optuna_search(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_optuna_search, scene_id,
+@router.get(
+    "/optuna-search/{scene_id}",
+    response_model=OptunaSearch,
+    response_model_exclude_none=True,
+)
+def optuna_search(scene_id: str) -> OptunaSearch:
+    return _typed_or_404(
+        OptunaSearch, get_optuna_search, scene_id,
         hint=f"optuna_search for '{scene_id}' not generated yet",
     )
 
@@ -771,58 +831,88 @@ def mutual_information_hidsag(subset_code: str) -> MutualInformationHidsag:
     )
 
 
-@router.get("/rate-distortion-curve/{scene_id}")
-def rate_distortion_curve(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_rate_distortion_curve, scene_id,
+@router.get(
+    "/rate-distortion-curve/{scene_id}",
+    response_model=RateDistortionCurve,
+    response_model_exclude_none=True,
+)
+def rate_distortion_curve(scene_id: str) -> RateDistortionCurve:
+    return _typed_or_404(
+        RateDistortionCurve, get_rate_distortion_curve, scene_id,
         hint=f"rate_distortion_curve for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-routed-classifier/{scene_id}")
-def topic_routed_classifier(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_routed_classifier, scene_id,
+@router.get(
+    "/topic-routed-classifier/{scene_id}",
+    response_model=TopicRoutedClassifier,
+    response_model_exclude_none=True,
+)
+def topic_routed_classifier(scene_id: str) -> TopicRoutedClassifier:
+    return _typed_or_404(
+        TopicRoutedClassifier, get_topic_routed_classifier, scene_id,
         hint=f"topic_routed_classifier for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-routed-deep-gate/{scene_id}")
-def topic_routed_deep_gate(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_routed_deep_gate, scene_id,
+@router.get(
+    "/topic-routed-deep-gate/{scene_id}",
+    response_model=TopicRoutedDeepGate,
+    response_model_exclude_none=True,
+)
+def topic_routed_deep_gate(scene_id: str) -> TopicRoutedDeepGate:
+    return _typed_or_404(
+        TopicRoutedDeepGate, get_topic_routed_deep_gate, scene_id,
         hint=f"topic_routed_deep_gate for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/neural-topic-comparison/{scene_id}")
-def neural_topic_comparison(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_neural_topic_comparison, scene_id,
+@router.get(
+    "/neural-topic-comparison/{scene_id}",
+    response_model=NeuralTopicComparison,
+    response_model_exclude_none=True,
+)
+def neural_topic_comparison(scene_id: str) -> NeuralTopicComparison:
+    return _typed_or_404(
+        NeuralTopicComparison, get_neural_topic_comparison, scene_id,
         hint=f"neural_topic_comparison for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/neural-topic-seed-stability/{scene_id}")
-def neural_topic_seed_stability(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_neural_topic_seed_stability, scene_id,
+@router.get(
+    "/neural-topic-seed-stability/{scene_id}",
+    response_model=NeuralTopicSeedStability,
+    response_model_exclude_none=True,
+)
+def neural_topic_seed_stability(scene_id: str) -> NeuralTopicSeedStability:
+    return _typed_or_404(
+        NeuralTopicSeedStability, get_neural_topic_seed_stability, scene_id,
         hint=f"neural_topic_seed_stability for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/embedded-baseline/{scene_id}")
-def embedded_baseline(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_embedded_baseline, scene_id,
+@router.get(
+    "/embedded-baseline/{scene_id}",
+    response_model=EmbeddedBaseline,
+    response_model_exclude_none=True,
+)
+def embedded_baseline(scene_id: str) -> EmbeddedBaseline:
+    return _typed_or_404(
+        EmbeddedBaseline, get_embedded_baseline, scene_id,
         hint=f"embedded_baseline for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-stability/{scene_id}")
-def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
+@router.get(
+    "/topic-stability/{scene_id}",
+    response_model=TopicStability,
+    response_model_exclude_none=True,
+)
+def topic_stability(scene_id: str, k_offset: int = 0) -> TopicStability:
     try:
-        return get_topic_stability(scene_id, k_offset=k_offset)
+        return TopicStability.model_validate(
+            get_topic_stability(scene_id, k_offset=k_offset)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -830,10 +920,18 @@ def topic_stability(scene_id: str, k_offset: int = 0) -> dict:
         ) from exc
 
 
-@router.get("/deep-seed-stability/{scene_id}")
-def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 7) -> dict:
+@router.get(
+    "/deep-seed-stability/{scene_id}",
+    response_model=SeedStability,
+    response_model_exclude_none=True,
+)
+def deep_seed_stability(
+    scene_id: str, method: str = "cae_1d_8", n_seeds: int = 7
+) -> SeedStability:
     try:
-        return get_deep_seed_stability(scene_id, method=method, n_seeds=n_seeds)
+        return SeedStability.model_validate(
+            get_deep_seed_stability(scene_id, method=method, n_seeds=n_seeds)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -841,18 +939,28 @@ def deep_seed_stability(scene_id: str, method: str = "cae_1d_8", n_seeds: int = 
         ) from exc
 
 
-@router.get("/deep-anomaly/{scene_id}")
-def deep_anomaly(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_deep_anomaly, scene_id,
+@router.get(
+    "/deep-anomaly/{scene_id}",
+    response_model=DeepAnomaly,
+    response_model_exclude_none=True,
+)
+def deep_anomaly(scene_id: str) -> DeepAnomaly:
+    return _typed_or_404(
+        DeepAnomaly, get_deep_anomaly, scene_id,
         hint=f"deep_anomaly for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/classical-seed-stability/{scene_id}")
-def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
+@router.get(
+    "/classical-seed-stability/{scene_id}",
+    response_model=SeedStability,
+    response_model_exclude_none=True,
+)
+def classical_seed_stability(scene_id: str, method: str = "pca_8") -> SeedStability:
     try:
-        return get_classical_seed_stability(scene_id, method=method)
+        return SeedStability.model_validate(
+            get_classical_seed_stability(scene_id, method=method)
+        )
     except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
@@ -860,50 +968,74 @@ def classical_seed_stability(scene_id: str, method: str = "pca_8") -> dict:
         ) from exc
 
 
-@router.get("/topic-to-usgs-v7/{scene_id}")
-def topic_to_usgs_v7(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_to_usgs_v7, scene_id,
+@router.get(
+    "/topic-to-usgs-v7/{scene_id}",
+    response_model=TopicToUsgsV7,
+    response_model_exclude_none=True,
+)
+def topic_to_usgs_v7(scene_id: str) -> TopicToUsgsV7:
+    return _typed_or_404(
+        TopicToUsgsV7, get_topic_to_usgs_v7, scene_id,
         hint=f"topic_to_usgs_v7 for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/hidsag-cross-preprocessing-stability/{subset_code}")
-def hidsag_cross_preprocessing_stability(subset_code: str) -> dict:
-    return _serve_or_404(
-        get_hidsag_cross_preprocessing_stability, subset_code,
+@router.get(
+    "/hidsag-cross-preprocessing-stability/{subset_code}",
+    response_model=HidsagCrossPreprocessingStability,
+    response_model_exclude_none=True,
+)
+def hidsag_cross_preprocessing_stability(subset_code: str) -> HidsagCrossPreprocessingStability:
+    return _typed_or_404(
+        HidsagCrossPreprocessingStability, get_hidsag_cross_preprocessing_stability, subset_code,
         hint=f"hidsag_cross_preprocessing_stability for '{subset_code}' not generated yet",
     )
 
 
-@router.get("/topic-anomaly/{scene_id}")
-def topic_anomaly(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_anomaly, scene_id,
+@router.get(
+    "/topic-anomaly/{scene_id}",
+    response_model=TopicAnomaly,
+    response_model_exclude_none=True,
+)
+def topic_anomaly(scene_id: str) -> TopicAnomaly:
+    return _typed_or_404(
+        TopicAnomaly, get_topic_anomaly, scene_id,
         hint=f"topic_anomaly for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-spatial-continuous/{scene_id}")
-def topic_spatial_continuous(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_spatial_continuous, scene_id,
+@router.get(
+    "/topic-spatial-continuous/{scene_id}",
+    response_model=TopicSpatialContinuous,
+    response_model_exclude_none=True,
+)
+def topic_spatial_continuous(scene_id: str) -> TopicSpatialContinuous:
+    return _typed_or_404(
+        TopicSpatialContinuous, get_topic_spatial_continuous, scene_id,
         hint=f"topic_spatial_continuous for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/topic-spatial-full/{scene_id}")
-def topic_spatial_full(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_spatial_full, scene_id,
+@router.get(
+    "/topic-spatial-full/{scene_id}",
+    response_model=TopicSpatialFull,
+    response_model_exclude_none=True,
+)
+def topic_spatial_full(scene_id: str) -> TopicSpatialFull:
+    return _typed_or_404(
+        TopicSpatialFull, get_topic_spatial_full, scene_id,
         hint=f"topic_spatial_full for '{scene_id}' not generated yet",
     )
 
 
-@router.get("/endmember-baseline/{scene_id}")
-def endmember_baseline(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_endmember_baseline, scene_id,
+@router.get(
+    "/endmember-baseline/{scene_id}",
+    response_model=EndmemberBaseline,
+    response_model_exclude_none=True,
+)
+def endmember_baseline(scene_id: str) -> EndmemberBaseline:
+    return _typed_or_404(
+        EndmemberBaseline, get_endmember_baseline, scene_id,
         hint=f"endmember_baseline for '{scene_id}' not generated yet",
     )
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@react-three/drei": "^10.7.7",
@@ -31,14 +33,18 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0-beta.6",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16",
     "@types/katex": "^0.16.7",
     "@types/node": "^22.9.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/three": "^0.184.0",
     "@vitejs/plugin-react": "^4.3.3",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.0.0-beta.6",
     "typescript": "^5.7.2",
-    "vite": "^6.0.1"
+    "vite": "^6.0.1",
+    "vitest": "^2"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -63,6 +63,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0-beta.6
         version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/katex':
         specifier: ^0.16.7
         version: 0.16.8
@@ -81,6 +87,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.3
         version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       tailwindcss:
         specifier: ^4.0.0-beta.6
         version: 4.2.4
@@ -90,8 +99,29 @@ importers:
       vite:
         specifier: ^6.0.1
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^2
+        version: 2.1.9(@types/node@22.19.17)(jsdom@29.1.1)(lightningcss@1.32.0)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -180,8 +210,54 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -189,10 +265,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -201,16 +289,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -219,10 +325,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -231,10 +349,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -243,10 +373,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -255,10 +397,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -267,16 +421,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -291,6 +463,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -301,6 +479,12 @@ packages:
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -315,16 +499,34 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.12':
@@ -333,11 +535,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -625,8 +842,34 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -691,6 +934,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@xstate/react@4.1.3':
     resolution: {integrity: sha512-zhE+ZfrcCR87bu71Rkh5Z5ruZBivR/7uD/dkelzJqjQdI45IZc9DqTI8lL4Cg5+VN2p5k86KxDsusqW1kW11Tg==}
     peerDependencies:
@@ -699,6 +971,25 @@ packages:
     peerDependenciesMeta:
       xstate:
         optional: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -719,6 +1010,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   camera-controls@3.1.2:
     resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
     engines: {node: '>=22.0.0', npm: '>=10.5.1'}
@@ -727,6 +1022,14 @@ packages:
 
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -752,8 +1055,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -764,12 +1078,29 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-gpu@5.0.70:
     resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
@@ -781,6 +1112,18 @@ packages:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -789,6 +1132,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -823,6 +1173,10 @@ packages:
   hls.js@1.6.16:
     resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
@@ -837,6 +1191,13 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
@@ -855,6 +1216,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -943,6 +1313,13 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@11.4.0:
+    resolution: {integrity: sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -950,6 +1327,10 @@ packages:
     resolution: {integrity: sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -960,6 +1341,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   meshline@3.3.1:
     resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
     peerDependencies:
@@ -967,6 +1351,10 @@ packages:
 
   meshoptimizer@1.1.1:
     resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -979,9 +1367,19 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -997,8 +1395,16 @@ packages:
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   promise-worker-transferable@1.0.4:
     resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -1020,6 +1426,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1055,6 +1464,10 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1063,6 +1476,10 @@ packages:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1082,9 +1499,15 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   stats-gl@2.4.2:
     resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
@@ -1095,10 +1518,20 @@ packages:
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   suspend-react@0.1.3:
     resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
     peerDependencies:
       react: '>=17.0'
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
@@ -1123,9 +1556,42 @@ packages:
   three@0.184.0:
     resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   troika-three-text@0.52.4:
     resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
@@ -1151,6 +1617,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1174,6 +1644,42 @@ packages:
   utility-types@3.11.0:
     resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
     engines: {node: '>= 4'}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -1215,9 +1721,38 @@ packages:
       yaml:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   webgl-constants@1.1.1:
     resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
@@ -1225,10 +1760,34 @@ packages:
   webgl-sdf-generator@1.1.1:
     resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xstate@5.31.0:
     resolution: {integrity: sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ==}
@@ -1270,6 +1829,28 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1385,54 +1966,133 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@dimforge/rapier3d-compat@0.12.0': {}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -1441,10 +2101,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1453,17 +2119,31 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1696,7 +2376,39 @@ snapshots:
       '@tanstack/query-core': 5.100.9
       react: 19.2.5
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tweenjs/tween.js@23.1.3': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -1775,6 +2487,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@xstate/react@4.1.3(@types/react@19.2.14)(react@19.2.5)(xstate@5.31.0)':
     dependencies:
       react: 19.2.5
@@ -1784,6 +2536,18 @@ snapshots:
       xstate: 5.31.0
     transitivePeerDependencies:
       - '@types/react'
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
 
   base64-js@1.5.1: {}
 
@@ -1806,11 +2570,23 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  cac@6.7.14: {}
+
   camera-controls@3.1.2(three@0.184.0):
     dependencies:
       three: 0.184.0
 
   caniuse-lite@1.0.30001791: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   clsx@2.1.1: {}
 
@@ -1830,17 +2606,41 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
+  dequal@2.0.3: {}
 
   detect-gpu@5.0.70:
     dependencies:
       webgl-constants: 1.1.1
 
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   draco3d@1.5.7: {}
 
@@ -1850,6 +2650,36 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1882,6 +2712,12 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -1901,6 +2737,12 @@ snapshots:
 
   hls.js@1.6.16: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
@@ -1917,6 +2759,10 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  indent-string@4.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@2.2.2: {}
 
   isexe@2.0.0: {}
@@ -1931,6 +2777,32 @@ snapshots:
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.4.0
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -1993,6 +2865,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@11.4.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2000,6 +2876,8 @@ snapshots:
   lucide-react@0.460.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  lz-string@1.5.0: {}
 
   maath@0.10.8(@types/three@0.184.0)(three@0.184.0):
     dependencies:
@@ -2010,11 +2888,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdn-data@2.27.1: {}
+
   meshline@3.3.1(three@0.184.0):
     dependencies:
       three: 0.184.0
 
   meshoptimizer@1.1.1: {}
+
+  min-indent@1.0.1: {}
 
   ms@2.1.3: {}
 
@@ -2022,7 +2904,15 @@ snapshots:
 
   node-releases@2.0.38: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-key@3.1.1: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2036,10 +2926,18 @@ snapshots:
 
   potpack@1.0.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   promise-worker-transferable@1.0.4:
     dependencies:
       is-promise: 2.2.2
       lie: 3.3.0
+
+  punycode@2.3.1: {}
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:
@@ -2055,6 +2953,8 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.5(react@19.2.5)
       typescript: 5.9.3
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -2079,6 +2979,11 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   require-from-string@2.0.2: {}
 
@@ -2113,6 +3018,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -2125,7 +3034,11 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
 
   stats-gl@2.4.2(@types/three@0.184.0)(three@0.184.0):
     dependencies:
@@ -2134,9 +3047,17 @@ snapshots:
 
   stats.js@0.17.0: {}
 
+  std-env@3.10.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   suspend-react@0.1.3(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.1: {}
 
@@ -2160,10 +3081,34 @@ snapshots:
 
   three@0.184.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   troika-three-text@0.52.4(three@0.184.0):
     dependencies:
@@ -2191,6 +3136,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.25.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2209,6 +3156,34 @@ snapshots:
 
   utility-types@3.11.0: {}
 
+  vite-node@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.13
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
@@ -2223,15 +3198,76 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
+  vitest@2.1.9(@types/node@22.19.17)(jsdom@29.1.1)(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   void-elements@3.1.0: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   webgl-constants@1.1.1: {}
 
   webgl-sdf-generator@1.1.1: {}
 
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xstate@5.31.0: {}
 

--- a/frontend/src/pages/workspace/components/RecentlyViewed.test.tsx
+++ b/frontend/src/pages/workspace/components/RecentlyViewed.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * RecentlyViewed (c234) tests — the chip strip + the useTrackRecentScene
+ * hook persist (scene, rep) tuples through localStorage and exclude the
+ * currently-active tuple from the chip list.
+ */
+import { describe, expect, it, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { RecentlyViewed, type RecentEntry } from "./RecentlyViewed";
+
+const sample: RecentEntry[] = [
+  { scene: "indian-pines-corrected", rep: "lda", ts: 1 },
+  { scene: "salinas-corrected", rep: "lda", ts: 2 },
+  { scene: "kennedy-space-center", rep: "lda", ts: 3 },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("RecentlyViewed", () => {
+  it("renders chips for entries other than the active tuple", () => {
+    render(
+      <MemoryRouter>
+        <RecentlyViewed
+          currentScene="indian-pines-corrected"
+          currentRep="lda"
+          history={sample}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Salinas/i)).toBeInTheDocument();
+    expect(screen.getByText(/KSC/i)).toBeInTheDocument();
+    // Active tuple should NOT appear
+    expect(screen.queryByText(/Indian Pines/i)).not.toBeInTheDocument();
+  });
+
+  it("returns null when only the active tuple is in history", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <RecentlyViewed
+          currentScene="indian-pines-corrected"
+          currentRep="lda"
+          history={[{ scene: "indian-pines-corrected", rep: "lda", ts: 1 }]}
+        />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when history is empty", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <RecentlyViewed
+          currentScene={null}
+          currentRep={null}
+          history={[]}
+        />
+      </MemoryRouter>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("labels the strip as 'Recently viewed'", () => {
+    render(
+      <MemoryRouter>
+        <RecentlyViewed
+          currentScene={null}
+          currentRep={null}
+          history={sample}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Recently viewed/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: /recently viewed scenes/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/workspace/components/TabStates.test.tsx
+++ b/frontend/src/pages/workspace/components/TabStates.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * TabLoading / TabEmpty / TabError (cycle 226) — shared placeholders
+ * used across Workspace tabs. Tests cover defaults, custom messages,
+ * the retry-button hook, and accessibility roles.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TabEmpty, TabError, TabLoading } from "./TabStates";
+
+describe("TabLoading", () => {
+  it("renders default 'Loading…' and has role=status", () => {
+    render(<TabLoading />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText(/Loading…/)).toBeInTheDocument();
+  });
+
+  it("honours custom message", () => {
+    render(<TabLoading message="Cooking topics" />);
+    expect(screen.getByText("Cooking topics")).toBeInTheDocument();
+  });
+});
+
+describe("TabEmpty", () => {
+  it("renders default empty state without 'detail'", () => {
+    render(<TabEmpty />);
+    expect(screen.getByText(/No data available/i)).toBeInTheDocument();
+  });
+
+  it("renders detail when provided", () => {
+    render(<TabEmpty message="No labels" detail="/api/topic-views/foo" />);
+    expect(screen.getByText("No labels")).toBeInTheDocument();
+    expect(screen.getByText("/api/topic-views/foo")).toBeInTheDocument();
+  });
+});
+
+describe("TabError", () => {
+  it("renders role=alert", () => {
+    render(<TabError />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders Retry button when onRetry is supplied and fires the callback", () => {
+    const onRetry = vi.fn();
+    render(<TabError onRetry={onRetry} />);
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("omits Retry button when onRetry is undefined", () => {
+    render(<TabError />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/workspace/state/tabs.test.ts
+++ b/frontend/src/pages/workspace/state/tabs.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Single source-of-truth invariants for Explore tabs (cycle 132 split).
+ *
+ * These tests pin the relationship between the flat ExploreTab union,
+ * the keyboard nav order, the 6-phase grouping, and the tab→wiki map.
+ * Drift in any of these would silently break Workspace navigation.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  EXPLORE_PHASES,
+  EXPLORE_TAB_ORDER,
+  TAB_WIKI_PAGE,
+  findPhaseFor,
+  type ExploreTab,
+} from "./tabs";
+
+describe("ExploreTab invariants", () => {
+  it("EXPLORE_TAB_ORDER has no duplicates", () => {
+    const set = new Set(EXPLORE_TAB_ORDER);
+    expect(set.size).toBe(EXPLORE_TAB_ORDER.length);
+  });
+
+  it("Every tab in EXPLORE_PHASES appears in EXPLORE_TAB_ORDER", () => {
+    for (const phase of EXPLORE_PHASES) {
+      for (const tab of phase.tabs) {
+        expect(EXPLORE_TAB_ORDER).toContain(tab.id);
+      }
+    }
+  });
+
+  it("Every tab in EXPLORE_TAB_ORDER appears in exactly one phase", () => {
+    for (const id of EXPLORE_TAB_ORDER) {
+      const hits = EXPLORE_PHASES.filter((p) =>
+        p.tabs.some((t) => t.id === id),
+      );
+      expect(hits, `tab '${id}' must appear in exactly 1 phase`).toHaveLength(1);
+    }
+  });
+
+  it("Every tab carries a wiki-page mapping", () => {
+    for (const id of EXPLORE_TAB_ORDER) {
+      expect(TAB_WIKI_PAGE[id]).toBeTruthy();
+    }
+  });
+
+  it("findPhaseFor returns the phase actually containing each tab", () => {
+    for (const id of EXPLORE_TAB_ORDER) {
+      const phase = findPhaseFor(id);
+      expect(phase.tabs.some((t) => t.id === id)).toBe(true);
+    }
+  });
+
+  it("findPhaseFor falls back to the first phase for an unknown tab", () => {
+    const fallback = findPhaseFor("definitely-not-a-tab" as ExploreTab);
+    expect(fallback).toBe(EXPLORE_PHASES[0]);
+  });
+
+  it("Exactly 6 phases (Data, Topics, Geometry, Drilldown, Manipulate, Stability)", () => {
+    expect(EXPLORE_PHASES).toHaveLength(6);
+  });
+});

--- a/frontend/src/pages/workspace/state/tabs.ts
+++ b/frontend/src/pages/workspace/state/tabs.ts
@@ -66,6 +66,7 @@ export const EXPLORE_TAB_ORDER: ExploreTab[] = [
   "bandmask",
   "agreement",
   "applydoc",
+  "recipes",
   "usgs",
   "metrics",
 ];

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,28 @@
+/**
+ * Vitest setup: install jest-dom matchers and stub browser APIs the
+ * components touch but jsdom doesn't implement (matchMedia, IntersectionObserver).
+ */
+import "@testing-library/jest-dom/vitest";
+
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  });
+}
+
+if (!window.IntersectionObserver) {
+  // @ts-expect-error jsdom doesn't ship IntersectionObserver
+  window.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  };
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,23 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+// Vitest-only config, kept separate from vite.config.ts because
+// vitest pulls in Vite v5 while the production build runs against
+// Vite v6 — sharing a single config produces conflicting plugin
+// types. The build/test paths thus stay independent.
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    css: false,
+  },
+});


### PR DESCRIPTION
## Summary

Two code-side cycles since c245-246 deploy (PR #470):

- **c249** (#471): Pydantic for 19 more routes — agreement matrices,
  narratives, interpretability cards, representations, topic-routed,
  neural-topic, rate-distortion, all stability families, anomaly,
  USGS, endmember, external-validation, method-statistics-HIDSAG,
  DMR-LDA-HIDSAG, optuna-search. Cumulative coverage:
  **74 routes typed / 8 remaining untyped (~90%)**.

- **c250** (#472): Vitest + jsdom + @testing-library/react scaffold;
  18 tests (1.1s wall-clock) across 3 files (tabs invariants,
  TabStates, RecentlyViewed). **Found and fixed a real bug**: the
  'recipes' tab was in EXPLORE_PHASES but missing from
  EXPLORE_TAB_ORDER, so \`[\` / \`]\` keyboard nav silently skipped it.

Paper cycles c251 + c252 (PRs #12, #13, develop only):
- c251: posterior predictive check — overturns previous Suppl G
  claim (residuals significantly non-Gaussian: Shapiro-Wilk
  p=0.0014, KS p=0.043, excess kurtosis +1.39).
- c252: canonical-K rule justification — resolves F-4 recommended
  K=4 vs canonical K = max(4, min(12, n_classes)) contradiction
  by showing the two optimise different objectives.

## Test plan

- [x] Each task PR's smoke 109/109 verified.
- [x] \`pnpm test\` → 18 passed; \`pytest tests/\` → 24 passed.
- [ ] \`update.sh\` on Hetzner.
- [ ] Smoke 109/109 on https://lda-hsi.fasl-work.com.
- [ ] OpenAPI schema count monotonic ≥ 148.

Refs #440 P1 1.2 (90%), #441 testing scaffold.