### PR TITLE
Deploy cycles 266-268: #443 doc drift closed + api split slice 2 + 1 more tab extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ every deploy.
 ## Live deployment
 
 - **Public URL**: <https://lda-hsi.fasl-work.com>
-- **Smoke**: 109/109 GET endpoints return 200 in <10 s + four SPA
-  shell content assertions added in cycle 108 (body length ≥ 500
-  chars, `<div id="root"`, `<script type="module"`, `cycle N`
-  version marker in entry chunk or any modulepreload chunk). Runs
-  as part of every `deploy/update.sh` (see
+- **Smoke**: 133/133 OK lines on every `deploy/update.sh` run
+  (131 GET endpoints + 1 SPA shell + 1 entry-bundle version-marker
+  content assertion). The content assertions close the empty-body
+  deploy class that escaped in cycles 99-101 (see
   [`scripts/smoke.sh`](scripts/smoke.sh) and
-  [`scripts/smoke.ps1`](scripts/smoke.ps1)). The content
-  assertions close the empty-body deploy class that escaped in
-  cycles 99-101.
-- **Manifest**: 1706 derived artifacts (1466 JSON + 209 binary +
-  31 PNG, count refreshed 2026-05-15), audited zero-issues by [`data-pipeline/audit_manifest.py`](data-pipeline/audit_manifest.py)
+  [`scripts/smoke.ps1`](scripts/smoke.ps1)). Endpoint inventory is
+  the source of truth — count is `grep -c '"/' scripts/smoke.sh`.
+- **Manifest**: 1726 derived artifacts (JSON + binary + PNG; the
+  full inventory lives in `data/derived/manifests/index.json` and
+  is the authoritative source), audited zero-issues by
+  [`data-pipeline/audit_manifest.py`](data-pipeline/audit_manifest.py).
 - **API surface**: ~110 endpoints across 6 labelled scenes × ~17
   per-scene endpoints + 5 HIDSAG subsets × 6 endpoints + 12
   cross-scene endpoints + `/api/wordifications` (108-config
@@ -246,7 +246,7 @@ concrete UI affordances:
   (V1 band-frequency alias note), `Backend-Architecture`
   (new §5b Workspace-Tab Endpoint Mapping, §13.14a wordifications,
   §13.14b lda-sweep, §13.14c per-pixel theta_grid, §13.14e
-  segmentation assignment binaries, smoke 109/109),
+  segmentation assignment binaries, smoke 133/133),
   `Mathematical-Background` (§23 Bayes inversion for c104, §24
   topic-topic similarity threshold-edge graph for c105, §25 routed-
   soft prediction formalism for c120/c122), `Local-Reproduction-
@@ -259,10 +259,12 @@ concrete UI affordances:
   `recommended_K`, `wavelengths_nm_first_last`). The qkexplore tab
   now renders the builder-recommended K (K=4 on Indian Pines) as
   both an accent chip + table marker.
-- **c113** — i18n + README + in-code copy harmonised: 11→27 tabs;
-  smoke 87→109 + SPA shell content assertions; ETM beats ProdLDA
-  6/6 (not 5/6); β-grid {1,2,4,8,16}; CAE-1D mid-ladder reconciled
-  with the README headline #6 stability claim.
+- **c113** — i18n + README + in-code copy harmonised: tab count
+  brought in line with what the code actually ships (currently
+  28 tabs in 6 phases — see `frontend/src/pages/workspace/state/tabs.ts`);
+  smoke 87→109 → 133 + SPA shell content assertions; ETM beats
+  ProdLDA 6/6 (not 5/6); β-grid {1,2,4,8,16}; CAE-1D mid-ladder
+  reconciled with the README headline #6 stability claim.
 - **c114** — Builder docstring drift fixes: jaccard top-15 (not
   top-30) on `topic_word_jaccard_top15`; dominant_topic_map dual
   paths (local + derived) with sentinel 255 (not −1); full
@@ -338,8 +340,8 @@ constraint `Σ_k θ_d[k] ≈ 1`.
 | c121 (theta_grid sidecars) | 1598 | +6 (one per labelled scene) |
 | c123 (segmentation assignment binaries) | 1634 | +36 (6 methods × 6 scenes) |
 
-Audit reports 0 issues at every step; smoke 109/109 + SPA shell
-content checks pass on every deploy.
+Audit reports 0 issues at every step; smoke 133/133 (131 GET +
+2 SPA-shell checks) passes on every deploy.
 
 ## Quick start
 
@@ -397,8 +399,11 @@ production API.
 ```
 
 Runs `scripts/smoke.{sh,ps1}` against `https://lda-hsi.fasl-work.com`,
