### PR TITLE
c274: route 3 builders through research_core.paths (#444 P1 3.2)

### DIFF
--- a/data-pipeline/build_analysis_payload.py
+++ b/data-pipeline/build_analysis_payload.py
@@ -18,11 +18,15 @@ from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
 from sklearn.metrics import silhouette_score
 
+# c274: route through research_core.paths.DERIVED_DIR instead of
+# re-deriving ROOT locally (closes one of the 13 builders flagged in
+# #444 P1 item 3.2).
+from research_core.paths import DERIVED_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-REAL_PATH = ROOT / "data" / "derived" / "real" / "real_samples.json"
-SPECTRAL_PATH = ROOT / "data" / "derived" / "spectral" / "library_samples.json"
-OUTPUT_DIR = ROOT / "data" / "derived" / "analysis"
+
+REAL_PATH = DERIVED_DIR / "real" / "real_samples.json"
+SPECTRAL_PATH = DERIVED_DIR / "spectral" / "library_samples.json"
+OUTPUT_DIR = DERIVED_DIR / "analysis"
 OUTPUT_PATH = OUTPUT_DIR / "analysis.json"
 RANDOM_STATE = 42
 

--- a/data-pipeline/build_corpus_previews.py
+++ b/data-pipeline/build_corpus_previews.py
@@ -14,15 +14,19 @@ from pathlib import Path
 from statistics import median
 from typing import Any, Iterable
 
+# c274: route through research_core.paths.DERIVED_DIR instead of
+# re-deriving ROOT locally (closes one of the 13 builders flagged in
+# #444 P1 item 3.2).
+from research_core.paths import DERIVED_DIR
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-ROOT = Path(__file__).resolve().parents[1]
-SPECTRAL_PATH = ROOT / "data" / "derived" / "spectral" / "library_samples.json"
-REAL_PATH = ROOT / "data" / "derived" / "real" / "real_samples.json"
-OUTPUT_DIR = ROOT / "data" / "derived" / "corpus"
+SPECTRAL_PATH = DERIVED_DIR / "spectral" / "library_samples.json"
+REAL_PATH = DERIVED_DIR / "real" / "real_samples.json"
+OUTPUT_DIR = DERIVED_DIR / "corpus"
 OUTPUT_PATH = OUTPUT_DIR / "corpus_previews.json"
 
 

--- a/data-pipeline/build_demo.py
+++ b/data-pipeline/build_demo.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from itertools import permutations
-from pathlib import Path
 
 import numpy as np
 from sklearn.decomposition import LatentDirichletAllocation
@@ -20,9 +19,13 @@ from sklearn.linear_model import LinearRegression
 from sklearn.metrics import root_mean_squared_error
 from sklearn.model_selection import LeaveOneOut
 
+# c274: route through research_core.paths.DATA_DIR instead of
+# re-deriving ROOT locally (closes one of the 13 builders flagged
+# in #444 P1 item 3.2).
+from research_core.paths import DATA_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-OUTPUT = ROOT / "data" / "demo" / "demo.json"
+
+OUTPUT = DATA_DIR / "demo" / "demo.json"
 RNG = np.random.default_rng(42)
 
 


### PR DESCRIPTION
Refactors 3 of 13 builders flagged in #444 P1 3.2 to import DATA_DIR / DERIVED_DIR from research_core.paths instead of defining their own ROOT locally. Builders: build_demo, build_corpus_previews, build_analysis_payload. Behaviour unchanged. Progress: 3/13.