### PR TITLE
Deploy cycles 272-275: 1 more tab + api split slice 3 + 3 builders refactored + wordifications orchestrator

### DIFF
--- a/data-pipeline/build_analysis_payload.py
+++ b/data-pipeline/build_analysis_payload.py
@@ -18,11 +18,15 @@ from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
 from sklearn.metrics import silhouette_score
 
+# c274: route through research_core.paths.DERIVED_DIR instead of
+# re-deriving ROOT locally (closes one of the 13 builders flagged in
+# #444 P1 item 3.2).
+from research_core.paths import DERIVED_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-REAL_PATH = ROOT / "data" / "derived" / "real" / "real_samples.json"
-SPECTRAL_PATH = ROOT / "data" / "derived" / "spectral" / "library_samples.json"
-OUTPUT_DIR = ROOT / "data" / "derived" / "analysis"
+
+REAL_PATH = DERIVED_DIR / "real" / "real_samples.json"
+SPECTRAL_PATH = DERIVED_DIR / "spectral" / "library_samples.json"
+OUTPUT_DIR = DERIVED_DIR / "analysis"
 OUTPUT_PATH = OUTPUT_DIR / "analysis.json"
 RANDOM_STATE = 42
 

--- a/data-pipeline/build_corpus_previews.py
+++ b/data-pipeline/build_corpus_previews.py
@@ -14,15 +14,19 @@ from pathlib import Path
 from statistics import median
 from typing import Any, Iterable
 
+# c274: route through research_core.paths.DERIVED_DIR instead of
+# re-deriving ROOT locally (closes one of the 13 builders flagged in
+# #444 P1 item 3.2).
+from research_core.paths import DERIVED_DIR
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-ROOT = Path(__file__).resolve().parents[1]
-SPECTRAL_PATH = ROOT / "data" / "derived" / "spectral" / "library_samples.json"
-REAL_PATH = ROOT / "data" / "derived" / "real" / "real_samples.json"
-OUTPUT_DIR = ROOT / "data" / "derived" / "corpus"
+SPECTRAL_PATH = DERIVED_DIR / "spectral" / "library_samples.json"
+REAL_PATH = DERIVED_DIR / "real" / "real_samples.json"
+OUTPUT_DIR = DERIVED_DIR / "corpus"
 OUTPUT_PATH = OUTPUT_DIR / "corpus_previews.json"
 
 

--- a/data-pipeline/build_demo.py
+++ b/data-pipeline/build_demo.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from itertools import permutations
-from pathlib import Path
 
 import numpy as np
 from sklearn.decomposition import LatentDirichletAllocation
@@ -20,9 +19,13 @@ from sklearn.linear_model import LinearRegression
 from sklearn.metrics import root_mean_squared_error
 from sklearn.model_selection import LeaveOneOut
 
+# c274: route through research_core.paths.DATA_DIR instead of
+# re-deriving ROOT locally (closes one of the 13 builders flagged
+# in #444 P1 item 3.2).
+from research_core.paths import DATA_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-OUTPUT = ROOT / "data" / "demo" / "demo.json"
+
+OUTPUT = DATA_DIR / "demo" / "demo.json"
 RNG = np.random.default_rng(42)
 
 