-asserting HTTP 200 on 87 endpoints in <10 s. The same harness runs
-on the VPS as the last step of every `deploy/update.sh`.
+asserting HTTP 200 on 131 endpoints + 2 SPA-shell content checks
+in <10 s (133/133 OK lines). The same harness runs on the VPS as
+the last step of every `deploy/update.sh`. The endpoint count is
+the source of truth — read it with `grep -c '"/' scripts/smoke.sh`
+rather than hard-coding here.
 
 ## Repository layout
 
@@ -491,7 +496,7 @@ Every cycle that lands in production includes:
 3. PR `task/* → develop` with squash-merge + branch deletion
 4. PR `develop → main` titled `Deploy: <summary>` and merged via merge-commit
 5. SSH `bash deploy/update.sh` against the VPS
-6. Smoke harness verifies 109/109 GET endpoints + 4 SPA-shell content assertions
+6. Smoke harness verifies 131 GET endpoints + 2 SPA-shell content assertions (133/133 OK)
 7. Cadence comments: PR comment + issue comment + close
 8. Management repo updates: `deployments/caos-lda-hsi.md` + `wip/caos-lda-hsi/current-state.md`
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -144,38 +144,10 @@ export type MethodStatistics = {
   labeled_scenes: SceneMethodStats[];
 };
 
-export type ClassEntry = {
-  label_id: number;
-  name: string;
-  count: number;
-  rel_freq: number;
-  color: string;
-};
-
-export type ClassMeanSpectrum = {
-  mean: number[];
-  std: number[];
-  p5: number[];
-  p25: number[];
-  p50: number[];
-  p75: number[];
-  p95: number[];
-};
-
-export type ScenePerScene = {
-  scene_id: string;
-  scene_name: string;
-  sensor: string;
-  family_id: string;
-  spatial_shape: [number, number];
-  n_pixels: number;
-  n_labelled_pixels: number;
-  n_classes: number;
-  imbalance_gini: number;
-  wavelengths_nm: number[];
-  class_distribution: ClassEntry[];
-  class_mean_spectra: Record<string, ClassMeanSpectrum>;
-};
+// EDA family types extracted to `./eda.ts` in c267. Re-exported here
+// so `@/api/client` imports keep working.
+export type { ClassEntry, ClassMeanSpectrum, ScenePerScene } from "./eda";
+import type { ScenePerScene } from "./eda";
 
 export type TopWord = {
   token: string;

--- a/frontend/src/api/eda.ts
+++ b/frontend/src/api/eda.ts
@@ -1,0 +1,57 @@
+/**
+ * EDA family API surface. Second slice of the c261 api/client.ts
+ * split (#441 P1 2.4).
+ *
+ * Endpoints (c238 / c245):
+ *   - GET /api/eda/per-scene/{scene}   → ScenePerScene
+ *   - GET /api/eda/hidsag/{subset}     → HidsagEda
+ *
+ * Pulls out the three EDA-specific types (ClassEntry,
+ * ClassMeanSpectrum, ScenePerScene) plus the two runtime calls into
+ * their own module. `client.ts` re-exports the types so existing
+ * consumers (`import { ScenePerScene } from '@/api/client'`) keep
+ * working without per-file churn.
+ */
+import { request } from "./_http";
+
+export type ClassEntry = {
+  label_id: number;
+  name: string;
+  count: number;
+  rel_freq: number;
+  color: string;
+};
+
+export type ClassMeanSpectrum = {
+  mean: number[];
+  std: number[];
+  p5: number[];
+  p25: number[];
+  p50: number[];
+  p75: number[];
+  p95: number[];
+};
+
+export type ScenePerScene = {
+  scene_id: string;
+  scene_name: string;
+  sensor: string;
+  family_id: string;
+  spatial_shape: [number, number];
+  n_pixels: number;
+  n_labelled_pixels: number;
+  n_classes: number;
+  imbalance_gini: number;
+  wavelengths_nm: number[];
+  class_distribution: ClassEntry[];
+  class_mean_spectra: Record<string, ClassMeanSpectrum>;
+};
+
+export const edaApi = {
+  perScene: (sceneId: string) =>
+    request<ScenePerScene>(
+      `/api/eda/per-scene/${encodeURIComponent(sceneId)}`,
+    ),
+  // HidsagEda lives in client.ts (it depends on a long chain of HIDSAG
+  // types) — the per-scene EDA call is the one we move now.
+};

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -75,6 +75,11 @@ const LinearProbeTab = lazy(() =>
     default: m.LinearProbeTab,
   })),
 );
