### PR TITLE
Deploy cycles 254-257: 100% Pydantic + Vitest +28 tests (#440 fully closed, #441 expanded)

### DIFF
--- a/app/models/precompute.py
+++ b/app/models/precompute.py
@@ -935,3 +935,141 @@ class MethodStatisticsHidsag(BaseModel):
     ranking: dict[str, Any] | None = None
     generated_at: str | None = None
     builder_version: str | None = None
+
+
+# ============================================================================
+# c254: final-slice models — manifest, groupings, topic-variants,
+# representations index, bayesian-comparison, llm-tea-leaves.
+# Closes #440 P1 1.2 fully at 82 of 82 routes (100%).
+# ============================================================================
+
+
+class ManifestArtifact(BaseModel):
+    model_config = _PassThroughConfig
+    path: str | None = None
+    bytes: int | None = None
+    sha256: str | None = None
+    builder: str | None = None
+
+
+class ManifestClaim(BaseModel):
+    model_config = _PassThroughConfig
+    claim: str | None = None
+    source: str | None = None
+
+
+class Manifest(BaseModel):
+    """Derived-artefacts manifest emitted by curate-for-web."""
+    model_config = _PassThroughConfig
+    generated_at: str
+    git_sha: str | None = None
+    builders: dict[str, Any] = Field(default_factory=dict)
+    scenes: list[str] = Field(default_factory=list)
+    artifacts: list[dict[str, Any]] = Field(default_factory=list)
+    claims_allowed: list[dict[str, Any]] = Field(default_factory=list)
+    rule: str | None = None
+
+
+# Index envelopes for groupings / topic-variants / representations all
+# share the {count, items: [...]} shape (computed dynamically by the
+# service layer). One generic model handles all three.
+
+
+class IndexItem(BaseModel):
+    model_config = _PassThroughConfig
+    # No fixed keys — different routes name the discriminator field
+    # differently (method vs variant vs subset_code etc).
+
+
+class CountItemsIndex(BaseModel):
+    """Generic envelope for groupings/topic-variants/representations
+    index responses: {count: int, items: [...]}.
+    """
+    model_config = _PassThroughConfig
+    count: int
+    items: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class GroupingDetail(BaseModel):
+    model_config = _PassThroughConfig
+    scene_id: str
+    method: str
+    n_groups: int | None = None
+    group_size_distribution: dict[str, Any] | None = None
+    between_within_variance_ratio: float | None = None
+    agreement_vs_label: dict[str, Any] | None = None
+    mean_spectrum_per_group: list[dict[str, Any]] | None = None
+    spatial_shape: list[int] | None = None
+    assignment_path: str | None = None
+    assignment_format: str | None = None
+    assignment_dtype_max_id: int | None = None
+    wavelengths_nm: list[float] | None = None
+    served_path: str | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None
+
+
+class TopicVariantDetail(BaseModel):
+    """ETM / ProdLDA / DMR-LDA / Gensim multicore variant detail."""
+    model_config = _PassThroughConfig
+    scene_id: str
+    variant: str
+    topic_count: int
+    vocabulary_size: int | None = None
+    topic_prevalence: list[float] | None = None
+    top_words_per_topic: list[Any] | None = None
+    wavelengths_nm: list[float] | None = None
+    fit_meta: dict[str, Any] | None = None
+    downstream_kmeans_vs_label: dict[str, Any] | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None
+
+
+class BayesianMethodPosterior(BaseModel):
+    model_config = _PassThroughConfig
+    method: str
+    posterior_mean: float | None = None
+    posterior_std: float | None = None
+    hdi94_lo: float | None = None
+    hdi94_hi: float | None = None
+
+
+class BayesianComparison(BaseModel):
+    """Common envelope for all task_type variants of /bayesian-comparison.
+
+    Different task_types ("regression" | "classification" |
+    "classification-labelled" | "classification-labelled-deep")
+    populate slightly different subsets of fields; all fields are
+    optional to absorb the polymorphism without separate response
+    models per task.
+    """
+    # Disable the "model_" protected-namespace warning for model_summary.
+    model_config = ConfigDict(extra="allow", protected_namespaces=())
+    task_type: str | None = None
+    scope: str | None = None
+    n_observations: int | None = None
+    n_methods: int | None = None
+    n_scenes: int | None = None
+    n_subsets: int | None = None
+    n_folds: int | None = None
+    n_targets: int | None = None
+    method_names: list[str] | None = None
+    scene_names: list[str] | None = None
+    subset_names: list[str] | None = None
+    method_posteriors: list[dict[str, Any]] | None = None
+    pairwise_p_a_gt_b: dict[str, Any] | None = None
+    model_summary: str | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None
+
+
+class LlmTeaLeaves(BaseModel):
+    """Permissive envelope — no live JSON exists in the test fixture
+    tree, so we cannot tighten the schema. The route returns whatever
+    `build_b12_llm_tea_leaves` produced when ANTHROPIC_API_KEY was set.
+    """
+    model_config = _PassThroughConfig
+    scene_id: str
+    framework_axis: str | None = None
+    generated_at: str | None = None
+    builder_version: str | None = None

--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -11,9 +11,15 @@ from app.models.band_masks import (
     BandMasksIndexResponse,
 )
 from app.models.precompute import (
+    BayesianComparison,
+    CountItemsIndex,
     CrossMethodAgreement,
     CrossSceneTransfer,
     DeepAnomaly,
+    GroupingDetail,
+    LlmTeaLeaves,
+    Manifest,
+    TopicVariantDetail,
     DmrLdaHidsag,
     EdaHidsag,
     EdaPerScene,
@@ -357,10 +363,14 @@ def _typed_or_404(model, loader, *args, hint: str):
     return model.model_validate(_serve_or_404(loader, *args, hint=hint))
 
 
-@router.get("/manifest")
-def derived_manifest() -> dict:
-    return _serve_or_404(
-        get_derived_manifest,
+@router.get(
+    "/manifest",
+    response_model=Manifest,
+    response_model_exclude_none=True,
+)
+def derived_manifest() -> Manifest:
+    return _typed_or_404(
+        Manifest, get_derived_manifest,
         hint="manifest not generated yet; run scripts/local.* curate-for-web",
     )
 
@@ -598,18 +608,26 @@ def band_masks_hidsag_summary(
     )
 
 
-@router.get("/groupings")
-def groupings_index() -> dict:
-    return _serve_or_404(
-        get_groupings_index,
+@router.get(
+    "/groupings",
+    response_model=CountItemsIndex,
+    response_model_exclude_none=True,
+)
+def groupings_index() -> CountItemsIndex:
+    return _typed_or_404(
+        CountItemsIndex, get_groupings_index,
         hint="groupings not generated yet; run scripts/local.* build-groupings",
     )
 
 
-@router.get("/groupings/{method}/{scene_id}")
-def grouping(method: str, scene_id: str) -> dict:
-    return _serve_or_404(
-        get_grouping, method, scene_id,
+@router.get(
+    "/groupings/{method}/{scene_id}",
+    response_model=GroupingDetail,
+    response_model_exclude_none=True,
+)
+def grouping(method: str, scene_id: str) -> GroupingDetail:
+    return _typed_or_404(
+        GroupingDetail, get_grouping, method, scene_id,
         hint=f"grouping {method}/{scene_id} not generated yet",
     )
 
@@ -700,18 +718,26 @@ def quantization_sensitivity(scene_id: str) -> QuantizationSensitivity:
     )
 
 
-@router.get("/topic-variants")
-def topic_variants_index() -> dict:
-    return _serve_or_404(
-        get_topic_variants_index,
+@router.get(
+    "/topic-variants",
+    response_model=CountItemsIndex,
+    response_model_exclude_none=True,
+)
+def topic_variants_index() -> CountItemsIndex:
+    return _typed_or_404(
+        CountItemsIndex, get_topic_variants_index,
         hint="topic variants not generated yet",
     )
 
 
-@router.get("/topic-variants/{variant}/{scene_id}")
-def topic_variant(variant: str, scene_id: str) -> dict:
-    return _serve_or_404(
-        get_topic_variant, variant, scene_id,
+@router.get(
+    "/topic-variants/{variant}/{scene_id}",
+    response_model=TopicVariantDetail,
+    response_model_exclude_none=True,
+)
+def topic_variant(variant: str, scene_id: str) -> TopicVariantDetail:
+    return _typed_or_404(
+        TopicVariantDetail, get_topic_variant, variant, scene_id,
         hint=f"topic variant {variant}/{scene_id} not generated yet",
     )
 
@@ -728,10 +754,14 @@ def lda_sweep(scene_id: str) -> LdaSweep:
     )
 
 
-@router.get("/representations")
-def representations_index() -> dict:
-    return _serve_or_404(
-        get_representations_index,
+@router.get(
+    "/representations",
+    response_model=CountItemsIndex,
+    response_model_exclude_none=True,
+)
+def representations_index() -> CountItemsIndex:
+    return _typed_or_404(
+        CountItemsIndex, get_representations_index,
         hint="representations not generated yet",
     )
 
@@ -760,16 +790,20 @@ def dmr_lda_hidsag(subset_code: str) -> DmrLdaHidsag:
     )
 
 
-@router.get("/bayesian-comparison/{task_type}")
-def bayesian_comparison(task_type: str) -> dict:
+@router.get(
+    "/bayesian-comparison/{task_type}",
+    response_model=BayesianComparison,
+    response_model_exclude_none=True,
+)
+def bayesian_comparison(task_type: str) -> BayesianComparison:
     if task_type == "classification-labelled":
-        return _serve_or_404(
-            get_bayesian_classification_labelled,
+        return _typed_or_404(
+            BayesianComparison, get_bayesian_classification_labelled,
             hint="bayesian_comparison labelled-classification not generated yet",
         )
     if task_type == "classification-labelled-deep":
-        return _serve_or_404(
-            get_bayesian_classification_labelled_deep,
+        return _typed_or_404(
+            BayesianComparison, get_bayesian_classification_labelled_deep,
             hint="bayesian_comparison labelled-classification-deep not generated yet",
         )
     if task_type not in ("regression", "classification"):
@@ -777,8 +811,8 @@ def bayesian_comparison(task_type: str) -> dict:
             status_code=400,
             detail="task_type must be regression | classification | classification-labelled | classification-labelled-deep",
         )
-    return _serve_or_404(
-        get_bayesian_comparison, task_type,
+    return _typed_or_404(
+        BayesianComparison, get_bayesian_comparison, task_type,
         hint=f"bayesian_comparison for '{task_type}' not generated yet",
     )
 
@@ -1040,10 +1074,14 @@ def endmember_baseline(scene_id: str) -> EndmemberBaseline:
     )
 
 
-@router.get("/llm-tea-leaves/{scene_id}")
-def llm_tea_leaves(scene_id: str) -> dict:
-    return _serve_or_404(
-        get_llm_tea_leaves, scene_id,
+@router.get(
+    "/llm-tea-leaves/{scene_id}",
+    response_model=LlmTeaLeaves,
+    response_model_exclude_none=True,
+)
+def llm_tea_leaves(scene_id: str) -> LlmTeaLeaves:
+    return _typed_or_404(
+        LlmTeaLeaves, get_llm_tea_leaves, scene_id,
         hint=(
             f"llm_tea_leaves for '{scene_id}' not generated yet "
             "(set ANTHROPIC_API_KEY and run build_b12_llm_tea_leaves)"

--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * CommandPalette (c232) tests — Ctrl+K toggles open, fuzzy filter
+ * narrows results, keyboard nav (Arrow + Enter) selects items, Esc
+ * closes.
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { CommandPalette } from "./CommandPalette";
+
+function renderPalette() {
+  return render(
+    <MemoryRouter>
+      <CommandPalette />
+    </MemoryRouter>,
+  );
+}
+
+describe("CommandPalette", () => {
+  it("renders nothing visible until Ctrl+K is pressed", () => {
+    renderPalette();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens on Ctrl+K and renders a dialog", () => {
+    renderPalette();
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("opens on Cmd+K (macOS) as well", () => {
+    renderPalette();
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("closes when Escape is pressed", () => {
+    renderPalette();
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("lists scene shortcuts among results when open with no query", () => {
+    renderPalette();
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    // 6 labelled scenes appear with "Open ..." prefix.
+    expect(screen.getByText(/Open Indian Pines/i)).toBeInTheDocument();
+    expect(screen.getByText(/Open Salinas-A/i)).toBeInTheDocument();
+    expect(screen.getByText(/Open Botswana/i)).toBeInTheDocument();
+  });
+
+  it("filters by query — typing 'botswana' narrows to that scene", () => {
+    renderPalette();
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "botswana" } });
+    expect(screen.getByText(/Open Botswana/i)).toBeInTheDocument();
+    // Other scenes should NOT be visible after the filter.
+    expect(screen.queryByText(/Open Salinas-A/i)).not.toBeInTheDocument();
+  });
+
+  it("does not open Ctrl+K when typing inside an input field elsewhere", () => {
+    // Render an input and dispatch Ctrl+K with the input as the
+    // event target — the palette should NOT toggle so the user can
+    // type 'k' freely inside form fields.
+    render(
+      <MemoryRouter>
+        <input data-testid="other" />
+        <CommandPalette />
+      </MemoryRouter>,
+    );
+    const other = screen.getByTestId("other");
+    other.focus();
+    fireEvent.keyDown(other, { key: "k", ctrlKey: true });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/workspace/components/ExploreNav.test.tsx
+++ b/frontend/src/pages/workspace/components/ExploreNav.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * ExploreNav (c132 + c246) tests. Pin the two-tier tablist a11y
+ * structure: outer phase-tabs with id + aria-controls; inner
+ * tabpanel labelled by the active phase tab; non-color "contains
+ * active tab" signal (WCAG 1.4.1).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import type { TFunction } from "i18next";
+import { ExploreNav } from "./ExploreNav";
+import { EXPLORE_PHASES } from "../state/tabs";
+
+// Minimal i18n shim — the component reads pages:workspace.tabs.* labels.
+const t = ((key: string) => {
+  const fallback = key.split(".").pop() ?? key;
+  return fallback;
+}) as unknown as TFunction<["pages"]>;
+
+describe("ExploreNav", () => {
+  it("renders one tablist per phase row + one panel wrapping the sub-tablist", () => {
+    render(<ExploreNav tab="raw" setTab={() => undefined} t={t} />);
+    // Outer phase tablist
+    expect(
+      screen.getByRole("tablist", { name: /workspace phase/i }),
+    ).toBeInTheDocument();
+    // Phase panel for the active phase
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveAttribute("aria-labelledby");
+  });
+
+  it("phase tabs carry id + aria-controls + aria-selected", () => {
+    render(<ExploreNav tab="raw" setTab={() => undefined} t={t} />);
+    const phaseTablist = screen.getByRole("tablist", { name: /workspace phase/i });
+    const tabs = within(phaseTablist).getAllByRole("tab");
+    // Sanity: 6 phases (Data, Topics, Geometry, Drilldown, Manipulate, Stability)
+    expect(tabs).toHaveLength(EXPLORE_PHASES.length);
+    for (const t of tabs) {
+      expect(t.id).toMatch(/^phase-tab-/);
+      expect(t.getAttribute("aria-controls")).toMatch(/^phase-panel-/);
+      expect(t.getAttribute("aria-selected")).toMatch(/^(true|false)$/);
+    }
+  });
+
+  it("Exactly one phase tab is aria-selected", () => {
+    render(<ExploreNav tab="raw" setTab={() => undefined} t={t} />);
+    const phaseTablist = screen.getByRole("tablist", { name: /workspace phase/i });
+    const tabs = within(phaseTablist).getAllByRole("tab");
+    const selected = tabs.filter((t) => t.getAttribute("aria-selected") === "true");
+    expect(selected).toHaveLength(1);
+  });
+
+  it("non-active phase containing the active tab gets a textual '· active' marker", () => {
+    // raw is in phase 'data'. Click 'topics' phase to make 'data' inactive
+    // while still containing the active tab; the marker must be textual.
+    render(<ExploreNav tab="raw" setTab={() => undefined} t={t} />);
+    // Initially 'data' phase is active (raw is in it). Click 'topics':
+    const phaseTablist = screen.getByRole("tablist", { name: /workspace phase/i });
+    const tabs = within(phaseTablist).getAllByRole("tab");
+    const topicsTab = tabs.find((b) =>
+      /Topics/i.test(b.textContent ?? ""),
+    );
+    if (topicsTab) fireEvent.click(topicsTab);
+    // 'data' phase should still mark itself as containing the active tab
+    // via the textual '· active' suffix.
+    expect(screen.getByText("· active")).toBeInTheDocument();
+  });
+
+  it("clicking a sub-tab invokes setTab with the tab id", () => {
+    const setTab = vi.fn();
+    render(<ExploreNav tab="raw" setTab={setTab} t={t} />);
+    // sub-tablist for the active phase
+    const subTablist = screen.getByRole("tablist", { name: /panels/i });
+    const subTabs = within(subTablist).getAllByRole("tab");
+    if (subTabs[0]) fireEvent.click(subTabs[0]);
+    expect(setTab).toHaveBeenCalled();
+  });
+});

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -1,0 +1,56 @@
+"""Regression tests for the CORS dev/prod origin split (c241 / #440 P2 1.6)."""
+from __future__ import annotations
+
+import importlib
+import os
+
+from app.config import Settings
+
+
+def _fresh_settings(**env: str) -> Settings:
+    """Construct Settings with the given env vars, isolated from the
+    process environment."""
+    saved = {}
+    for k in ("APP_ENV", "DEV_ORIGINS", "PROD_ORIGINS", "ALLOWED_ORIGINS"):
+        saved[k] = os.environ.get(k)
+        if k in env:
+            os.environ[k] = env[k]
+        elif k in os.environ:
+            del os.environ[k]
+    try:
+        return Settings()
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_dev_default_excludes_prod_url() -> None:
+    s = _fresh_settings(APP_ENV="development")
+    assert "https://lda-hsi.fasl-work.com" not in s.origins
+
+
+def test_prod_locks_down_to_single_origin() -> None:
+    s = _fresh_settings(APP_ENV="production")
+    assert s.origins == ["https://lda-hsi.fasl-work.com"]
+
+
+def test_allowed_origins_override_wins() -> None:
+    s = _fresh_settings(
+        APP_ENV="production",
+        ALLOWED_ORIGINS="https://override.example.com",
+    )
+    assert s.origins == ["https://override.example.com"]
+
+
+def test_origins_strips_whitespace_in_csv() -> None:
+    s = _fresh_settings(
+        APP_ENV="production",
+        ALLOWED_ORIGINS=" https://a.example.com , https://b.example.com ",
+    )
+    assert s.origins == [
+        "https://a.example.com",
+        "https://b.example.com",
+    ]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,65 @@
+"""Unit tests for the `_serve_or_404` + `_typed_or_404` helpers (c239)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from app.routers.content import _serve_or_404, _typed_or_404
+
+
+class _SampleResponse(BaseModel):
+    name: str
+    value: int
+
+
+def test_serve_or_404_passes_args() -> None:
+    def loader(a: str, b: int) -> dict:
+        return {"a": a, "b": b}
+
+    assert _serve_or_404(loader, "x", 42, hint="not generated") == {"a": "x", "b": 42}
+
+
+def test_serve_or_404_no_args() -> None:
+    def loader() -> dict:
+        return {"empty": True}
+
+    assert _serve_or_404(loader, hint="not generated") == {"empty": True}
+
+
+def test_serve_or_404_translates_file_not_found() -> None:
+    def loader() -> dict:
+        raise FileNotFoundError("missing")
+
+    with pytest.raises(HTTPException) as ei:
+        _serve_or_404(loader, hint="custom hint here")
+    assert ei.value.status_code == 404
+    assert "custom hint here" in str(ei.value.detail)
+
+
+def test_serve_or_404_passes_other_exceptions() -> None:
+    def loader() -> dict:
+        raise ValueError("not a FileNotFoundError")
+
+    # Should NOT be translated to 404 — propagates as-is.
+    with pytest.raises(ValueError):
+        _serve_or_404(loader, hint="ignored")
+
+
+def test_typed_or_404_validates_into_model() -> None:
+    def loader() -> dict:
+        return {"name": "hello", "value": 7}
+
+    result = _typed_or_404(_SampleResponse, loader, hint="not generated")
+    assert isinstance(result, _SampleResponse)
+    assert result.name == "hello"
+    assert result.value == 7
+
+
+def test_typed_or_404_translates_file_not_found() -> None:
+    def loader() -> dict:
+        raise FileNotFoundError()
+
+    with pytest.raises(HTTPException) as ei:
+        _typed_or_404(_SampleResponse, loader, hint="typed not generated")
+    assert ei.value.status_code == 404

--- a/tests/test_pydantic_coverage.py
+++ b/tests/test_pydantic_coverage.py
@@ -1,0 +1,121 @@
+"""End-to-end Pydantic-coverage tests.
+
+After c254 every `/api/*` route declares a response_model. This file
+pins that invariant: any future PR that adds a route without a
+response model will trip the `test_all_get_routes_have_response_model`
+check.
+
+Also samples one happy-path call per of the new c245 + c249 + c254
+route families so OpenAPI drift is caught.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.routers.content import router as content_router
+
+
+def test_all_get_routes_have_response_model() -> None:
+    """Every GET route under /api/* must declare a response_model.
+
+    Closes #440 P1 1.2 as a permanent invariant.
+    """
+    missing: list[str] = []
+    for route in content_router.routes:
+        if not hasattr(route, "response_model"):
+            continue
+        if route.response_model is None and "GET" in route.methods:
+            missing.append(route.path)
+    assert not missing, (
+        f"{len(missing)} GET routes lack a response_model: {missing}"
+    )
+
+
+def test_openapi_schema_count_monotonic(client: TestClient) -> None:
+    """The OpenAPI schema component count should be ≥ 100 after c254
+    (we shipped 172 live on 2026-05-18 and 100% Pydantic adds more)."""
+    res = client.get("/openapi.json")
+    assert res.status_code == 200
+    schemas = res.json().get("components", {}).get("schemas", {})
+    assert len(schemas) >= 100, f"Only {len(schemas)} schemas in OpenAPI"
+
+
+PER_SCENE_ENDPOINTS_TO_SAMPLE = [
+    "/api/eda/per-scene/indian-pines-corrected",
+    "/api/spectral-browser/indian-pines-corrected",
+    "/api/spectral-density/indian-pines-corrected",
+    "/api/topic-to-library/indian-pines-corrected",
+    "/api/quantization-sensitivity/indian-pines-corrected",
+    "/api/lda-sweep/indian-pines-corrected",
+    "/api/linear-probe-panel/indian-pines-corrected",
+    "/api/mutual-information/indian-pines-corrected",
+    "/api/cross-method-agreement/indian-pines-corrected",
+    "/api/topic-routed-classifier/indian-pines-corrected",
+    "/api/neural-topic-comparison/indian-pines-corrected",
+    "/api/rate-distortion-curve/indian-pines-corrected",
+    "/api/topic-anomaly/indian-pines-corrected",
+    "/api/endmember-baseline/indian-pines-corrected",
+    "/api/topic-to-usgs-v7/indian-pines-corrected",
+]
+
+
+@pytest.mark.parametrize("path", PER_SCENE_ENDPOINTS_TO_SAMPLE)
+def test_typed_route_happy_path(client: TestClient, path: str) -> None:
+    res = client.get(path)
+    assert res.status_code == 200, f"{path} returned {res.status_code}"
+    body = res.json()
+    assert isinstance(body, dict), f"{path} did not return a JSON object"
+
+
+def test_super_topics_envelope(client: TestClient) -> None:
+    res = client.get("/api/super-topics")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["n_topics_total"] == 63
+    assert body["n_scenes"] == 6
+
+
+def test_cross_scene_transfer_envelope(client: TestClient) -> None:
+    res = client.get("/api/cross-scene-transfer")
+    assert res.status_code == 200
+    body = res.json()
+    assert isinstance(body["transfer_matrix_macro_f1"], list)
+
+
+def test_bayesian_comparison_polymorphic(client: TestClient) -> None:
+    """The /bayesian-comparison/{task_type} route returns the same
+    envelope for all 4 task types — verify each works."""
+    for task in [
+        "regression",
+        "classification",
+        "classification-labelled",
+        "classification-labelled-deep",
+    ]:
+        res = client.get(f"/api/bayesian-comparison/{task}")
+        assert res.status_code == 200, (
+            f"/api/bayesian-comparison/{task} returned {res.status_code}"
+        )
+        body = res.json()
+        assert "method_names" in body or "method_posteriors" in body
+
+
+def test_bayesian_comparison_invalid_400(client: TestClient) -> None:
+    res = client.get("/api/bayesian-comparison/garbage")
+    assert res.status_code == 400
+
+
+def test_groupings_index_envelope(client: TestClient) -> None:
+    res = client.get("/api/groupings")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["count"] == len(body["items"])
+    assert body["count"] > 0
+
+
+def test_manifest_envelope(client: TestClient) -> None:
+    res = client.get("/api/manifest")
+    assert res.status_code == 200
+    body = res.json()
+    assert "generated_at" in body
+    assert isinstance(body.get("artifacts", []), list)


### PR DESCRIPTION
## Summary

Four code-side cycles since c249-250 deploy (PR #473):

- **c254** PR #474 — Pydantic for the last 8 routes. **82/82 routes
  typed (100%)**. Zero \`-> dict\` handlers remain in content.py.
  Closes #440 P1 1.2 fully.
- **c255** wiki sync — paired-ARI CI + PPC + canonical-K + per-class
  P/R findings propagated to Bayesian-Method-Comparison.md and
  Multi-Axis-Addendum-B.md (wiki master 0b278ff).
- **c256** PR #475 — Backend tests 24 → **57** in 1.54s. Adds an
  invariant test that walks the router and fails if any GET route
  lacks a response_model (permanent #440 P1 1.2 guard) +
  c241 CORS tests + c239 helper tests.
- **c257** PR #476 — Frontend Vitest 18 → **30** in 2.9s. Adds
  CommandPalette (7 tests) + ExploreNav (5 tests pinning c246 a11y
  wiring).

Paper deploy in PR #14 (paper main → 57dfc74) lands the 5 paper-side
cycles (c235, c243, c247, c251, c252).

## #440 status — fully closed

| Item | Status |
|---|---|
| P0 1.5 SPA path traversal | ✅ c224 |
| P1 1.1 Dead helper | ✅ c239 |
| P1 1.2 47 untyped handlers | ✅ **c254 (100%)** |
| P1 1.3 try/except boilerplate | ✅ c239 |
| P1 1.4 Lazy imports | ✅ c240 |
| P1 1.7 Zero tests | ✅ c242 → 57 in c256 |
| P2 1.6 CORS dev/prod split | ✅ c241 |

## Test plan

- [x] pytest tests/ -v → 57 passed in 1.54s.
- [x] pnpm test → 30 passed in 2.9s.
- [x] Smoke harness 109/109 OK locally.
- [ ] update.sh on Hetzner.
- [ ] OpenAPI ≥ 180 schemas (was 172 after c249).