### PR TITLE
Cycle 264: metadata envelope on 7 more builders — closes #444 P1 3.1 fully

### DIFF
--- a/data-pipeline/build_corpus_previews.py
+++ b/data-pipeline/build_corpus_previews.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 
 import json
 from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
 from statistics import median
 from typing import Any, Iterable
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -347,8 +352,11 @@ def main() -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     payload = {
         "source": "Static corpus previews generated from compact derived spectral assets",
-        "generated_at": "2026-04-30",
         "previews": previews,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: corpus-previews static landing-card content",
+        "generated_at": _now_iso(),
+        "builder_version": "build_corpus_previews v0.2",
     }
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)

--- a/data-pipeline/build_exploration_views.py
+++ b/data-pipeline/build_exploration_views.py
@@ -445,7 +445,10 @@ def main() -> int:
         "generated_at": date.today().isoformat(),
         "scenes": scene_views,
         "spectral_library": library_view,
-        "hidsag": hidsag_view
+        "hidsag": hidsag_view,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: pre-computed Workspace landing views",
+        "builder_version": "build_exploration_views v0.2",
     }
 
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/data-pipeline/build_hidsag_band_quality.py
+++ b/data-pipeline/build_hidsag_band_quality.py
@@ -157,6 +157,9 @@ def main() -> None:
                     ],
                 },
                 "subsets": subset_rows,
+                # Closes #444 P1 item 3.1 (builder metadata envelope).
+                "framework_axis": "F-9 HIDSAG preprocessing — bad-band quality heuristic",
+                "builder_version": "build_hidsag_band_quality v0.2",
             },
             handle,
             indent=2,

--- a/data-pipeline/build_hidsag_curated_subset.py
+++ b/data-pipeline/build_hidsag_curated_subset.py
@@ -253,6 +253,9 @@ def main() -> None:
                 "source": "Curated HIDSAG local subset",
                 "generated_at": str(date.today()),
                 "subsets": subset_rows,
+                # Closes #444 P1 item 3.1 (builder metadata envelope).
+                "framework_axis": "inventory: HIDSAG curated local subset",
+                "builder_version": "build_hidsag_curated_subset v0.2",
             },
             handle,
             indent=2,

--- a/data-pipeline/build_hidsag_region_documents.py
+++ b/data-pipeline/build_hidsag_region_documents.py
@@ -251,6 +251,9 @@ def main() -> None:
                 "patch_grid": {"rows": PATCH_GRID_ROWS, "cols": PATCH_GRID_COLS},
                 "npz_path": str(OUTPUT_NPZ_PATH),
                 "subsets": subset_summaries,
+                # Closes #444 P1 item 3.1 (builder metadata envelope).
+                "framework_axis": "documentation: HIDSAG patch-level region documents",
+                "builder_version": "build_hidsag_region_documents v0.2",
             },
             handle,
             indent=2,

--- a/data-pipeline/build_segmentation_baselines.py
+++ b/data-pipeline/build_segmentation_baselines.py
@@ -298,6 +298,9 @@ def main() -> None:
             }
         ],
         "scenes": scenes,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: SLIC segmentation baseline reference",
+        "builder_version": "build_segmentation_baselines v0.2",
     }
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:

--- a/data-pipeline/build_subset_cards.py
+++ b/data-pipeline/build_subset_cards.py
@@ -424,6 +424,9 @@ def main() -> int:
         "source": "Compact public subset cards extracted from the interactive subset registry",
         "generated_at": generated_at,
         "cards": summaries,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: subset cards for the Workspace landing tabs",
+        "builder_version": "build_subset_cards v0.2",
     }
     with (OUT_DIR / "index.json").open("w", encoding="utf-8") as handle:
         json.dump(index, handle, ensure_ascii=False, indent=2, sort_keys=False)


### PR DESCRIPTION
## Summary

Closes #444 P1 item 3.1 fully. c229 covered 6 of 13 builders;
this PR covers the other 7:

- build_corpus_previews
- build_exploration_views
- build_hidsag_band_quality
- build_hidsag_curated_subset
- build_hidsag_region_documents
- build_segmentation_baselines
- build_subset_cards

Each gains \`framework_axis\` + \`builder_version\`; all already had
\`generated_at\` except build_corpus_previews which now ships proper
ISO 8601 UTC instead of the static '2026-04-30' string.

## Verification

- python -m py_compile on all 7 files → clean
- pytest tests/ → 57 passed

Cumulative #444 P1 3.1: **13 of 13 builders now ship the envelope**.

Item 3.2 (research_core bypass) is deferred — each builder needs
individual refactoring to route through research_core.paths /
inventory / class_catalog. Open as a separate follow-on cycle.

Closes #444 P1 3.1.