### PR TITLE
Cycle 256: expand backend tests from 24 to 57 (#440)

### DIFF
--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -1,0 +1,56 @@
+"""Regression tests for the CORS dev/prod origin split (c241 / #440 P2 1.6)."""
+from __future__ import annotations
+
+import importlib
+import os
+
+from app.config import Settings
+
+
+def _fresh_settings(**env: str) -> Settings:
+    """Construct Settings with the given env vars, isolated from the
+    process environment."""
+    saved = {}
+    for k in ("APP_ENV", "DEV_ORIGINS", "PROD_ORIGINS", "ALLOWED_ORIGINS"):
+        saved[k] = os.environ.get(k)
+        if k in env:
+            os.environ[k] = env[k]
+        elif k in os.environ:
+            del os.environ[k]
+    try:
+        return Settings()
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_dev_default_excludes_prod_url() -> None:
+    s = _fresh_settings(APP_ENV="development")
+    assert "https://lda-hsi.fasl-work.com" not in s.origins
+
+
+def test_prod_locks_down_to_single_origin() -> None:
+    s = _fresh_settings(APP_ENV="production")
+    assert s.origins == ["https://lda-hsi.fasl-work.com"]
+
+
+def test_allowed_origins_override_wins() -> None:
+    s = _fresh_settings(
+        APP_ENV="production",
+        ALLOWED_ORIGINS="https://override.example.com",
+    )
+    assert s.origins == ["https://override.example.com"]
+
+
+def test_origins_strips_whitespace_in_csv() -> None:
+    s = _fresh_settings(
+        APP_ENV="production",
+        ALLOWED_ORIGINS=" https://a.example.com , https://b.example.com ",
+    )
+    assert s.origins == [
+        "https://a.example.com",
+        "https://b.example.com",
+    ]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,65 @@
+"""Unit tests for the `_serve_or_404` + `_typed_or_404` helpers (c239)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from app.routers.content import _serve_or_404, _typed_or_404
+
+
+class _SampleResponse(BaseModel):
+    name: str
+    value: int
+
+
+def test_serve_or_404_passes_args() -> None:
+    def loader(a: str, b: int) -> dict:
+        return {"a": a, "b": b}
+
+    assert _serve_or_404(loader, "x", 42, hint="not generated") == {"a": "x", "b": 42}
+
+
+def test_serve_or_404_no_args() -> None:
+    def loader() -> dict:
+        return {"empty": True}
+
+    assert _serve_or_404(loader, hint="not generated") == {"empty": True}
+
+
+def test_serve_or_404_translates_file_not_found() -> None:
+    def loader() -> dict:
+        raise FileNotFoundError("missing")
+
+    with pytest.raises(HTTPException) as ei:
+        _serve_or_404(loader, hint="custom hint here")
+    assert ei.value.status_code == 404
+    assert "custom hint here" in str(ei.value.detail)
+
+
+def test_serve_or_404_passes_other_exceptions() -> None:
+    def loader() -> dict:
+        raise ValueError("not a FileNotFoundError")
+
+    # Should NOT be translated to 404 — propagates as-is.
+    with pytest.raises(ValueError):
+        _serve_or_404(loader, hint="ignored")
+
+
+def test_typed_or_404_validates_into_model() -> None:
+    def loader() -> dict:
+        return {"name": "hello", "value": 7}
+
+    result = _typed_or_404(_SampleResponse, loader, hint="not generated")
+    assert isinstance(result, _SampleResponse)
+    assert result.name == "hello"
+    assert result.value == 7
+
+
+def test_typed_or_404_translates_file_not_found() -> None:
+    def loader() -> dict:
+        raise FileNotFoundError()
+
+    with pytest.raises(HTTPException) as ei:
+        _typed_or_404(_SampleResponse, loader, hint="typed not generated")
+    assert ei.value.status_code == 404

--- a/tests/test_pydantic_coverage.py
+++ b/tests/test_pydantic_coverage.py
@@ -1,0 +1,121 @@
+"""End-to-end Pydantic-coverage tests.
+
+After c254 every `/api/*` route declares a response_model. This file
+pins that invariant: any future PR that adds a route without a
+response model will trip the `test_all_get_routes_have_response_model`
+check.
+
+Also samples one happy-path call per of the new c245 + c249 + c254
+route families so OpenAPI drift is caught.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.routers.content import router as content_router
+
+
+def test_all_get_routes_have_response_model() -> None:
+    """Every GET route under /api/* must declare a response_model.
+
+    Closes #440 P1 1.2 as a permanent invariant.
+    """
+    missing: list[str] = []
+    for route in content_router.routes:
+        if not hasattr(route, "response_model"):
+            continue
+        if route.response_model is None and "GET" in route.methods:
+            missing.append(route.path)
+    assert not missing, (
+        f"{len(missing)} GET routes lack a response_model: {missing}"
+    )
+
+
+def test_openapi_schema_count_monotonic(client: TestClient) -> None:
+    """The OpenAPI schema component count should be ≥ 100 after c254
+    (we shipped 172 live on 2026-05-18 and 100% Pydantic adds more)."""
+    res = client.get("/openapi.json")
+    assert res.status_code == 200
+    schemas = res.json().get("components", {}).get("schemas", {})
+    assert len(schemas) >= 100, f"Only {len(schemas)} schemas in OpenAPI"
+
+
+PER_SCENE_ENDPOINTS_TO_SAMPLE = [
+    "/api/eda/per-scene/indian-pines-corrected",
+    "/api/spectral-browser/indian-pines-corrected",
+    "/api/spectral-density/indian-pines-corrected",
+    "/api/topic-to-library/indian-pines-corrected",
+    "/api/quantization-sensitivity/indian-pines-corrected",
+    "/api/lda-sweep/indian-pines-corrected",
+    "/api/linear-probe-panel/indian-pines-corrected",
+    "/api/mutual-information/indian-pines-corrected",
+    "/api/cross-method-agreement/indian-pines-corrected",
+    "/api/topic-routed-classifier/indian-pines-corrected",
+    "/api/neural-topic-comparison/indian-pines-corrected",
+    "/api/rate-distortion-curve/indian-pines-corrected",
+    "/api/topic-anomaly/indian-pines-corrected",
+    "/api/endmember-baseline/indian-pines-corrected",
+    "/api/topic-to-usgs-v7/indian-pines-corrected",
+]
+
+
+@pytest.mark.parametrize("path", PER_SCENE_ENDPOINTS_TO_SAMPLE)
+def test_typed_route_happy_path(client: TestClient, path: str) -> None:
+    res = client.get(path)
+    assert res.status_code == 200, f"{path} returned {res.status_code}"
+    body = res.json()
+    assert isinstance(body, dict), f"{path} did not return a JSON object"
+
+
+def test_super_topics_envelope(client: TestClient) -> None:
+    res = client.get("/api/super-topics")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["n_topics_total"] == 63
+    assert body["n_scenes"] == 6
+
+
+def test_cross_scene_transfer_envelope(client: TestClient) -> None:
+    res = client.get("/api/cross-scene-transfer")
+    assert res.status_code == 200
+    body = res.json()
+    assert isinstance(body["transfer_matrix_macro_f1"], list)
+
+
+def test_bayesian_comparison_polymorphic(client: TestClient) -> None:
+    """The /bayesian-comparison/{task_type} route returns the same
+    envelope for all 4 task types — verify each works."""
+    for task in [
+        "regression",
+        "classification",
+        "classification-labelled",
+        "classification-labelled-deep",
+    ]:
+        res = client.get(f"/api/bayesian-comparison/{task}")
+        assert res.status_code == 200, (
+            f"/api/bayesian-comparison/{task} returned {res.status_code}"
+        )
+        body = res.json()
+        assert "method_names" in body or "method_posteriors" in body
+
+
+def test_bayesian_comparison_invalid_400(client: TestClient) -> None:
+    res = client.get("/api/bayesian-comparison/garbage")
+    assert res.status_code == 400
+
+
+def test_groupings_index_envelope(client: TestClient) -> None:
+    res = client.get("/api/groupings")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["count"] == len(body["items"])
+    assert body["count"] > 0
+
+
+def test_manifest_envelope(client: TestClient) -> None:
+    res = client.get("/api/manifest")
+    assert res.status_code == 200
+    body = res.json()
+    assert "generated_at" in body
+    assert isinstance(body.get("artifacts", []), list)


### PR DESCRIPTION
## Summary

Triples the backend test suite (24 → 57 tests, 1.54s wall-clock) to
guard the surfaces introduced in c239-c254.

## New test files

| File | Tests | Targets |
|---|---|---|
| \`tests/test_pydantic_coverage.py\` | 24 | All 82 routes via invariant test + 15 happy-path samples + bayesian-comparison polymorphism + 400 |
| \`tests/test_cors_config.py\` | 4 | c241 dev/prod CORS split |
| \`tests/test_helpers.py\` | 6 | \`_serve_or_404\` + \`_typed_or_404\` |

## Invariant guard

\`test_all_get_routes_have_response_model\` walks the router's
routes and fails if any GET route lacks a response_model. This
permanently locks in the #440 P1 1.2 result so a future PR can't
silently regress it.

## Test plan

- [x] pytest tests/ -v → **57 passed in 1.54s**.

Refs #440 (all P0/P1/P2 items now have at least one test asserting
the fix).