### PR TITLE
Deploy cycles 260-264: smoke +24 + api split slice 1 + 7 lazy tabs + 2 extracts + 7 builders

### DIFF
--- a/data-pipeline/build_corpus_previews.py
+++ b/data-pipeline/build_corpus_previews.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 
 import json
 from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
 from statistics import median
 from typing import Any, Iterable
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -347,8 +352,11 @@ def main() -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     payload = {
         "source": "Static corpus previews generated from compact derived spectral assets",
-        "generated_at": "2026-04-30",
         "previews": previews,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: corpus-previews static landing-card content",
+        "generated_at": _now_iso(),
+        "builder_version": "build_corpus_previews v0.2",
     }
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)

--- a/data-pipeline/build_exploration_views.py
+++ b/data-pipeline/build_exploration_views.py
@@ -445,7 +445,10 @@ def main() -> int:
         "generated_at": date.today().isoformat(),
         "scenes": scene_views,
         "spectral_library": library_view,
-        "hidsag": hidsag_view
+        "hidsag": hidsag_view,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: pre-computed Workspace landing views",
+        "builder_version": "build_exploration_views v0.2",
     }
 
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/data-pipeline/build_hidsag_band_quality.py
+++ b/data-pipeline/build_hidsag_band_quality.py
@@ -157,6 +157,9 @@ def main() -> None:
                     ],
                 },
                 "subsets": subset_rows,
+                # Closes #444 P1 item 3.1 (builder metadata envelope).
+                "framework_axis": "F-9 HIDSAG preprocessing — bad-band quality heuristic",
+                "builder_version": "build_hidsag_band_quality v0.2",
             },
             handle,
             indent=2,

--- a/data-pipeline/build_hidsag_curated_subset.py
+++ b/data-pipeline/build_hidsag_curated_subset.py
@@ -253,6 +253,9 @@ def main() -> None:
                 "source": "Curated HIDSAG local subset",
                 "generated_at": str(date.today()),
                 "subsets": subset_rows,
+                # Closes #444 P1 item 3.1 (builder metadata envelope).
+                "framework_axis": "inventory: HIDSAG curated local subset",
+                "builder_version": "build_hidsag_curated_subset v0.2",
             },
             handle,
             indent=2,

--- a/data-pipeline/build_hidsag_region_documents.py
+++ b/data-pipeline/build_hidsag_region_documents.py
@@ -251,6 +251,9 @@ def main() -> None:
                 "patch_grid": {"rows": PATCH_GRID_ROWS, "cols": PATCH_GRID_COLS},
                 "npz_path": str(OUTPUT_NPZ_PATH),
                 "subsets": subset_summaries,
+                # Closes #444 P1 item 3.1 (builder metadata envelope).
+                "framework_axis": "documentation: HIDSAG patch-level region documents",
+                "builder_version": "build_hidsag_region_documents v0.2",
             },
             handle,
             indent=2,

--- a/data-pipeline/build_segmentation_baselines.py
+++ b/data-pipeline/build_segmentation_baselines.py
@@ -298,6 +298,9 @@ def main() -> None:
             }
         ],
         "scenes": scenes,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: SLIC segmentation baseline reference",
+        "builder_version": "build_segmentation_baselines v0.2",
     }
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     with OUTPUT_PATH.open("w", encoding="utf-8") as handle:

--- a/data-pipeline/build_subset_cards.py
+++ b/data-pipeline/build_subset_cards.py
@@ -424,6 +424,9 @@ def main() -> int:
         "source": "Compact public subset cards extracted from the interactive subset registry",
         "generated_at": generated_at,
         "cards": summaries,
+        # Closes #444 P1 item 3.1 (builder metadata envelope).
+        "framework_axis": "documentation: subset cards for the Workspace landing tabs",
+        "builder_version": "build_subset_cards v0.2",
     }
     with (OUT_DIR / "index.json").open("w", encoding="utf-8") as handle:
         json.dump(index, handle, ensure_ascii=False, indent=2, sort_keys=False)