--- a/data-pipeline/build_wordifications_all.py
+++ b/data-pipeline/build_wordifications_all.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Unified entry point for the three wordifications variants.
+
+Closes #444 P1 item 3.4 by giving callers one command instead of
+three:
+
+    python -m data_pipeline.build_wordifications_all \\
+        --variant {v4plus,v6plus,v7v11,all}
+
+Internally dispatches to the existing per-variant modules
+(``build_wordifications_v4plus``, ``build_wordifications_v6plus``,
+``build_wordifications_v7v11``) so the recipe-building logic itself
+is not touched. A future cycle can pull the shared scaffolding out
+into a common helper and collapse the three variants into one
+parametrised builder.
+
+Recipes by variant:
+- v4plus  → V4, V5, V10
+- v6plus  → V6, V8, V9, V12
+- v7v11   → V7, V11
+- all     → run all three in sequence
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+
+VARIANT_MODULES = {
+    "v4plus": "build_wordifications_v4plus",
+    "v6plus": "build_wordifications_v6plus",
+    "v7v11": "build_wordifications_v7v11",
+}
+
+
+def run(variant: str) -> int:
+    if variant not in VARIANT_MODULES:
+        print(f"error: unknown variant '{variant}'", file=sys.stderr)
+        return 2
+    module_name = VARIANT_MODULES[variant]
+    module = importlib.import_module(module_name)
+    if not hasattr(module, "main"):
+        print(f"error: {module_name} has no main()", file=sys.stderr)
+        return 2
+    print(f"--- running {module_name}.main() ---")
+    rc = module.main()
+    return rc if isinstance(rc, int) else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run one or all wordifications variants. Each variant emits a "
+            "subset of the V1..V12 recipe family; together they cover the "
+            "full grid the framework's canonical fits select from."
+        ),
+    )
+    parser.add_argument(
+        "--variant",
+        choices=list(VARIANT_MODULES.keys()) + ["all"],
+        default="all",
+        help="Which variant module to invoke. 'all' runs every variant.",
+    )
+    args = parser.parse_args()
+
+    if args.variant == "all":
+        for v in VARIANT_MODULES:
+            rc = run(v)
+            if rc != 0:
+                print(f"variant '{v}' returned {rc}; aborting", file=sys.stderr)
+                return rc
+        return 0
+    return run(args.variant)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -570,55 +570,24 @@ export type TopicStability = {
   };
 };
 