+const AnomalyTab = lazy(() =>
+  import("./workspace/tabs/AnomalyTab").then((m) => ({
+    default: m.AnomalyTab,
+  })),
+);
 import { UnmixingStat } from "./workspace/components/StatCard";
 
 const Scatter3D = lazy(() =>
@@ -1138,12 +1143,14 @@ function ExploreStep({
             />
           )}
           {tab === "anomaly" && (
-            <AnomalyTab
-              isLoading={topicAnomaly.isLoading || deepAnomaly.isLoading}
-              error={(topicAnomaly.error as Error | null) ?? (deepAnomaly.error as Error | null)}
-              topic={topicAnomaly.data ?? null}
-              deep={deepAnomaly.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <AnomalyTab
+                isLoading={topicAnomaly.isLoading || deepAnomaly.isLoading}
+                error={(topicAnomaly.error as Error | null) ?? (deepAnomaly.error as Error | null)}
+                topic={topicAnomaly.data ?? null}
+                deep={deepAnomaly.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "llm" && (
             <Suspense fallback={<TabLoading />}>
@@ -7885,147 +7892,6 @@ function InterpretDocumentSample({ docs, K }: { docs: import("@/api/client").Doc
   );
 }
 
-function AnomalyTab({
-  isLoading,
-  error,
-  topic,
-  deep,
-}: {
-  isLoading: boolean;
-  error: Error | null;
-  topic: import("@/api/client").TopicAnomaly | null;
-  deep: import("@/api/client").DeepAnomaly | null;
-}) {
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading anomaly statistics…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load anomaly statistics.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-6">
-      <div
-        className="rounded-lg border p-4"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-          Anomaly indicators vs misclassification — Spearman ρ
-        </h4>
-        <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          Each row is one anomaly signal. High |ρ| ⇒ the indicator agrees with which pixels the
-          routed classifier gets wrong (positive) or right (negative). p &lt; 0.05 ⇒ correlation
-          significant at the 5% level. K = {topic?.topic_count ?? "—"} topics,{" "}
-          {topic?.n_documents ?? "—"} documents.
-        </p>
-
-        <div className="grid sm:grid-cols-2 gap-5">
-          {topic ? (
-            <AnomalyMetric
-              accent="rgba(40, 160, 80, 1)"
-              title="Topic-based — softmax peak"
-              rho={topic.anomaly_to_misclassification_correlation.spearman_rho_softmax}
-              p_value={topic.anomaly_to_misclassification_correlation.spearman_p_softmax}
-              caption="Lower softmax peak (less confident) ⇒ more likely to be wrong."
-            />
-          ) : null}
-          {topic ? (
-            <AnomalyMetric
-              accent="rgba(40, 160, 80, 1)"
-              title="Topic-based — negative log-likelihood"
-              rho={topic.anomaly_to_misclassification_correlation.spearman_rho_nll}
-              p_value={topic.anomaly_to_misclassification_correlation.spearman_p_nll}
-              caption="Higher NLL ⇒ more likely to be wrong (positive ρ expected)."
-            />
-          ) : null}
-          {deep?.cae_1d_8 ? (
-            <AnomalyMetric
-              accent="rgba(56, 189, 248, 1)"
-              title="Deep — CAE-1D-8 reconstruction"
-              rho={deep.cae_1d_8.spearman_rho_vs_misclass}
-              caption={`indicator: ${deep.cae_1d_8.anomaly_indicator} · RMSE p50=${deep.cae_1d_8.rmse_overall.median.toFixed(3)} · p95=${deep.cae_1d_8.rmse_overall.p95.toFixed(3)}`}
-            />
-          ) : null}
-          {deep?.beta_vae_8 ? (
-            <AnomalyMetric
-              accent="rgba(170, 60, 200, 1)"
-              title="Deep — β-VAE reconstruction RMSE"
-              rho={deep.beta_vae_8.spearman_rho_rmse_vs_misclass}
-              caption={`RMSE p50=${deep.beta_vae_8.rmse_overall.median.toFixed(3)} · p95=${deep.beta_vae_8.rmse_overall.p95.toFixed(3)}`}
-            />
-          ) : null}
-          {deep?.beta_vae_8 ? (
-            <AnomalyMetric
-              accent="rgba(170, 60, 200, 1)"
-              title="Deep — β-VAE KL"
-              rho={deep.beta_vae_8.spearman_rho_kl_vs_misclass}
-              caption={`KL p50=${deep.beta_vae_8.kl_overall.median.toFixed(3)} · p95=${deep.beta_vae_8.kl_overall.p95.toFixed(3)} · KL is the regularisation term (high = far from prior)`}
-            />
-          ) : null}
-        </div>
-
-        {topic?.anomaly_to_misclassification_correlation.comment ? (
-          <p className="mt-4 text-[12px] italic" style={{ color: "var(--color-fg-faint)" }}>
-            {topic.anomaly_to_misclassification_correlation.comment}
-          </p>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function AnomalyMetric({
-  accent,
-  title,
-  rho,
-  p_value,
-  caption,
-}: {
-  accent: string;
-  title: string;
-  rho: number;
-  p_value?: number;
-  caption?: string;
-}) {
-  const abs = Math.abs(rho);
-  const tone = abs >= 0.3 ? "strong" : abs >= 0.15 ? "moderate" : "weak";
-  const significant = p_value !== undefined ? p_value < 0.05 : null;
-  return (
-    <div className="border-l-2 pl-3" style={{ borderColor: accent }}>
-      <div className="text-[10.5px] uppercase tracking-widest font-semibold" style={{ color: accent }}>
-        {title}
-      </div>
-      <div className="flex items-baseline gap-2 mt-1">
-        <span className="text-[24px] font-mono leading-tight" style={{ color: "var(--color-fg)" }}>
-          {rho >= 0 ? "+" : ""}{rho.toFixed(3)}
-        </span>
-        <span className="text-[10px] uppercase tracking-widest" style={{ color: "var(--color-fg-faint)" }}>
-          ρ · {tone}
-        </span>
-        {p_value !== undefined ? (
-          <span
-            className="ml-auto text-[10.5px] font-mono px-1.5 py-0.5 rounded"
-            style={{
-              color: significant ? "rgba(40,160,80,1)" : "var(--color-fg-faint)",
-              backgroundColor: significant ? "rgba(40,160,80,0.12)" : "transparent",
-              border: significant ? "1px solid rgba(40,160,80,0.4)" : "1px solid var(--color-border)",
-            }}
-          >
-            p = {p_value < 0.0001 ? "<1e-4" : p_value.toFixed(4)}
-          </span>
-        ) : null}
-      </div>
-      {caption ? (
-        <p className="text-[11px] mt-1" style={{ color: "var(--color-fg-faint)" }}>
-          {caption}
-        </p>
-      ) : null}
-    </div>
-  );
-}
 
 function RobustnessTab({
   sceneId,

--- a/frontend/src/pages/workspace/tabs/AnomalyTab.tsx
+++ b/frontend/src/pages/workspace/tabs/AnomalyTab.tsx
@@ -1,0 +1,214 @@
+/**
+ * Anomaly tab (extracted from Workspace.tsx in c268 as part of
+ * #441 P1 2.1).
+ *
+ * Renders Spearman ρ between anomaly indicators and misclassification
+ * across (topic-based softmax, topic-based NLL, deep CAE-1D-8 RMSE,
+ * deep β-VAE RMSE, deep β-VAE KL). Source: `/api/topic-anomaly/{scene}`
+ * + `/api/deep-anomaly/{scene}`.
+ *
+ * AnomalyMetric stays as a private helper inside this module — it
+ * is only used here.
+ */
+import type { DeepAnomaly, TopicAnomaly } from "@/api/client";
+
+export function AnomalyTab({
+  isLoading,
+  error,
+  topic,
+  deep,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  topic: TopicAnomaly | null;
+  deep: DeepAnomaly | null;
+}) {
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        Loading anomaly statistics…
+      </p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load anomaly statistics.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <h4
+          className="text-base font-semibold mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Anomaly indicators vs misclassification — Spearman ρ
+        </h4>
+        <p
+          className="text-[12px] mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          Each row is one anomaly signal. High |ρ| ⇒ the indicator
+          agrees with which pixels the routed classifier gets wrong
+          (positive) or right (negative). p &lt; 0.05 ⇒ correlation
+          significant at the 5% level. K = {topic?.topic_count ?? "—"}{" "}
+          topics, {topic?.n_documents ?? "—"} documents.
+        </p>
+
+        <div className="grid sm:grid-cols-2 gap-5">
+          {topic ? (
+            <AnomalyMetric
+              accent="rgba(40, 160, 80, 1)"
+              title="Topic-based — softmax peak"
+              rho={
+                topic.anomaly_to_misclassification_correlation.spearman_rho_softmax
+              }
+              p_value={
+                topic.anomaly_to_misclassification_correlation.spearman_p_softmax
+              }
+              caption="Lower softmax peak (less confident) ⇒ more likely to be wrong."
+            />
+          ) : null}
+          {topic ? (
+            <AnomalyMetric
+              accent="rgba(40, 160, 80, 1)"
+              title="Topic-based — negative log-likelihood"
+              rho={
+                topic.anomaly_to_misclassification_correlation.spearman_rho_nll
+              }
+              p_value={
+                topic.anomaly_to_misclassification_correlation.spearman_p_nll
+              }
+              caption="Higher NLL ⇒ more likely to be wrong (positive ρ expected)."
+            />
+          ) : null}
+          {deep?.cae_1d_8 ? (
+            <AnomalyMetric
+              accent="rgba(56, 189, 248, 1)"
+              title="Deep — CAE-1D-8 reconstruction"
+              rho={deep.cae_1d_8.spearman_rho_vs_misclass}
+              caption={`indicator: ${deep.cae_1d_8.anomaly_indicator} · RMSE p50=${deep.cae_1d_8.rmse_overall.median.toFixed(3)} · p95=${deep.cae_1d_8.rmse_overall.p95.toFixed(3)}`}
+            />
+          ) : null}
+          {deep?.beta_vae_8 ? (
+            <AnomalyMetric
+              accent="rgba(170, 60, 200, 1)"
+              title="Deep — β-VAE reconstruction RMSE"
+              rho={deep.beta_vae_8.spearman_rho_rmse_vs_misclass}
+              caption={`RMSE p50=${deep.beta_vae_8.rmse_overall.median.toFixed(3)} · p95=${deep.beta_vae_8.rmse_overall.p95.toFixed(3)}`}
+            />
+          ) : null}
+          {deep?.beta_vae_8 ? (
+            <AnomalyMetric
+              accent="rgba(170, 60, 200, 1)"
+              title="Deep — β-VAE KL"
+              rho={deep.beta_vae_8.spearman_rho_kl_vs_misclass}
+              caption={`KL p50=${deep.beta_vae_8.kl_overall.median.toFixed(3)} · p95=${deep.beta_vae_8.kl_overall.p95.toFixed(3)} · KL is the regularisation term (high = far from prior)`}
+            />
+          ) : null}
+        </div>
+
+        {topic?.anomaly_to_misclassification_correlation.comment ? (
+          <p
+            className="mt-4 text-[12px] italic"
+            style={{ color: "var(--color-fg-faint)" }}
+          >
+            {topic.anomaly_to_misclassification_correlation.comment}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function AnomalyMetric({
+  accent,
+  title,
+  rho,
+  p_value,
+  caption,
+}: {
+  accent: string;
+  title: string;
+  rho: number;
+  p_value?: number;
+  caption?: string;
+}) {
+  const abs = Math.abs(rho);
+  const tone = abs >= 0.3 ? "strong" : abs >= 0.15 ? "moderate" : "weak";
+  const significant = p_value !== undefined ? p_value < 0.05 : null;
+  return (
+    <div className="border-l-2 pl-3" style={{ borderColor: accent }}>
+      <div
+        className="text-[10.5px] uppercase tracking-widest font-semibold"
+        style={{ color: accent }}
+      >
+        {title}
+      </div>
+      <div className="flex items-baseline gap-2 mt-1">
+        <span
+          className="text-[24px] font-mono leading-tight"
+          style={{ color: "var(--color-fg)" }}
+        >
+          {rho >= 0 ? "+" : ""}
+          {rho.toFixed(3)}
+        </span>
+        <span
+          className="text-[10px] uppercase tracking-widest"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          ρ · {tone}
+        </span>
+        {p_value !== undefined ? (
+          <span
+            className="ml-auto text-[10.5px] font-mono px-1.5 py-0.5 rounded"
+            style={{
+              color: significant
+                ? "rgba(40,160,80,1)"
+                : "var(--color-fg-faint)",
+              backgroundColor: significant
+                ? "rgba(40,160,80,0.12)"
+                : "transparent",
+              border: significant
+                ? "1px solid rgba(40,160,80,0.4)"
+                : "1px solid var(--color-border)",
+            }}
+          >
+            p = {p_value < 0.0001 ? "<1e-4" : p_value.toFixed(4)}
+          </span>
+        ) : null}
+      </div>
+      {caption ? (
+        <p
+          className="text-[11px] mt-1"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {caption}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three code-side cycles since c260-264 deploy (PR #483):

- **c266** PR #484 — Close #443 doc drift fully. README counters
  refreshed (133/133 smoke, 1726 artefacts, source-of-truth notes);
  wiki §2 SVG redrawn on master c169431 to match 5-page reality;
  old 'Tab N — X' headings relabelled as 'Page N — X'.
- **c267** PR #485 — api/client.ts split slice 2. EDA family
  (ClassEntry, ClassMeanSpectrum, ScenePerScene) extracted to
  api/eda.ts (56 LOC) + new edaApi.perScene(). client.ts: 1241 → 1213
  LOC (-2.3% / -179 net since c261).
- **c268** PR #486 — Extract AnomalyTab + private AnomalyMetric
  helper. Workspace.tsx: 9848 → 9707 LOC. Entry chunk: 258 → 254 KB.
  Cumulative since c262: 311 → 254 KB (-18%). 8 tabs extracted + lazy.

Paper develop → main deploy in PR #16 (paper main 2fbd937) lands
c269 (16 DOCX regenerated + bib_audit.py).

## Issue status

- #443 ✅ **CLOSED** (all 5 P1 items)
- #441 2.1 progress: 8 tabs extracted + lazy / 21 still inline
- #441 2.4 progress: api/client.ts 1392 → 1213 LOC (-13%)

## Test plan

- [x] pnpm typecheck → clean
- [x] pnpm test → 30 passed
- [x] pytest → 57 passed
- [ ] update.sh on Hetzner
- [ ] Smoke 133/133 on https://lda-hsi.fasl-work.com