--- a/frontend/src/api/_http.ts
+++ b/frontend/src/api/_http.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared HTTP primitives for the api/ subtree. Lives at `_http.ts` so
+ * the bandmask / eda / topics / hidsag per-family modules can call
+ * `request()` without circular imports through `client.ts`.
+ *
+ * Behaviour identical to the original implementation in `client.ts` —
+ * extracted as part of the c261 api-client split (#441 P1 item 2.4).
+ */
+
+const BASE = (import.meta.env.VITE_API_BASE ?? "").replace(/\/$/, "");
+
+export class ApiError extends Error {
+  status: number;
+  url: string;
+  constructor(message: string, status: number, url: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.url = url;
+  }
+}
+
+export async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${BASE}${path}`;
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new ApiError(
+      `Request failed: ${res.status} ${res.statusText}`,
+      res.status,
+      url,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export async function requestBuffer(
+  path: string,
+  init?: RequestInit,
+): Promise<ArrayBuffer> {
+  const url = `${BASE}${path}`;
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new ApiError(
+      `Request failed: ${res.status} ${res.statusText}`,
+      res.status,
+      url,
+    );
+  }
+  return await res.arrayBuffer();
+}

--- a/frontend/src/api/bandmask.ts
+++ b/frontend/src/api/bandmask.ts
@@ -1,0 +1,182 @@
+/**
+ * Band-mask family API surface. Extracted from `api/client.ts` as the
+ * first slice of #441 P1 item 2.4 ("api/client.ts 1392 LOC / 96 exports").
+ *
+ * Endpoints (c236):
+ *   - GET /api/band-masks                          → BandMaskIndex
+ *   - GET /api/band-masks/canonical-comparison     → BandMaskCanonicalComparison
+ *   - GET /api/band-masks/{scene}/{mask}           → BandMaskSummary
+ *   - GET /api/band-masks-hidsag                   → BandMaskHidsagIndex
+ *   - GET /api/band-masks-hidsag/{subset}/{mask}   → BandMaskHidsagSummary
+ *
+ * The runtime calls + their wrappers live here; `api/client.ts`
+ * re-exports for backwards compatibility so existing imports keep
+ * working without per-file churn.
+ */
+import type {
+  DominantTopicMapMeta,
+  LabelCell,
+  LdaConfig,
+  ThetaGridMeta,
+} from "./client";
+
+// ---- types ----------------------------------------------------------
+
+export type BandMaskIndexEntry = {
+  scene_id: string;
+  mask_id: string;
+  mask_label?: string;
+  topic_count?: number;
+  n_bands_full?: number;
+  n_bands_kept?: number;
+  perplexity_train?: number;
+  ari_dominant_vs_label?: number;
+  mean_confidence?: number;
+  summary_path?: string;
+  skipped?: boolean;
+  reason?: string;
+};
+
+export type BandMaskIndex = {
+  generated_at: string;
+  builder_version: string;
+  mask_definitions: Record<
+    string,
+    { label: string; description: string }
+  >;
+  entries: BandMaskIndexEntry[];
+};
+
+export type BandMaskComparisonEntry = {
+  scene_id: string;
+  mask_id: string;
+  skipped?: boolean;
+  reason?: string;
+  n_paired_pixels?: number;
+  paired_ari_dominant_topics?: number | null;
+  swap_rate_under_hungarian_alignment?: number;
+  n_topic_swaps?: number;
+  kl_p_label_given_topic_mean?: number | null;
+  kl_p_label_given_topic_max?: number | null;
+  hungarian_assignment?: Record<string, number>;
+  topic_count_canonical?: number;
+  topic_count_masked?: number;
+  n_bands_full?: number;
+  n_bands_kept?: number;
+  ari_dominant_vs_label_masked?: number;
+  perplexity_train_masked?: number;
+};
+
+export type BandMaskCanonicalComparison = {
+  generated_at: string;
+  builder_version: string;
+  description: string;
+  entries: BandMaskComparisonEntry[];
+};
+
+export type BandMaskHidsagIndexEntry = {
+  subset_code: string;
+  mask_id: string;
+  mask_label?: string;
+  topic_count?: number;
+  n_bands_full?: number;
+  n_bands_kept?: number;
+  perplexity_train?: number;
+  mean_confidence?: number;
+  summary_path?: string;
+  skipped?: boolean;
+  reason?: string;
+};
+
+export type BandMaskHidsagIndex = {
+  generated_at: string;
+  builder_version: string;
+  modality: string;
+  mask_definitions: Record<string, { label: string; description: string }>;
+  entries: BandMaskHidsagIndexEntry[];
+};
+
+export type HidsagCovariateProbability = {
+  covariate: string;
+  count: number;
+  p: number;
+};
+
+export type BandMaskHidsagSummary = {
+  subset_code: string;
+  mask_id: string;
+  mask_label: string;
+  mask_description: string;
+  modality: string;
+  topic_count: number;
+  document_count: number;
+  vocabulary_size: number;
+  n_bands_full: number;
+  n_bands_kept: number;
+  kept_band_indices: number[];
+  wavelengths_nm_kept_first_last: [number, number];
+  wavelengths_nm_kept: number[];
+  topic_prevalence: number[];
+  topic_distance_cosine: number[][];
+  top_words_per_topic_lambda_05: string[][];
+  p_covariate_given_topic_dominant: HidsagCovariateProbability[][];
+  docs_per_topic_dominant: number[];
+  perplexity_train: number;
+  mean_confidence: number;
+  doc_names: string[];
+  sample_names: string[];
+  covariates: string[];
+  theta_per_doc: number[][];
+  lda_config: LdaConfig;
+  generated_at: string;
+  builder_version: string;
+};
+
+export type BandMaskSummary = {
+  scene_id: string;
+  mask_id: string;
+  mask_label: string;
+  mask_description: string;
+  spatial_shape: [number, number];
+  topic_count: number;
+  document_count: number;
+  vocabulary_size: number;
+  n_bands_full: number;
+  n_bands_kept: number;
+  kept_band_indices: number[];
+  wavelengths_nm_kept_first_last: [number, number];
+  wavelengths_nm_kept: number[];
+  topic_prevalence: number[];
+  topic_distance_cosine: number[][];
+  top_words_per_topic_lambda_05: string[][];
+  p_label_given_topic_dominant: LabelCell[][];
+  docs_per_topic_dominant: number[];
+  perplexity_train: number;
+  ari_dominant_vs_label: number;
+  mean_confidence: number;
+  lda_config: LdaConfig;
+  dominant_topic_map: DominantTopicMapMeta;
+  theta_grid: ThetaGridMeta;
+  generated_at: string;
+  builder_version: string;
+};
+
+// ---- runtime calls --------------------------------------------------
+
+import { request } from "./_http";
+
+export const bandMaskApi = {
+  index: () => request<BandMaskIndex>(`/api/band-masks`),
+  canonicalComparison: () =>
+    request<BandMaskCanonicalComparison>(`/api/band-masks/canonical-comparison`),
+  summary: (sceneId: string, maskId: string) =>
+    request<BandMaskSummary>(
+      `/api/band-masks/${encodeURIComponent(sceneId)}/${encodeURIComponent(maskId)}`,
+    ),
+  hidsagIndex: () =>
+    request<BandMaskHidsagIndex>(`/api/band-masks-hidsag`),
+  hidsagSummary: (subsetCode: string, maskId: string) =>
+    request<BandMaskHidsagSummary>(
+      `/api/band-masks-hidsag/${encodeURIComponent(subsetCode)}/${encodeURIComponent(maskId)}`,
+    ),
+};

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,47 +8,34 @@
  * so `/api` and `/generated` are same-origin too.
  */
 
-const BASE = (import.meta.env.VITE_API_BASE ?? "").replace(/\/$/, "");
+// Shared HTTP primitives moved to `_http.ts` as part of the c261
+// api-client split (#441 P1 2.4). Re-exported for back-compat with
+// existing consumers that import `ApiError` from `@/api/client`.
+import { ApiError, request, requestBuffer } from "./_http";
+export { ApiError };
 
-export class ApiError extends Error {
-  status: number;
-  url: string;
-  constructor(message: string, status: number, url: string) {
-    super(message);
-    this.name = "ApiError";
-    this.status = status;
-    this.url = url;
-  }
-}
-
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const url = `${BASE}${path}`;
-  const res = await fetch(url, init);
-  if (!res.ok) {
-    throw new ApiError(
-      `Request failed: ${res.status} ${res.statusText}`,
-      res.status,
-      url,
-    );
-  }
-  return (await res.json()) as T;
-}
-
-async function requestBuffer(
-  path: string,
-  init?: RequestInit,
-): Promise<ArrayBuffer> {
-  const url = `${BASE}${path}`;
-  const res = await fetch(url, init);
-  if (!res.ok) {
-    throw new ApiError(
-      `Request failed: ${res.status} ${res.statusText}`,
-      res.status,
-      url,
-    );
-  }
-  return await res.arrayBuffer();
-}
+// Pull the BandMask family from its own module so we can both consume
+// the types here (the existing `api.bandMasks*` runtime methods stay
+// for back-compat) AND re-export them so `@/api/client` imports keep
+// working without per-file churn.
+import type {
+  BandMaskCanonicalComparison,
+  BandMaskHidsagIndex,
+  BandMaskHidsagSummary,
+  BandMaskIndex,
+  BandMaskSummary,
+} from "./bandmask";
+export type {
+  BandMaskCanonicalComparison,
+  BandMaskComparisonEntry,
+  BandMaskHidsagIndex,
+  BandMaskHidsagIndexEntry,
+  BandMaskHidsagSummary,
+  BandMaskIndex,
+  BandMaskIndexEntry,
+  BandMaskSummary,
+  HidsagCovariateProbability,
+} from "./bandmask";
 
 export type RawFile = {
   raw_dataset_id: string;
@@ -1056,144 +1043,6 @@ export type FelzenszwalbGroupings = {
   builder_version?: string;
 };
 
-export type BandMaskIndexEntry = {
-  scene_id: string;
-  mask_id: string;
-  mask_label?: string;
-  topic_count?: number;
-  n_bands_full?: number;
-  n_bands_kept?: number;
-  perplexity_train?: number;
-  ari_dominant_vs_label?: number;
-  mean_confidence?: number;
-  summary_path?: string;
-  skipped?: boolean;
-  reason?: string;
-};
-
-export type BandMaskIndex = {
-  generated_at: string;
-  builder_version: string;
-  mask_definitions: Record<
-    string,
-    { label: string; description: string }
-  >;
-  entries: BandMaskIndexEntry[];
-};
-
-export type BandMaskComparisonEntry = {
-  scene_id: string;
-  mask_id: string;
-  skipped?: boolean;
-  reason?: string;
-  n_paired_pixels?: number;
-  paired_ari_dominant_topics?: number | null;
-  swap_rate_under_hungarian_alignment?: number;
-  n_topic_swaps?: number;
-  kl_p_label_given_topic_mean?: number | null;
-  kl_p_label_given_topic_max?: number | null;
-  hungarian_assignment?: Record<string, number>;
-  topic_count_canonical?: number;
-  topic_count_masked?: number;
-  n_bands_full?: number;
-  n_bands_kept?: number;
-  ari_dominant_vs_label_masked?: number;
-  perplexity_train_masked?: number;
-};
-
-export type BandMaskCanonicalComparison = {
-  generated_at: string;
-  builder_version: string;
-  description: string;
-  entries: BandMaskComparisonEntry[];
-};
-
-export type BandMaskHidsagIndexEntry = {
-  subset_code: string;
-  mask_id: string;
-  mask_label?: string;
-  topic_count?: number;
-  n_bands_full?: number;
-  n_bands_kept?: number;
-  perplexity_train?: number;
-  mean_confidence?: number;
-  summary_path?: string;
-  skipped?: boolean;
-  reason?: string;
-};
-
-export type BandMaskHidsagIndex = {
-  generated_at: string;
-  builder_version: string;
-  modality: string;
-  mask_definitions: Record<string, { label: string; description: string }>;
-  entries: BandMaskHidsagIndexEntry[];
-};
-
-export type HidsagCovariateProbability = {
-  covariate: string;
-  count: number;
-  p: number;
-};
-
-export type BandMaskHidsagSummary = {
-  subset_code: string;
-  mask_id: string;
-  mask_label: string;
-  mask_description: string;
-  modality: string;
-  topic_count: number;
-  document_count: number;
-  vocabulary_size: number;
-  n_bands_full: number;
-  n_bands_kept: number;
-  kept_band_indices: number[];
-  wavelengths_nm_kept_first_last: [number, number];
-  wavelengths_nm_kept: number[];
-  topic_prevalence: number[];
-  topic_distance_cosine: number[][];
-  top_words_per_topic_lambda_05: string[][];
-  p_covariate_given_topic_dominant: HidsagCovariateProbability[][];
-  docs_per_topic_dominant: number[];
-  perplexity_train: number;
-  mean_confidence: number;
-  doc_names: string[];
-  sample_names: string[];
-  covariates: string[];
-  theta_per_doc: number[][];
-  lda_config: LdaConfig;
-  generated_at: string;
-  builder_version: string;
-};
-
-export type BandMaskSummary = {
-  scene_id: string;
-  mask_id: string;
-  mask_label: string;
-  mask_description: string;
-  spatial_shape: [number, number];
-  topic_count: number;
-  document_count: number;
-  vocabulary_size: number;
-  n_bands_full: number;
-  n_bands_kept: number;
-  kept_band_indices: number[];
-  wavelengths_nm_kept_first_last: [number, number];
-  wavelengths_nm_kept: number[];
-  topic_prevalence: number[];
-  topic_distance_cosine: number[][];
-  top_words_per_topic_lambda_05: string[][];
-  p_label_given_topic_dominant: LabelCell[][];
-  docs_per_topic_dominant: number[];
-  perplexity_train: number;
-  ari_dominant_vs_label: number;
-  mean_confidence: number;
-  lda_config: LdaConfig;
-  dominant_topic_map: DominantTopicMapMeta;
-  theta_grid: ThetaGridMeta;
-  generated_at: string;
-  builder_version: string;
-};
 
 export type WordificationsIndexItem = {
   id: string;

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -6228,6 +6228,7 @@ function Stepper({
   ctx: { family: string | null; subset: string | null; rep: string | null };
 }) {
   void state;
+  const { t } = useTranslation(["pages"]);
   const labels = STEPS;
   return (
     <ol
@@ -6273,7 +6274,7 @@ function Stepper({
             >
               {i + 1}
             </span>
-            <span>{s.label}</span>
+            <span>{t(`workspace.step.${s.key}` as never, s.label) as string}</span>
             {isDone && i === 0 && ctx.family && (
               <span
                 className="text-xs font-mono opacity-70"

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -33,7 +33,7 @@ import {
   WIKI_BASE,
 } from "./workspace/state/tabs";
 import { ExploreNav } from "./workspace/components/ExploreNav";
-import { TabEmpty } from "./workspace/components/TabStates";
+import { TabEmpty, TabLoading } from "./workspace/components/TabStates";
 import {
   RecentlyViewed,
   useTrackRecentScene,
@@ -42,11 +42,29 @@ import {
   type RoutedPrediction,
   computeRoutedPrediction,
 } from "./workspace/helpers/routedPrediction";
-import { BandMaskTab } from "./workspace/tabs/BandMaskTab";
-import { HidsagBandMaskTab } from "./workspace/tabs/HidsagBandMaskTab";
-import { ApplyToDocumentTab } from "./workspace/tabs/ApplyToDocumentTab";
-import { RecipesTab } from "./workspace/tabs/RecipesTab";
-import { QKExploreTab } from "./workspace/tabs/QKExploreTab";
+// Tabs are lazy-loaded so the Workspace entry chunk does not ship
+// their heavy dependencies (e.g. interactive plots in BandMaskTab,
+// HIDSAG covariate machinery, recipe pickers) until the user
+// actually navigates to that tab. Closes #441 P1 2.7 partial.
+const BandMaskTab = lazy(() =>
+  import("./workspace/tabs/BandMaskTab").then((m) => ({ default: m.BandMaskTab })),
+);
+const HidsagBandMaskTab = lazy(() =>
+  import("./workspace/tabs/HidsagBandMaskTab").then((m) => ({
+    default: m.HidsagBandMaskTab,
+  })),
+);
+const ApplyToDocumentTab = lazy(() =>
+  import("./workspace/tabs/ApplyToDocumentTab").then((m) => ({
+    default: m.ApplyToDocumentTab,
+  })),
+);
+const RecipesTab = lazy(() =>
+  import("./workspace/tabs/RecipesTab").then((m) => ({ default: m.RecipesTab })),
+);
+const QKExploreTab = lazy(() =>
+  import("./workspace/tabs/QKExploreTab").then((m) => ({ default: m.QKExploreTab })),
+);
 import { UnmixingStat } from "./workspace/components/StatCard";
 
 const Scatter3D = lazy(() =>
@@ -1092,12 +1110,14 @@ function ExploreStep({
             />
           )}
           {tab === "recipes" && (
-            <RecipesTab
-              sceneId={subsetId!}
-              isLoading={wordifIndex.isLoading}
-              error={wordifIndex.error as Error | null}
-              index={wordifIndex.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <RecipesTab
+                sceneId={subsetId!}
+                isLoading={wordifIndex.isLoading}
+                error={wordifIndex.error as Error | null}
+                index={wordifIndex.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "supertopics" && (
             <SuperTopicsTab
@@ -1155,27 +1175,33 @@ function ExploreStep({
             />
           )}
           {tab === "qkexplore" && (
-            <QKExploreTab
-              isLoading={ldaSweepQ.isLoading}
-              error={ldaSweepQ.error as Error | null}
-              sweep={ldaSweepQ.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <QKExploreTab
+                isLoading={ldaSweepQ.isLoading}
+                error={ldaSweepQ.error as Error | null}
+                sweep={ldaSweepQ.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "bandmask" && subsetId && isLabelled && (
-            <BandMaskTab
-              sceneId={subsetId}
-              isLoading={bandMaskIndexQ.isLoading}
-              error={bandMaskIndexQ.error as Error | null}
-              index={bandMaskIndexQ.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <BandMaskTab
+                sceneId={subsetId}
+                isLoading={bandMaskIndexQ.isLoading}
+                error={bandMaskIndexQ.error as Error | null}
+                index={bandMaskIndexQ.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "bandmask" && subsetId && isHidsag && (
-            <HidsagBandMaskTab
-              subsetCode={toHidsagSubsetCode(subsetId)}
-              isLoading={bandMaskHidsagIndexQ.isLoading}
-              error={bandMaskHidsagIndexQ.error as Error | null}
-              index={bandMaskHidsagIndexQ.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <HidsagBandMaskTab
+                subsetCode={toHidsagSubsetCode(subsetId)}
+                isLoading={bandMaskHidsagIndexQ.isLoading}
+                error={bandMaskHidsagIndexQ.error as Error | null}
+                index={bandMaskHidsagIndexQ.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "spatial" && (
             <SpatialStructureTab
@@ -1196,15 +1222,17 @@ function ExploreStep({
             />
           )}
           {tab === "applydoc" && (
-            <ApplyToDocumentTab
-              isLoading={applyDocs.isLoading || applyTopicViews.isLoading || applyTopicToData.isLoading}
-              error={(applyDocs.error as Error | null) ?? (applyTopicViews.error as Error | null) ?? (applyTopicToData.error as Error | null)}
-              docs={applyDocs.data ?? null}
-              topicViews={applyTopicViews.data ?? null}
-              topicToData={applyTopicToData.data ?? null}
-              selectedTopic={selectedTopic}
-              setSelectedTopic={setSelectedTopic}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <ApplyToDocumentTab
+                isLoading={applyDocs.isLoading || applyTopicViews.isLoading || applyTopicToData.isLoading}
+                error={(applyDocs.error as Error | null) ?? (applyTopicViews.error as Error | null) ?? (applyTopicToData.error as Error | null)}
+                docs={applyDocs.data ?? null}
+                topicViews={applyTopicViews.data ?? null}
+                topicToData={applyTopicToData.data ?? null}
+                selectedTopic={selectedTopic}
+                setSelectedTopic={setSelectedTopic}
+              />
+            </Suspense>
           )}
           {tab === "browser" && (
             <SpectralBrowserTab

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -65,6 +65,16 @@ const RecipesTab = lazy(() =>
 const QKExploreTab = lazy(() =>
   import("./workspace/tabs/QKExploreTab").then((m) => ({ default: m.QKExploreTab })),
 );
+const LlmTeaLeavesTab = lazy(() =>
+  import("./workspace/tabs/LlmTeaLeavesTab").then((m) => ({
+    default: m.LlmTeaLeavesTab,
+  })),
+);
+const LinearProbeTab = lazy(() =>
+  import("./workspace/tabs/LinearProbeTab").then((m) => ({
+    default: m.LinearProbeTab,
+  })),
+);
 import { UnmixingStat } from "./workspace/components/StatCard";
 
 const Scatter3D = lazy(() =>
@@ -1136,18 +1146,22 @@ function ExploreStep({
             />
           )}
           {tab === "llm" && (
-            <LlmTeaLeavesTab
-              isLoading={llmTeaLeaves.isLoading}
-              error={llmTeaLeaves.error as Error | null}
-              data={llmTeaLeaves.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <LlmTeaLeavesTab
+                isLoading={llmTeaLeaves.isLoading}
+                error={llmTeaLeaves.error as Error | null}
+                data={llmTeaLeaves.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "probe" && (
-            <LinearProbeTab
-              isLoading={linearProbe.isLoading}
-              error={linearProbe.error as Error | null}
-              data={linearProbe.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <LinearProbeTab
+                isLoading={linearProbe.isLoading}
+                error={linearProbe.error as Error | null}
+                data={linearProbe.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "neural" && (
             <NeuralTopicComparisonTab
@@ -8009,216 +8023,6 @@ function AnomalyMetric({
           {caption}
         </p>
       ) : null}
-    </div>
-  );
-}
-
-function LlmTeaLeavesTab({
-  isLoading,
-  error,
-  data,
-}: {
-  isLoading: boolean;
-  error: Error | null;
-  data: import("@/api/client").LlmTeaLeaves | null;
-}) {
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading LLM tea-leaves evaluation…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load LLM tea-leaves.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-  if (!data) return <TabEmpty />;
-
-  const attempted = data.per_topic.filter((t) => !t.skipped);
-  return (
-    <div className="space-y-5">
-      <div
-        className="rounded-xl border p-5 relative overflow-hidden"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <div
-          aria-hidden
-          className="absolute top-0 left-0 right-0 h-1"
-          style={{ background: "linear-gradient(90deg, rgba(240, 228, 66, 1) 0%, rgba(214, 140, 40, 1) 100%)" }}
-        />
-        <h4 className="text-base font-semibold mt-1 mb-1" style={{ color: "var(--color-fg)" }}>
-          LLM tea leaves · word-intrusion test
-        </h4>
-        <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          For each topic, top-N words by relevance λ get one intruder word inserted. An LLM
-          ({data.model}) is asked to pick the odd word out. Correct picks ⇒ topic is coherent
-          enough to make the intruder obvious. Higher accuracy ⇒ more interpretable topics.
-        </p>
-        <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
-          <UnmixingStat label="model" value={data.model} />
-          <UnmixingStat label="λ relevance" value={data.lambda_used} />
-          <UnmixingStat label="top-N per topic" value={String(data.top_n_per_topic)} />
-          <UnmixingStat
-            label="intrusion accuracy"
-            value={`${(data.intrusion_accuracy * 100).toFixed(1)}% · ${data.n_correct_intrusion}/${data.n_attempted}`}
-          />
-        </div>
-      </div>
-
-      <div
-        className="rounded-lg border p-4"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-          Per-topic intrusion results · {attempted.length} attempted of {data.topic_count}
-        </h4>
-        <div className="overflow-x-auto">
-          <table className="w-full text-[12px]" style={{ color: "var(--color-fg)" }}>
-            <thead>
-              <tr style={{ color: "var(--color-fg-faint)" }}>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">topic</th>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">top words</th>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">intruder</th>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">LLM picked</th>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">verdict</th>
-                <th className="text-left font-mono text-[11px] pb-1">LLM label</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.per_topic.map((t) => {
-                const correct = t.intrusion_correct;
-                return (
-                  <tr key={t.topic_id} style={{ borderTop: "1px solid var(--color-border)" }}>
-                    <td className="py-1 pr-3 font-mono">t{t.topic_id}</td>
-                    <td className="py-1 pr-3 font-mono text-[11px]">
-                      {t.skipped ? <span style={{ color: "var(--color-fg-faint)" }}>skipped ({t.reason})</span> : t.top_words?.slice(0, 5).join(", ")}
-                      {(t.top_words?.length ?? 0) > 5 ? <span style={{ color: "var(--color-fg-faint)" }}>, …</span> : null}
-                    </td>
-                    <td className="py-1 pr-3 font-mono">
-                      <span style={{ backgroundColor: "var(--color-accent-soft)", padding: "1px 4px", borderRadius: 3 }}>{t.intruder ?? "—"}</span>
-                    </td>
-                    <td className="py-1 pr-3 font-mono">{t.llm_chose ?? "—"}</td>
-                    <td className="py-1 pr-3 font-mono">
-                      {correct === true ? (
-                        <span style={{ color: "rgba(40,160,80,1)" }}>✓ correct</span>
-                      ) : correct === false ? (
-                        <span style={{ color: "rgba(214,39,40,1)" }}>✗ wrong</span>
-                      ) : (
-                        <span style={{ color: "var(--color-fg-faint)" }}>—</span>
-                      )}
-                    </td>
-                    <td className="py-1 truncate text-[11px]" style={{ maxWidth: 240 }} title={t.llm_label}>
-                      {t.llm_label ?? "—"}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function LinearProbeTab({
-  isLoading,
-  error,
-  data,
-}: {
-  isLoading: boolean;
-  error: Error | null;
-  data: import("@/api/client").LinearProbePanel | null;
-}) {
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading linear probe panel…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load linear probe panel.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-  if (!data) return <TabEmpty />;
-
-  const methods = Object.entries(data.method_metrics);
-  const sorted = data.ranking_by_macro_f1_mean
-    ? data.ranking_by_macro_f1_mean.map((r) => [r.method, data.method_metrics[r.method]] as const).filter(([, m]) => !!m)
-    : methods.sort((a, b) => (b[1].macro_f1.mean - a[1].macro_f1.mean));
-
-  const maxF1 = sorted[0]?.[1]?.macro_f1.mean ?? 1;
-
-  return (
-    <div className="space-y-5">
-      <div
-        className="rounded-xl border p-5 relative overflow-hidden"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <div
-          aria-hidden
-          className="absolute top-0 left-0 right-0 h-1"
-          style={{ background: "linear-gradient(90deg, rgba(56,189,248,1) 0%, rgba(40,160,80,1) 100%)" }}
-        />
-        <h4 className="text-base font-semibold mt-1 mb-1" style={{ color: "var(--color-fg)" }}>
-          Linear probe panel · {data.n_classes ?? "?"}-class macro F1
-        </h4>
-        <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          Trains a linear classifier on each method's latent (K = {data.K ?? "?"}) and reports
-          macro-F1, accuracy, and balanced accuracy with 95% CI. Linear probing isolates the
-          representation's separability — a strong probe means the latent already arranges classes
-          in linear half-spaces.
-        </p>
-      </div>
-
-      <div
-        className="rounded-lg border p-4"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-          Method ranking · macro F1
-        </h4>
-        <div className="overflow-x-auto">
-          <table className="w-full text-[12.5px]" style={{ color: "var(--color-fg)" }}>
-            <thead>
-              <tr style={{ color: "var(--color-fg-faint)" }}>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">rank</th>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">method</th>
-                <th className="text-right font-mono text-[11px] pb-1 pr-3">macro F1</th>
-                <th className="text-right font-mono text-[11px] pb-1 pr-3">accuracy</th>
-                <th className="text-right font-mono text-[11px] pb-1 pr-3">balanced acc</th>
-                <th className="text-left font-mono text-[11px] pb-1">bar</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map(([m, mm], i) => {
-                if (!mm) return null;
-                const f1 = mm.macro_f1;
-                const norm = f1.mean / Math.max(1e-9, maxF1);
-                return (
-                  <tr key={m} style={{ borderTop: "1px solid var(--color-border)" }}>
-                    <td className="py-1 pr-3 font-mono">{i + 1}</td>
-                    <td className="py-1 pr-3 font-mono">{m}</td>
-                    <td className="py-1 pr-3 text-right font-mono">
-                      {f1.mean.toFixed(3)}
-                      {f1.ci95 ? <span className="opacity-70 ml-1 text-[10.5px]">[{f1.ci95[0].toFixed(3)}, {f1.ci95[1].toFixed(3)}]</span> : null}
-                    </td>
-                    <td className="py-1 pr-3 text-right font-mono">
-                      {mm.accuracy.mean.toFixed(3)}
-                    </td>
-                    <td className="py-1 pr-3 text-right font-mono">
-                      {mm.balanced_accuracy ? mm.balanced_accuracy.mean.toFixed(3) : "—"}
-                    </td>
-                    <td className="py-1 w-[180px]">
-                      <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                        <div className="h-2 rounded" style={{ width: `${norm * 100}%`, backgroundColor: "var(--color-accent)" }} />
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
     </div>
   );
 }

--- a/frontend/src/pages/workspace/tabs/BandMaskTab.tsx
+++ b/frontend/src/pages/workspace/tabs/BandMaskTab.tsx
@@ -237,7 +237,8 @@ export function BandMaskTab({
           summary={summaryQ.data}
           comparison={
             comparisonQ.data?.entries.find(
-              (e) => e.scene_id === sceneId && e.mask_id === maskId,
+              (e: BandMaskComparisonEntry) =>
+                e.scene_id === sceneId && e.mask_id === maskId,
             ) ?? null
           }
         />

--- a/frontend/src/pages/workspace/tabs/LinearProbeTab.tsx
+++ b/frontend/src/pages/workspace/tabs/LinearProbeTab.tsx
@@ -1,0 +1,188 @@
+/**
+ * Linear probe panel tab (extracted from Workspace.tsx in c263 as part
+ * of #441 P1 2.1).
+ *
+ * Renders the method-by-method linear-probe ranking with macro F1 +
+ * accuracy + balanced accuracy + a side-by-side bar chart. Source data:
+ * `/api/linear-probe-panel/{scene}`.
+ */
+import type { LinearProbePanel } from "@/api/client";
+
+import { TabEmpty } from "../components/TabStates";
+
+export function LinearProbeTab({
+  isLoading,
+  error,
+  data,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  data: LinearProbePanel | null;
+}) {
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        Loading linear probe panel…
+      </p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load linear probe panel.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+  if (!data) return <TabEmpty />;
+
+  const methods = Object.entries(data.method_metrics);
+  const sorted = data.ranking_by_macro_f1_mean
+    ? data.ranking_by_macro_f1_mean
+        .map((r) => [r.method, data.method_metrics[r.method]] as const)
+        .filter(([, m]) => !!m)
+    : methods.sort(
+        (a, b) => b[1].macro_f1.mean - a[1].macro_f1.mean,
+      );
+
+  const maxF1 = sorted[0]?.[1]?.macro_f1.mean ?? 1;
+
+  return (
+    <div className="space-y-5">
+      <div
+        className="rounded-xl border p-5 relative overflow-hidden"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <div
+          aria-hidden
+          className="absolute top-0 left-0 right-0 h-1"
+          style={{
+            background:
+              "linear-gradient(90deg, rgba(56,189,248,1) 0%, rgba(40,160,80,1) 100%)",
+          }}
+        />
+        <h4
+          className="text-base font-semibold mt-1 mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Linear probe panel · {data.n_classes ?? "?"}-class macro F1
+        </h4>
+        <p
+          className="text-[12px] mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          Trains a linear classifier on each method&apos;s latent (K ={" "}
+          {data.K ?? "?"}) and reports macro-F1, accuracy, and balanced
+          accuracy with 95% CI. Linear probing isolates the
+          representation&apos;s separability — a strong probe means the latent
+          already arranges classes in linear half-spaces.
+        </p>
+      </div>
+
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <h4
+          className="text-base font-semibold mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Method ranking · macro F1
+        </h4>
+        <div className="overflow-x-auto">
+          <table
+            className="w-full text-[12.5px]"
+            style={{ color: "var(--color-fg)" }}
+          >
+            <thead>
+              <tr style={{ color: "var(--color-fg-faint)" }}>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  rank
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  method
+                </th>
+                <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                  macro F1
+                </th>
+                <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                  accuracy
+                </th>
+                <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                  balanced acc
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1">bar</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map(([m, mm], i) => {
+                if (!mm) return null;
+                const f1 = mm.macro_f1;
+                const norm = f1.mean / Math.max(1e-9, maxF1);
+                return (
+                  <tr
+                    key={m}
+                    style={{ borderTop: "1px solid var(--color-border)" }}
+                  >
+                    <td className="py-1 pr-3 font-mono">{i + 1}</td>
+                    <td className="py-1 pr-3 font-mono">{m}</td>
+                    <td className="py-1 pr-3 text-right font-mono">
+                      {f1.mean.toFixed(3)}
+                      {f1.ci95 ? (
+                        <span className="opacity-70 ml-1 text-[10.5px]">
+                          [{f1.ci95[0].toFixed(3)}, {f1.ci95[1].toFixed(3)}]
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="py-1 pr-3 text-right font-mono">
+                      {mm.accuracy.mean.toFixed(3)}
+                    </td>
+                    <td className="py-1 pr-3 text-right font-mono">
+                      {mm.balanced_accuracy
+                        ? mm.balanced_accuracy.mean.toFixed(3)
+                        : "—"}
+                    </td>
+                    <td className="py-1 w-[180px]">
+                      <div
+                        className="w-full h-2 rounded"
+                        style={{ backgroundColor: "var(--color-border)" }}
+                      >
+                        <div
+                          className="h-2 rounded"
+                          style={{
+                            width: `${norm * 100}%`,
+                            backgroundColor: "var(--color-accent)",
+                          }}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/workspace/tabs/LlmTeaLeavesTab.tsx
+++ b/frontend/src/pages/workspace/tabs/LlmTeaLeavesTab.tsx
@@ -1,0 +1,213 @@
+/**
+ * LLM tea-leaves word-intrusion tab (extracted from Workspace.tsx
+ * in c263 as part of #441 P1 2.1).
+ *
+ * Renders the per-topic word-intrusion test result from
+ * `/api/llm-tea-leaves/{scene}` — headline accuracy + per-topic table
+ * with intruder / LLM-picked / verdict / LLM label.
+ *
+ * No behavioural change versus the inline version; cut and paste +
+ * external imports converted.
+ */
+import type { LlmTeaLeaves } from "@/api/client";
+
+import { TabEmpty } from "../components/TabStates";
+import { UnmixingStat } from "../components/StatCard";
+
+export function LlmTeaLeavesTab({
+  isLoading,
+  error,
+  data,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  data: LlmTeaLeaves | null;
+}) {
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        Loading LLM tea-leaves evaluation…
+      </p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load LLM tea-leaves.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+  if (!data) return <TabEmpty />;
+
+  const attempted = data.per_topic.filter((t) => !t.skipped);
+  return (
+    <div className="space-y-5">
+      <div
+        className="rounded-xl border p-5 relative overflow-hidden"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <div
+          aria-hidden
+          className="absolute top-0 left-0 right-0 h-1"
+          style={{
+            background:
+              "linear-gradient(90deg, rgba(240, 228, 66, 1) 0%, rgba(214, 140, 40, 1) 100%)",
+          }}
+        />
+        <h4
+          className="text-base font-semibold mt-1 mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          LLM tea leaves · word-intrusion test
+        </h4>
+        <p
+          className="text-[12px] mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          For each topic, top-N words by relevance λ get one intruder word
+          inserted. An LLM ({data.model}) is asked to pick the odd word out.
+          Correct picks ⇒ topic is coherent enough to make the intruder
+          obvious. Higher accuracy ⇒ more interpretable topics.
+        </p>
+        <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
+          <UnmixingStat label="model" value={data.model} />
+          <UnmixingStat label="λ relevance" value={data.lambda_used} />
+          <UnmixingStat
+            label="top-N per topic"
+            value={String(data.top_n_per_topic)}
+          />
+          <UnmixingStat
+            label="intrusion accuracy"
+            value={`${(data.intrusion_accuracy * 100).toFixed(1)}% · ${data.n_correct_intrusion}/${data.n_attempted}`}
+          />
+        </div>
+      </div>
+
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <h4
+          className="text-base font-semibold mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Per-topic intrusion results · {attempted.length} attempted of{" "}
+          {data.topic_count}
+        </h4>
+        <div className="overflow-x-auto">
+          <table
+            className="w-full text-[12px]"
+            style={{ color: "var(--color-fg)" }}
+          >
+            <thead>
+              <tr style={{ color: "var(--color-fg-faint)" }}>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  topic
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  top words
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  intruder
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  LLM picked
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  verdict
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1">
+                  LLM label
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.per_topic.map((t) => {
+                const correct = t.intrusion_correct;
+                return (
+                  <tr
+                    key={t.topic_id}
+                    style={{ borderTop: "1px solid var(--color-border)" }}
+                  >
+                    <td className="py-1 pr-3 font-mono">t{t.topic_id}</td>
+                    <td className="py-1 pr-3 font-mono text-[11px]">
+                      {t.skipped ? (
+                        <span style={{ color: "var(--color-fg-faint)" }}>
+                          skipped ({t.reason})
+                        </span>
+                      ) : (
+                        t.top_words?.slice(0, 5).join(", ")
+                      )}
+                      {(t.top_words?.length ?? 0) > 5 ? (
+                        <span style={{ color: "var(--color-fg-faint)" }}>
+                          , …
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="py-1 pr-3 font-mono">
+                      <span
+                        style={{
+                          backgroundColor: "var(--color-accent-soft)",
+                          padding: "1px 4px",
+                          borderRadius: 3,
+                        }}
+                      >
+                        {t.intruder ?? "—"}
+                      </span>
+                    </td>
+                    <td className="py-1 pr-3 font-mono">
+                      {t.llm_chose ?? "—"}
+                    </td>
+                    <td className="py-1 pr-3 font-mono">
+                      {correct === true ? (
+                        <span style={{ color: "rgba(40,160,80,1)" }}>
+                          ✓ correct
+                        </span>
+                      ) : correct === false ? (
+                        <span style={{ color: "rgba(214,39,40,1)" }}>
+                          ✗ wrong
+                        </span>
+                      ) : (
+                        <span style={{ color: "var(--color-fg-faint)" }}>
+                          —
+                        </span>
+                      )}
+                    </td>
+                    <td
+                      className="py-1 truncate text-[11px]"
+                      style={{ maxWidth: 240 }}
+                      title={t.llm_label}
+                    >
+                      {t.llm_label ?? "—"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -11,7 +11,9 @@
 
 [CmdletBinding()]
 param(
-    [string]$BaseUrl = "http://127.0.0.1:8105"
+    # BaseUrl precedence: -BaseUrl param > $env:SMOKE_BASE_URL > localhost default
+    # (closes #444 item 4.3).
+    [string]$BaseUrl = $(if ($env:SMOKE_BASE_URL) { $env:SMOKE_BASE_URL } else { "http://127.0.0.1:8105" })
 )
 
 $ErrorActionPreference = "Stop"
@@ -98,6 +100,20 @@ $paths = @(
     "/api/mutual-information/hidsag/MINERAL1",
     "/api/rate-distortion-curve/indian-pines-corrected",
     "/api/topic-routed-classifier/indian-pines-corrected",
+    "/api/topic-routed-deep-gate/indian-pines-corrected",
+    "/api/optuna-search/indian-pines-corrected",
+    "/api/hidsag-subset-inventory",
+    "/api/hidsag-curated-subset",
+    "/api/hidsag-cross-preprocessing-stability/MINERAL1",
+    "/api/groupings/slic_2000/indian-pines-corrected",
+    "/api/groupings/patch_15/indian-pines-corrected",
+    "/api/representations/cae_1d_8/indian-pines-corrected",
+    "/api/representations/nmf_8/indian-pines-corrected",
+    "/api/topic-views/salinas-corrected",
+    "/api/topic-views/kennedy-space-center",
+    "/api/topic-views/botswana",
+    "/api/spatial/salinas-a-corrected",
+    "/api/spatial/pavia-university",
     "/api/embedded-baseline/indian-pines-corrected",
     "/api/topic-stability/indian-pines-corrected",
     "/api/deep-seed-stability/indian-pines-corrected",

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${1:-http://127.0.0.1:8105}"
+# BASE_URL precedence: positional arg > SMOKE_BASE_URL env var > localhost default.
+# Env var support added for CI / containerised callers (closes #444 item 4.3).
+BASE_URL="${1:-${SMOKE_BASE_URL:-http://127.0.0.1:8105}}"
 BASE_URL="${BASE_URL%/}"
 
 paths=(
@@ -86,6 +88,20 @@ paths=(
   "/api/mutual-information/hidsag/MINERAL1"
   "/api/rate-distortion-curve/indian-pines-corrected"
   "/api/topic-routed-classifier/indian-pines-corrected"
+  "/api/topic-routed-deep-gate/indian-pines-corrected"
+  "/api/optuna-search/indian-pines-corrected"
+  "/api/hidsag-subset-inventory"
+  "/api/hidsag-curated-subset"
+  "/api/hidsag-cross-preprocessing-stability/MINERAL1"
+  "/api/groupings/slic_2000/indian-pines-corrected"
+  "/api/groupings/patch_15/indian-pines-corrected"
+  "/api/representations/cae_1d_8/indian-pines-corrected"
+  "/api/representations/nmf_8/indian-pines-corrected"
+  "/api/topic-views/salinas-corrected"
+  "/api/topic-views/kennedy-space-center"
+  "/api/topic-views/botswana"
+  "/api/spatial/salinas-a-corrected"
+  "/api/spatial/pavia-university"
   "/api/embedded-baseline/indian-pines-corrected"
   "/api/topic-stability/indian-pines-corrected"
   "/api/deep-seed-stability/indian-pines-corrected"


### PR DESCRIPTION
## Summary

Five code-side cycles since c254-257 deploy (PR #477):

- **c260** PR #478 — Smoke 109 → **133** endpoints (+24); SMOKE_BASE_URL
  env-var fallback in smoke.{sh,ps1}; Workspace.tsx Spanish leak fix
  ('Familia'/'Conjunto' → t('workspace.step.family/subset')).
- **c261** PR #479 — Start the 1392-line api/client.ts split.
  Extracted BandMask family (9 types + new bandMaskApi) to
  api/bandmask.ts (165 LOC) + shared HTTP primitives to api/_http.ts
  (53 LOC). client.ts: 1392 → 1241 LOC. Type re-exports keep all
  existing imports working.
- **c262** PR #480 — Convert 5 extracted tabs (Recipes, QKExplore,
  BandMask, HidsagBandMask, ApplyToDocument) to React.lazy +
  Suspense. Workspace entry chunk **311 → 265 KB (-46 KB)**.
  49 KB of code now deferred across 5 tab chunks.
- **c263** PR #481 — Extract LlmTeaLeavesTab + LinearProbeTab from
  Workspace.tsx (210 lines moved). Workspace entry chunk **265 → 258
  KB**. Cumulative since c262: 311 → 258 KB (-17%).
- **c264** PR #482 — Builder metadata envelope on the remaining 7
  builders (corpus_previews, exploration_views, hidsag_band_quality,
  hidsag_curated_subset, hidsag_region_documents,
  segmentation_baselines, subset_cards). **Closes #444 P1 3.1 fully**
  (13 of 13 builders now ship the envelope).

## #441 / #444 status after this deploy

- #441 P1 2.3 Spanish leaks → ✅ c260
- #441 P1 2.4 api/client.ts → 🟡 c261 (slice 1/N — BandMask done)
- #441 P1 2.7 Lazy loading → 🟡 c262 (5 tabs done — 23 still inline)
- #441 P1 2.1 Workspace.tsx → 🟡 c263 (7 tabs total extracted — 21
  still inline)
- #444 P1 3.1 Builder metadata → ✅ c229 + c264 (13/13)
- #444 P1 4.1 Smoke gaps → ✅ c260
- #444 P1 4.2 Scene-locked smoke → 🟡 c260 (partial)
- #444 P1 4.3 BASE_URL env → ✅ c260

## Test plan

- [x] Each task PR's local checks (smoke / pytest / pnpm test) passed.
- [ ] update.sh on Hetzner.
- [ ] Smoke 133/133 on https://lda-hsi.fasl-work.com.
- [ ] OpenAPI ≥ 178 schemas (unchanged from c254 — no new routes).