-export type HidsagPreprocessingSubset = {
-  subset_code: string;
-  sample_count: number;
-  measurement_count_total: number;
-  classification_policy_ranking: {
-    policy_id: string;
-    best_model: string;
-    best_balanced_accuracy: number;
-  }[];
-  regression_policy_ranking: {
-    policy_id: string;
-    best_model: string;
-    best_r2: number;
-  }[];
-};
-
-export type HidsagCrossPreprocessingStability = {
-  subset_code: string;
-  topic_count: number;
-  policies: string[];
-  per_topic_jaccard_vs_policy0: {
-    policy_id: string;
-    matched_jaccard_top15_mean: number;
-    matched_jaccard_top15_min: number;
-    per_topic_matched_jaccard_top15: number[];
-  }[];
-  pairwise_matched_jaccard_top15_mean_matrix: number[][];
-  pairwise_matched_jaccard_top15_min_matrix: number[][];
-  off_diagonal_summary: {
-    off_diagonal_mean: number;
-    off_diagonal_min: number;
-    off_diagonal_std: number;
-    n_pairs: number;
-  };
-  methodology_note: string;
-};
-
-export type HidsagPreprocessingSensitivity = {
-  source?: string;
-  generated_at?: string;
-  methods?: {
-    policies?: {
-      policy_id: string;
-      policy_name: string;
-      description: string;
-    }[];
-  };
-  subsets: HidsagPreprocessingSubset[];
-};
+// HIDSAG family extracted to ./hidsag.ts in c273. Re-exports below
+// keep `import {...} from "@/api/client"` working across consumers.
+import type {
+  HidsagCrossPreprocessingStability,
+  HidsagEda,
+  HidsagMethodStatistics,
+  HidsagPreprocessingSensitivity,
+} from "./hidsag";
+export type {
+  HidsagBlock,
+  HidsagCrossPreprocessingStability,
+  HidsagDistribution,
+  HidsagEda,
+  HidsagMethodAggregate,
+  HidsagMethodStatistics,
+  HidsagPreprocessingSensitivity,
+  HidsagPreprocessingSubset,
+} from "./hidsag";
 
 export type SpectralBrowserRow = {
   i: number;
@@ -641,55 +610,6 @@ export type SpectralBrowserMeta = {
   rows: SpectralBrowserRow[];
 };
 
-export type HidsagDistribution = {
-  mean: number | null;
-  std: number | null;
-  ci95_lo: number | null;
-  ci95_hi: number | null;
-  median: number | null;
-  min: number | null;
-  max: number | null;
-};
-
-export type HidsagMethodAggregate = {
-  n_targets: number;
-  r2_distribution?: HidsagDistribution;
-  macro_f1_distribution?: HidsagDistribution;
-};
-
-export type HidsagBlock = {
-  primary_metric: string;
-  n_targets: number;
-  n_targets_complete?: number;
-  target_names: string[];
-  method_aggregates: Record<string, HidsagMethodAggregate>;
-  ranking?: { method: string; mean: number; rank: number }[];
-};
-
-export type HidsagMethodStatistics = {
-  subset_code: string;
-  dataset_id: string;
-  sample_count: number;
-  measurement_count_total: number;
-  regression: HidsagBlock | null;
-  classification: HidsagBlock | null;
-};
-
-export type HidsagEda = {
-  subset_code: string;
-  sample_count: number;
-  measurement_count_total: number;
-  numeric_variable_names: string[];
-  numeric_variables: Record<string, { mean: number; std: number; min: number; max: number; n_finite: number }>;
-  modality_band_counts: Record<string, number>;
-  spectrum_axis: { wavelength_nm: number[] };
-  mean_spectrum_by_measurement: Record<string, { mean: number[]; n: number }>;
-  mean_spectrum_by_measurement_stratum?: Record<string, Record<string, { mean: number[]; n: number; stratum_value: number | string | null }>>;
-  correlation_pearson?: number[][] | null;
-  correlation_spearman?: number[][] | null;
-  measurement_tags_top?: string[];
-  dominant_targets_by_mean?: { name: string; mean: number; std: number }[];
-};
 
 export type RoutedFoldMetric = {
   per_fold: number[];

--- a/frontend/src/api/hidsag.ts
+++ b/frontend/src/api/hidsag.ts
@@ -1,0 +1,124 @@
+/**
+ * HIDSAG family API surface. Third slice of the c261 api/client.ts
+ * split (#441 P1 2.4).
+ *
+ * Carries the 8 HIDSAG-specific types from the original client.ts:
+ *   HidsagPreprocessingSubset, HidsagCrossPreprocessingStability,
+ *   HidsagPreprocessingSensitivity, HidsagDistribution,
+ *   HidsagMethodAggregate, HidsagBlock, HidsagMethodStatistics,
+ *   HidsagEda.
+ *
+ * Runtime calls (hidsagEda, hidsagPreprocessingSensitivity, etc.)
+ * stay inside the existing `api` object in client.ts for back-compat;
+ * a future cycle can migrate them to a `hidsagApi` namespace once
+ * call sites are ready.
+ */
+
+export type HidsagPreprocessingSubset = {
+  subset_code: string;
+  sample_count: number;
+  measurement_count_total: number;
+  classification_policy_ranking: {
+    policy_id: string;
+    best_model: string;
+    best_balanced_accuracy: number;
+  }[];
+  regression_policy_ranking: {
+    policy_id: string;
+    best_model: string;
+    best_r2: number;
+  }[];
+};
+
+export type HidsagCrossPreprocessingStability = {
+  subset_code: string;
+  topic_count: number;
+  policies: string[];
+  per_topic_jaccard_vs_policy0: {
+    policy_id: string;
+    matched_jaccard_top15_mean: number;
+    matched_jaccard_top15_min: number;
+    per_topic_matched_jaccard_top15: number[];
+  }[];
+  pairwise_matched_jaccard_top15_mean_matrix: number[][];
+  pairwise_matched_jaccard_top15_min_matrix: number[][];
+  off_diagonal_summary: {
+    off_diagonal_mean: number;
+    off_diagonal_min: number;
+    off_diagonal_std: number;
+    n_pairs: number;
+  };
+  methodology_note: string;
+};
+
+export type HidsagPreprocessingSensitivity = {
+  source?: string;
+  generated_at?: string;
+  methods?: {
+    policies?: {
+      policy_id: string;
+      policy_name: string;
+      description: string;
+    }[];
+  };
+  subsets: HidsagPreprocessingSubset[];
+};
+
+export type HidsagDistribution = {
+  mean: number | null;
+  std: number | null;
+  ci95_lo: number | null;
+  ci95_hi: number | null;
+  median: number | null;
+  min: number | null;
+  max: number | null;
+};
+
+export type HidsagMethodAggregate = {
+  n_targets: number;
+  r2_distribution?: HidsagDistribution;
+  macro_f1_distribution?: HidsagDistribution;
+};
+
+export type HidsagBlock = {
+  primary_metric: string;
+  n_targets: number;
+  n_targets_complete?: number;
+  target_names: string[];
+  method_aggregates: Record<string, HidsagMethodAggregate>;
+  ranking?: { method: string; mean: number; rank: number }[];
+};
+
+export type HidsagMethodStatistics = {
+  subset_code: string;
+  dataset_id: string;
+  sample_count: number;
+  measurement_count_total: number;
+  regression: HidsagBlock | null;
+  classification: HidsagBlock | null;
+};
+
+export type HidsagEda = {
+  subset_code: string;
+  sample_count: number;
+  measurement_count_total: number;
+  numeric_variable_names: string[];
+  numeric_variables: Record<
+    string,
+    { mean: number; std: number; min: number; max: number; n_finite: number }
+  >;
+  modality_band_counts: Record<string, number>;
+  spectrum_axis: { wavelength_nm: number[] };
+  mean_spectrum_by_measurement: Record<string, { mean: number[]; n: number }>;
+  mean_spectrum_by_measurement_stratum?: Record<
+    string,
+    Record<
+      string,
+      { mean: number[]; n: number; stratum_value: number | string | null }
+    >
+  >;
+  correlation_pearson?: number[][] | null;
+  correlation_spearman?: number[][] | null;
+  measurement_tags_top?: string[];
+  dominant_targets_by_mean?: { name: string; mean: number; std: number }[];
+};

--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -2473,7 +2473,7 @@ function HidsagPreprocessing() {
         <>
           {data.methods?.policies && data.methods.policies.length > 0 && (
             <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3 mt-2 mb-4">
-              {data.methods.policies.map((p) => (
+              {data.methods.policies.map((p: { policy_id: string; policy_name: string; description: string }) => (
                 <div
                   key={p.policy_id}
                   className="rounded-md border p-3 text-[12.5px] leading-relaxed"
@@ -2501,7 +2501,7 @@ function HidsagPreprocessing() {
             </div>
           )}
           <div className="space-y-6 mt-2">
-            {data.subsets.map((s) => (
+            {data.subsets.map((s: import("@/api/client").HidsagPreprocessingSubset) => (
               <PreprocessingSubsetCard key={s.subset_code} subset={s} />
             ))}
           </div>

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -80,6 +80,11 @@ const AnomalyTab = lazy(() =>
     default: m.AnomalyTab,
   })),
 );
+const RobustnessTab = lazy(() =>
+  import("./workspace/tabs/RobustnessTab").then((m) => ({
+    default: m.RobustnessTab,
+  })),
+);
 import { UnmixingStat } from "./workspace/components/StatCard";
 
 const Scatter3D = lazy(() =>
@@ -1187,13 +1192,15 @@ function ExploreStep({
             />
           )}
           {tab === "robust" && (
-            <RobustnessTab
-              sceneId={subsetId!}
-              isLoading={quantSens.isLoading || xsTransfer.isLoading}
-              error={(quantSens.error as Error | null) ?? (xsTransfer.error as Error | null)}
-              quant={quantSens.data ?? null}
-              transfer={xsTransfer.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <RobustnessTab
+                sceneId={subsetId!}
+                isLoading={quantSens.isLoading || xsTransfer.isLoading}
+                error={(quantSens.error as Error | null) ?? (xsTransfer.error as Error | null)}
+                quant={quantSens.data ?? null}
+                transfer={xsTransfer.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "qkexplore" && (
             <Suspense fallback={<TabLoading />}>
@@ -7893,213 +7900,6 @@ function InterpretDocumentSample({ docs, K }: { docs: import("@/api/client").Doc
 }
 
 
-function RobustnessTab({
-  sceneId,
-  isLoading,
-  error,
-  quant,
-  transfer,
-}: {
-  sceneId: string;
-  isLoading: boolean;
-  error: Error | null;
-  quant: import("@/api/client").QuantizationSensitivity | null;
-  transfer: import("@/api/client").CrossSceneTransfer | null;
-}) {
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading robustness panels…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load robustness data.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-6">
-      {quant ? <QuantizationSensitivityCard quant={quant} /> : null}
-      {transfer ? <CrossSceneTransferCard transfer={transfer} currentScene={sceneId} /> : null}
-    </div>
-  );
-}
-
-function QuantizationSensitivityCard({ quant }: { quant: import("@/api/client").QuantizationSensitivity }) {
-  const okProbes = quant.probes.filter((p) => p.status === "ok");
-  const maxCos = Math.max(...okProbes.map((p) => p.matched_cosine_mean ?? 0), 1);
-  return (
-    <div
-      className="rounded-lg border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-        Quantization sensitivity · canonical {quant.canonical_recipe}/{quant.canonical_scheme} Q={quant.canonical_Q}
-      </h4>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Each probe re-runs LDA with a different wordification config, then matches topics back to
-        the canonical run by maximum-cosine (Hungarian). High <code>matched_cosine_mean</code> ⇒
-        topics are robust to the probe choice. ARI vs canonical reports whether the dominant-topic
-        assignment per document agrees.
-      </p>
-      <div className="overflow-x-auto">
-        <table className="w-full text-[12px]" style={{ color: "var(--color-fg)" }}>
-          <thead>
-            <tr style={{ color: "var(--color-fg-faint)" }}>
-              <th className="text-left font-mono text-[11px] pb-1 pr-3">probe config</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">cosine · mean</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">cosine · min</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">ARI vs canonical</th>
-              <th className="text-left font-mono text-[11px] pb-1">match strength</th>
-            </tr>
-          </thead>
-          <tbody>
-            {quant.probes.map((p) => {
-              const cosMean = p.matched_cosine_mean ?? 0;
-              const cosMin = p.matched_cosine_min ?? 0;
-              const ari = p.ari_dominant_vs_canonical ?? 0;
-              const w = (cosMean / maxCos) * 100;
-              const isOk = p.status === "ok";
-              return (
-                <tr key={p.config} style={{ borderTop: "1px solid var(--color-border)" }}>
-                  <td className="py-1 pr-3 font-mono text-[11.5px]">
-                    {p.config}
-                    {!isOk ? <span className="ml-1 text-[10.5px]" style={{ color: "var(--color-warn)" }}>({p.status})</span> : null}
-                  </td>
-                  <td className="py-1 pr-3 text-right font-mono">{cosMean.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono">{cosMin.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono">{ari.toFixed(3)}</td>
-                  <td className="py-1 w-[180px]">
-                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                      <div
-                        className="h-2 rounded"
-                        style={{
-                          width: `${w}%`,
-                          backgroundColor: cosMean >= 0.95 ? "rgba(40,160,80,0.9)" : cosMean >= 0.85 ? "rgba(214,140,40,0.9)" : "rgba(214,39,40,0.9)",
-                        }}
-                      />
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function CrossSceneTransferCard({
-  transfer,
-  currentScene,
-}: {
-  transfer: import("@/api/client").CrossSceneTransfer;
-  currentScene: string;
-}) {
-  const N = transfer.scene_order.length;
-  const labelW = 130;
-  const cell = 80;
-  const cellH = 44;
-  const W = labelW + N * cell + 8;
-  const H = labelW + N * cellH + 8;
-  const curIdx = transfer.scene_order.indexOf(currentScene);
-  const colour = (v: number) => {
-    const t = Math.max(0, Math.min(1, v));
-    const r = Math.round(255 * (1 - t));
-    const g = Math.round(180 * t + 60 * (1 - t));
-    const b = Math.round(60 * t + 60 * (1 - t));
-    return `rgb(${r}, ${g}, ${b})`;
-  };
-  return (
-    <div
-      className="rounded-lg border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-        Cross-scene transfer · macro F1
-      </h4>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Each cell M[i,j] = train LDA on scene i, freeze, evaluate downstream classifier on scene j.
-        Common wavelength grid {transfer.common_wavelength_grid.min_nm}–
-        {transfer.common_wavelength_grid.max_nm} nm, {transfer.common_wavelength_grid.n_bands} bands.
-        Wordification {transfer.wordification}, Q={transfer.quantization_scale},
-        samples_per_class={transfer.samples_per_class}. Diagonal = self-transfer.
-      </p>
-      <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 1080 }}>
-          {transfer.scene_order.map((sc, j) => (
-            <text
-              key={`c-${sc}`}
-              x={labelW + j * cell + cell / 2}
-              y={labelW - 4}
-              fontSize="10"
-              textAnchor="end"
-              transform={`rotate(-30 ${labelW + j * cell + cell / 2} ${labelW - 4})`}
-              fill={j === curIdx ? "var(--color-accent)" : "currentColor"}
-              opacity={j === curIdx ? 1 : 0.65}
-              fontFamily="ui-monospace, monospace"
-              fontWeight={j === curIdx ? 600 : 400}
-            >
-              → {sc}
-            </text>
-          ))}
-          {transfer.scene_order.map((sc, i) => (
-            <text
-              key={`r-${sc}`}
-              x={labelW - 6}
-              y={labelW + i * cellH + cellH / 2 + 4}
-              fontSize="10"
-              textAnchor="end"
-              fill={i === curIdx ? "var(--color-accent)" : "currentColor"}
-              opacity={i === curIdx ? 1 : 0.65}
-              fontFamily="ui-monospace, monospace"
-              fontWeight={i === curIdx ? 600 : 400}
-            >
-              {sc} →
-            </text>
-          ))}
-          {transfer.transfer_matrix_macro_f1.map((row, i) =>
-            row.map((v, j) => {
-              const isDiag = i === j;
-              const isCurRow = i === curIdx;
-              const isCurCol = j === curIdx;
-              const stroke = isCurRow || isCurCol ? "rgba(56,189,248,1)" : "none";
-              return (
-                <g key={`${i}-${j}`}>
-                  <rect
-                    x={labelW + j * cell}
-                    y={labelW + i * cellH}
-                    width={cell - 1}
-                    height={cellH - 1}
-                    fill={colour(v)}
-                    stroke={stroke}
-                    strokeWidth={isCurRow && isCurCol ? 2.5 : isCurRow || isCurCol ? 1.5 : 0}
-                  />
-                  <text
-                    x={labelW + j * cell + cell / 2}
-                    y={labelW + i * cellH + cellH / 2 + 2}
-                    fontSize="11"
-                    textAnchor="middle"
-                    fill={v > 0.45 ? "white" : "var(--color-fg)"}
-                    fontFamily="ui-monospace, monospace"
-                    fontWeight={isDiag ? 600 : 400}
-                  >
-                    {v.toFixed(3)}
-                  </text>
-                </g>
-              );
-            }),
-          )}
-        </svg>
-      </div>
-      {curIdx >= 0 ? (
-        <p className="mt-3 text-[11.5px]" style={{ color: "var(--color-fg-faint)" }}>
-          Highlight: current scene <strong style={{ color: "var(--color-accent)" }}>{currentScene}</strong> outlined in row {curIdx} (as source) and column {curIdx} (as target).
-          Self-transfer F1 = {transfer.transfer_matrix_macro_f1[curIdx]?.[curIdx]?.toFixed(3) ?? "—"}.
-        </p>
-      ) : null}
-    </div>
-  );
-}
 
 function SpatialStructureTab({
   isLoading,

--- a/frontend/src/pages/workspace/tabs/RobustnessTab.tsx
+++ b/frontend/src/pages/workspace/tabs/RobustnessTab.tsx
@@ -1,0 +1,332 @@
+/**
+ * Robustness tab (extracted from Workspace.tsx in c272 as part of
+ * #441 P1 2.1). Combines two complementary panels:
+ *
+ *   1. QuantizationSensitivityCard — table of probe configs vs the
+ *      canonical fit with matched-cosine + ARI per probe.
+ *   2. CrossSceneTransferCard — 5×5 SVG heatmap of macro F1 when
+ *      topics trained on scene i are evaluated downstream on scene j.
+ *
+ * Both helpers are module-local — only RobustnessTab consumes them.
+ */
+import type {
+  CrossSceneTransfer,
+  QuantizationSensitivity,
+} from "@/api/client";
+
+export function RobustnessTab({
+  sceneId,
+  isLoading,
+  error,
+  quant,
+  transfer,
+}: {
+  sceneId: string;
+  isLoading: boolean;
+  error: Error | null;
+  quant: QuantizationSensitivity | null;
+  transfer: CrossSceneTransfer | null;
+}) {
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        Loading robustness panels…
+      </p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load robustness data.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      {quant ? <QuantizationSensitivityCard quant={quant} /> : null}
+      {transfer ? (
+        <CrossSceneTransferCard transfer={transfer} currentScene={sceneId} />
+      ) : null}
+    </div>
+  );
+}
+
+function QuantizationSensitivityCard({
+  quant,
+}: {
+  quant: QuantizationSensitivity;
+}) {
+  const okProbes = quant.probes.filter((p) => p.status === "ok");
+  const maxCos = Math.max(
+    ...okProbes.map((p) => p.matched_cosine_mean ?? 0),
+    1,
+  );
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <h4
+        className="text-base font-semibold mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Quantization sensitivity · canonical {quant.canonical_recipe}/
+        {quant.canonical_scheme} Q={quant.canonical_Q}
+      </h4>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Each probe re-runs LDA with a different wordification config, then
+        matches topics back to the canonical run by maximum-cosine
+        (Hungarian). High <code>matched_cosine_mean</code> ⇒ topics are
+        robust to the probe choice. ARI vs canonical reports whether the
+        dominant-topic assignment per document agrees.
+      </p>
+      <div className="overflow-x-auto">
+        <table
+          className="w-full text-[12px]"
+          style={{ color: "var(--color-fg)" }}
+        >
+          <thead>
+            <tr style={{ color: "var(--color-fg-faint)" }}>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                probe config
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                cosine · mean
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                cosine · min
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                ARI vs canonical
+              </th>
+              <th className="text-left font-mono text-[11px] pb-1">
+                match strength
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {quant.probes.map((p) => {
+              const cosMean = p.matched_cosine_mean ?? 0;
+              const cosMin = p.matched_cosine_min ?? 0;
+              const ari = p.ari_dominant_vs_canonical ?? 0;
+              const w = (cosMean / maxCos) * 100;
+              const isOk = p.status === "ok";
+              return (
+                <tr
+                  key={p.config}
+                  style={{ borderTop: "1px solid var(--color-border)" }}
+                >
+                  <td className="py-1 pr-3 font-mono text-[11.5px]">
+                    {p.config}
+                    {!isOk ? (
+                      <span
+                        className="ml-1 text-[10.5px]"
+                        style={{ color: "var(--color-warn)" }}
+                      >
+                        ({p.status})
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {cosMean.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {cosMin.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {ari.toFixed(3)}
+                  </td>
+                  <td className="py-1 w-[180px]">
+                    <div
+                      className="w-full h-2 rounded"
+                      style={{ backgroundColor: "var(--color-border)" }}
+                    >
+                      <div
+                        className="h-2 rounded"
+                        style={{
+                          width: `${w}%`,
+                          backgroundColor:
+                            cosMean >= 0.95
+                              ? "rgba(40,160,80,0.9)"
+                              : cosMean >= 0.85
+                                ? "rgba(214,140,40,0.9)"
+                                : "rgba(214,39,40,0.9)",
+                        }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function CrossSceneTransferCard({
+  transfer,
+  currentScene,
+}: {
+  transfer: CrossSceneTransfer;
+  currentScene: string;
+}) {
+  const N = transfer.scene_order.length;
+  const labelW = 130;
+  const cell = 80;
+  const cellH = 44;
+  const W = labelW + N * cell + 8;
+  const H = labelW + N * cellH + 8;
+  const curIdx = transfer.scene_order.indexOf(currentScene);
+  const colour = (v: number) => {
+    const t = Math.max(0, Math.min(1, v));
+    const r = Math.round(255 * (1 - t));
+    const g = Math.round(180 * t + 60 * (1 - t));
+    const b = Math.round(60 * t + 60 * (1 - t));
+    return `rgb(${r}, ${g}, ${b})`;
+  };
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <h4
+        className="text-base font-semibold mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Cross-scene transfer · macro F1
+      </h4>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Each cell M[i,j] = train LDA on scene i, freeze, evaluate
+        downstream classifier on scene j. Common wavelength grid{" "}
+        {transfer.common_wavelength_grid.min_nm}–
+        {transfer.common_wavelength_grid.max_nm} nm,{" "}
+        {transfer.common_wavelength_grid.n_bands} bands. Wordification{" "}
+        {transfer.wordification}, Q={transfer.quantization_scale},
+        samples_per_class={transfer.samples_per_class}. Diagonal =
+        self-transfer.
+      </p>
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="max-w-full h-auto"
+          style={{ maxWidth: 1080 }}
+        >
+          {transfer.scene_order.map((sc, j) => (
+            <text
+              key={`c-${sc}`}
+              x={labelW + j * cell + cell / 2}
+              y={labelW - 4}
+              fontSize="10"
+              textAnchor="end"
+              transform={`rotate(-30 ${labelW + j * cell + cell / 2} ${labelW - 4})`}
+              fill={j === curIdx ? "var(--color-accent)" : "currentColor"}
+              opacity={j === curIdx ? 1 : 0.65}
+              fontFamily="ui-monospace, monospace"
+              fontWeight={j === curIdx ? 600 : 400}
+            >
+              → {sc}
+            </text>
+          ))}
+          {transfer.scene_order.map((sc, i) => (
+            <text
+              key={`r-${sc}`}
+              x={labelW - 6}
+              y={labelW + i * cellH + cellH / 2 + 4}
+              fontSize="10"
+              textAnchor="end"
+              fill={i === curIdx ? "var(--color-accent)" : "currentColor"}
+              opacity={i === curIdx ? 1 : 0.65}
+              fontFamily="ui-monospace, monospace"
+              fontWeight={i === curIdx ? 600 : 400}
+            >
+              {sc} →
+            </text>
+          ))}
+          {transfer.transfer_matrix_macro_f1.map((row, i) =>
+            row.map((v, j) => {
+              const isDiag = i === j;
+              const isCurRow = i === curIdx;
+              const isCurCol = j === curIdx;
+              const stroke =
+                isCurRow || isCurCol ? "rgba(56,189,248,1)" : "none";
+              return (
+                <g key={`${i}-${j}`}>
+                  <rect
+                    x={labelW + j * cell}
+                    y={labelW + i * cellH}
+                    width={cell - 1}
+                    height={cellH - 1}
+                    fill={colour(v)}
+                    stroke={stroke}
+                    strokeWidth={
+                      isCurRow && isCurCol
+                        ? 2.5
+                        : isCurRow || isCurCol
+                          ? 1.5
+                          : 0
+                    }
+                  />
+                  <text
+                    x={labelW + j * cell + cell / 2}
+                    y={labelW + i * cellH + cellH / 2 + 2}
+                    fontSize="11"
+                    textAnchor="middle"
+                    fill={v > 0.45 ? "white" : "var(--color-fg)"}
+                    fontFamily="ui-monospace, monospace"
+                    fontWeight={isDiag ? 600 : 400}
+                  >
+                    {v.toFixed(3)}
+                  </text>
+                </g>
+              );
+            }),
+          )}
+        </svg>
+      </div>
+      {curIdx >= 0 ? (
+        <p
+          className="mt-3 text-[11.5px]"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          Highlight: current scene{" "}
+          <strong style={{ color: "var(--color-accent)" }}>
+            {currentScene}
+          </strong>{" "}
+          outlined in row {curIdx} (as source) and column {curIdx} (as
+          target). Self-transfer F1 ={" "}
+          {transfer.transfer_matrix_macro_f1[curIdx]?.[curIdx]?.toFixed(3) ?? "—"}
+          .
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Four code-side cycles since c266-268 deploy (PR #487):

- **c272** PR #488 — Extract RobustnessTab + 2 helpers. Workspace.tsx
  9714 → 9507 LOC. Entry chunk 254 → 248 KB. Cumulative since c262:
  311 → 248 KB (-20%). **9 tabs extracted + lazy**.
- **c273** PR #489 — api/client.ts split slice 3: HIDSAG family
  (8 types → api/hidsag.ts, 130 LOC). client.ts: 1213 → 1128 LOC.
  Cumulative since c261: 1392 → 1128 LOC (-19%).
- **c274** PR #490 — Route 3 builders through research_core.paths:
  build_demo, build_corpus_previews, build_analysis_payload.
  **#444 P1 3.2 progress: 3/13**.
- **c275** PR #491 — Unified build_wordifications_all orchestrator
  via argparse + importlib dispatch. **Closes #444 P1 3.4**.

Paper deploy in PR #18 (paper main d3734ab) lands c276
(Sankey rasterisation at 600 dpi).

## #444 status after this deploy

- 3.1 ✅ closed
- 3.2 🟡 3/13 builders (c274)
- 3.4 ✅ closed (c275)
- 4.1+4.2+4.3 ✅ closed (c260)
- 5.1 ✅ closed (c242 + c256)

## Test plan

- [x] pnpm typecheck + test + build → clean
- [x] pytest → 57 passed
- [ ] update.sh on Hetzner