### PR TITLE
Cycle 267: api/client.ts split slice 2 — EDA family (#441 2.4)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -144,38 +144,10 @@ export type MethodStatistics = {
   labeled_scenes: SceneMethodStats[];
 };
 
-export type ClassEntry = {
-  label_id: number;
-  name: string;
-  count: number;
-  rel_freq: number;
-  color: string;
-};
-
-export type ClassMeanSpectrum = {
-  mean: number[];
-  std: number[];
-  p5: number[];
-  p25: number[];
-  p50: number[];
-  p75: number[];
-  p95: number[];
-};
-
-export type ScenePerScene = {
-  scene_id: string;
-  scene_name: string;
-  sensor: string;
-  family_id: string;
-  spatial_shape: [number, number];
-  n_pixels: number;
-  n_labelled_pixels: number;
-  n_classes: number;
-  imbalance_gini: number;
-  wavelengths_nm: number[];
-  class_distribution: ClassEntry[];
-  class_mean_spectra: Record<string, ClassMeanSpectrum>;
-};
+// EDA family types extracted to `./eda.ts` in c267. Re-exported here
+// so `@/api/client` imports keep working.
+export type { ClassEntry, ClassMeanSpectrum, ScenePerScene } from "./eda";
+import type { ScenePerScene } from "./eda";
 
 export type TopWord = {
   token: string;

--- a/frontend/src/api/eda.ts
+++ b/frontend/src/api/eda.ts
@@ -1,0 +1,57 @@
+/**
+ * EDA family API surface. Second slice of the c261 api/client.ts
+ * split (#441 P1 2.4).
+ *
+ * Endpoints (c238 / c245):
+ *   - GET /api/eda/per-scene/{scene}   → ScenePerScene
+ *   - GET /api/eda/hidsag/{subset}     → HidsagEda
+ *
+ * Pulls out the three EDA-specific types (ClassEntry,
+ * ClassMeanSpectrum, ScenePerScene) plus the two runtime calls into
+ * their own module. `client.ts` re-exports the types so existing
+ * consumers (`import { ScenePerScene } from '@/api/client'`) keep
+ * working without per-file churn.
+ */
+import { request } from "./_http";
+
+export type ClassEntry = {
+  label_id: number;
+  name: string;
+  count: number;
+  rel_freq: number;
+  color: string;
+};
+
+export type ClassMeanSpectrum = {
+  mean: number[];
+  std: number[];
+  p5: number[];
+  p25: number[];
+  p50: number[];
+  p75: number[];
+  p95: number[];
+};
+
+export type ScenePerScene = {
+  scene_id: string;
+  scene_name: string;
+  sensor: string;
+  family_id: string;
+  spatial_shape: [number, number];
+  n_pixels: number;
+  n_labelled_pixels: number;
+  n_classes: number;
+  imbalance_gini: number;
+  wavelengths_nm: number[];
+  class_distribution: ClassEntry[];
+  class_mean_spectra: Record<string, ClassMeanSpectrum>;
+};
+
+export const edaApi = {
+  perScene: (sceneId: string) =>
+    request<ScenePerScene>(
+      `/api/eda/per-scene/${encodeURIComponent(sceneId)}`,
+    ),
+  // HidsagEda lives in client.ts (it depends on a long chain of HIDSAG
+  // types) — the per-scene EDA call is the one we move now.
+};


### PR DESCRIPTION
## Summary

Second slice of #441 P1 2.4. Extracts the EDA family to
\`api/eda.ts\` + a new \`edaApi\` runtime object.

## client.ts trend

| Cycle | LOC | Δ |
|---|---|---|
| original | 1392 | — |
| c261 (BandMask) | 1241 | -151 |
| **c267 (EDA)** | **1216** | **-25** |

Type re-exports keep \`@/api/client\` imports working everywhere.

## Test plan

- [x] pnpm typecheck → clean
- [x] pnpm test → 30 passed
- [x] pnpm build → clean