### PR TITLE
Cycle 273: api/client.ts split slice 3 — HIDSAG family (#441 2.4)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -570,55 +570,24 @@ export type TopicStability = {
   };
 };
 
-export type HidsagPreprocessingSubset = {
-  subset_code: string;
-  sample_count: number;
-  measurement_count_total: number;
-  classification_policy_ranking: {
-    policy_id: string;
-    best_model: string;
-    best_balanced_accuracy: number;
-  }[];
-  regression_policy_ranking: {
-    policy_id: string;
-    best_model: string;
-    best_r2: number;
-  }[];
-};
-
-export type HidsagCrossPreprocessingStability = {
-  subset_code: string;
-  topic_count: number;
-  policies: string[];
-  per_topic_jaccard_vs_policy0: {
-    policy_id: string;
-    matched_jaccard_top15_mean: number;
-    matched_jaccard_top15_min: number;
-    per_topic_matched_jaccard_top15: number[];
-  }[];
-  pairwise_matched_jaccard_top15_mean_matrix: number[][];
-  pairwise_matched_jaccard_top15_min_matrix: number[][];
-  off_diagonal_summary: {
-    off_diagonal_mean: number;
-    off_diagonal_min: number;
-    off_diagonal_std: number;
-    n_pairs: number;
-  };
-  methodology_note: string;
-};
-
-export type HidsagPreprocessingSensitivity = {
-  source?: string;
-  generated_at?: string;
-  methods?: {
-    policies?: {
-      policy_id: string;
-      policy_name: string;
-      description: string;
-    }[];
-  };
-  subsets: HidsagPreprocessingSubset[];
-};
+// HIDSAG family extracted to ./hidsag.ts in c273. Re-exports below
+// keep `import {...} from "@/api/client"` working across consumers.
+import type {
+  HidsagCrossPreprocessingStability,
+  HidsagEda,
+  HidsagMethodStatistics,
+  HidsagPreprocessingSensitivity,
+} from "./hidsag";
+export type {
+  HidsagBlock,
+  HidsagCrossPreprocessingStability,
+  HidsagDistribution,
+  HidsagEda,
+  HidsagMethodAggregate,
+  HidsagMethodStatistics,
+  HidsagPreprocessingSensitivity,
+  HidsagPreprocessingSubset,
+} from "./hidsag";
 
 export type SpectralBrowserRow = {
   i: number;
@@ -641,55 +610,6 @@ export type SpectralBrowserMeta = {
   rows: SpectralBrowserRow[];
 };
 
-export type HidsagDistribution = {
-  mean: number | null;
-  std: number | null;
-  ci95_lo: number | null;
-  ci95_hi: number | null;
-  median: number | null;
-  min: number | null;
-  max: number | null;
-};
-
-export type HidsagMethodAggregate = {
-  n_targets: number;
-  r2_distribution?: HidsagDistribution;
-  macro_f1_distribution?: HidsagDistribution;
-};
-
-export type HidsagBlock = {
-  primary_metric: string;
-  n_targets: number;
-  n_targets_complete?: number;
-  target_names: string[];
-  method_aggregates: Record<string, HidsagMethodAggregate>;
-  ranking?: { method: string; mean: number; rank: number }[];
-};
-
-export type HidsagMethodStatistics = {
-  subset_code: string;
-  dataset_id: string;
-  sample_count: number;
-  measurement_count_total: number;
-  regression: HidsagBlock | null;
-  classification: HidsagBlock | null;
-};
-
-export type HidsagEda = {
-  subset_code: string;
-  sample_count: number;
-  measurement_count_total: number;
-  numeric_variable_names: string[];
-  numeric_variables: Record<string, { mean: number; std: number; min: number; max: number; n_finite: number }>;
-  modality_band_counts: Record<string, number>;
-  spectrum_axis: { wavelength_nm: number[] };
-  mean_spectrum_by_measurement: Record<string, { mean: number[]; n: number }>;
-  mean_spectrum_by_measurement_stratum?: Record<string, Record<string, { mean: number[]; n: number; stratum_value: number | string | null }>>;
-  correlation_pearson?: number[][] | null;
-  correlation_spearman?: number[][] | null;
-  measurement_tags_top?: string[];
-  dominant_targets_by_mean?: { name: string; mean: number; std: number }[];
-};
 
 export type RoutedFoldMetric = {
   per_fold: number[];

--- a/frontend/src/api/hidsag.ts
+++ b/frontend/src/api/hidsag.ts
@@ -1,0 +1,124 @@
+/**
+ * HIDSAG family API surface. Third slice of the c261 api/client.ts
+ * split (#441 P1 2.4).
+ *
+ * Carries the 8 HIDSAG-specific types from the original client.ts:
+ *   HidsagPreprocessingSubset, HidsagCrossPreprocessingStability,
+ *   HidsagPreprocessingSensitivity, HidsagDistribution,
+ *   HidsagMethodAggregate, HidsagBlock, HidsagMethodStatistics,
+ *   HidsagEda.
+ *
+ * Runtime calls (hidsagEda, hidsagPreprocessingSensitivity, etc.)
+ * stay inside the existing `api` object in client.ts for back-compat;
+ * a future cycle can migrate them to a `hidsagApi` namespace once
+ * call sites are ready.
+ */
+
+export type HidsagPreprocessingSubset = {
+  subset_code: string;
+  sample_count: number;
+  measurement_count_total: number;
+  classification_policy_ranking: {
+    policy_id: string;
+    best_model: string;
+    best_balanced_accuracy: number;
+  }[];
+  regression_policy_ranking: {
+    policy_id: string;
+    best_model: string;
+    best_r2: number;
+  }[];
+};
+
+export type HidsagCrossPreprocessingStability = {
+  subset_code: string;
+  topic_count: number;
+  policies: string[];
+  per_topic_jaccard_vs_policy0: {
+    policy_id: string;
+    matched_jaccard_top15_mean: number;
+    matched_jaccard_top15_min: number;
+    per_topic_matched_jaccard_top15: number[];
+  }[];
+  pairwise_matched_jaccard_top15_mean_matrix: number[][];
+  pairwise_matched_jaccard_top15_min_matrix: number[][];
+  off_diagonal_summary: {
+    off_diagonal_mean: number;
+    off_diagonal_min: number;
+    off_diagonal_std: number;
+    n_pairs: number;
+  };
+  methodology_note: string;
+};
+
+export type HidsagPreprocessingSensitivity = {
+  source?: string;
+  generated_at?: string;
+  methods?: {
+    policies?: {
+      policy_id: string;
+      policy_name: string;
+      description: string;
+    }[];
+  };
+  subsets: HidsagPreprocessingSubset[];
+};
+
+export type HidsagDistribution = {
+  mean: number | null;
+  std: number | null;
+  ci95_lo: number | null;
+  ci95_hi: number | null;
+  median: number | null;
+  min: number | null;
+  max: number | null;
+};
+
+export type HidsagMethodAggregate = {
+  n_targets: number;
+  r2_distribution?: HidsagDistribution;
+  macro_f1_distribution?: HidsagDistribution;
+};
+
+export type HidsagBlock = {
+  primary_metric: string;
+  n_targets: number;
+  n_targets_complete?: number;
+  target_names: string[];
+  method_aggregates: Record<string, HidsagMethodAggregate>;
+  ranking?: { method: string; mean: number; rank: number }[];
+};
+
+export type HidsagMethodStatistics = {
+  subset_code: string;
+  dataset_id: string;
+  sample_count: number;
+  measurement_count_total: number;
+  regression: HidsagBlock | null;
+  classification: HidsagBlock | null;
+};
+
+export type HidsagEda = {
+  subset_code: string;
+  sample_count: number;
+  measurement_count_total: number;
+  numeric_variable_names: string[];
+  numeric_variables: Record<
+    string,
+    { mean: number; std: number; min: number; max: number; n_finite: number }
+  >;
+  modality_band_counts: Record<string, number>;
+  spectrum_axis: { wavelength_nm: number[] };
+  mean_spectrum_by_measurement: Record<string, { mean: number[]; n: number }>;
+  mean_spectrum_by_measurement_stratum?: Record<
+    string,
+    Record<
+      string,
+      { mean: number[]; n: number; stratum_value: number | string | null }
+    >
+  >;
+  correlation_pearson?: number[][] | null;
+  correlation_spearman?: number[][] | null;
+  measurement_tags_top?: string[];
+  dominant_targets_by_mean?: { name: string; mean: number; std: number }[];
+};

--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -2473,7 +2473,7 @@ function HidsagPreprocessing() {
         <>
           {data.methods?.policies && data.methods.policies.length > 0 && (
             <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3 mt-2 mb-4">
-              {data.methods.policies.map((p) => (
+              {data.methods.policies.map((p: { policy_id: string; policy_name: string; description: string }) => (
                 <div
                   key={p.policy_id}
                   className="rounded-md border p-3 text-[12.5px] leading-relaxed"
@@ -2501,7 +2501,7 @@ function HidsagPreprocessing() {
             </div>
           )}
           <div className="space-y-6 mt-2">
-            {data.subsets.map((s) => (
+            {data.subsets.map((s: import("@/api/client").HidsagPreprocessingSubset) => (
               <PreprocessingSubsetCard key={s.subset_code} subset={s} />
             ))}
           </div>


### PR DESCRIPTION
## Summary

Third slice of #441 P1 2.4. Extracts the 8 HIDSAG types to
\`api/hidsag.ts\` (130 LOC).

## client.ts trend

| Cycle | LOC | Δ |
|---|---|---|
| Original | 1392 | — |
| c261 (BandMask) | 1241 | −151 |
| c267 (EDA) | 1213 | −28 |
| **c273 (HIDSAG)** | **1128** | **−85** |

**Cumulative: −264 LOC / −19%**.

## Incidental

Benchmarks.tsx gains 2 explicit .map() callback type annotations
where tsc-strict dropped inference through the re-export chain.

## Test plan

- [x] pnpm typecheck → clean
- [x] pnpm test → 30 passed
- [x] pnpm build → clean