### PR TITLE
Cycle 278: extract SuperTopicsTab + GatingTab (#441 2.1)

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -85,6 +85,16 @@ const RobustnessTab = lazy(() =>
     default: m.RobustnessTab,
   })),
 );
+const SuperTopicsTab = lazy(() =>
+  import("./workspace/tabs/SuperTopicsTab").then((m) => ({
+    default: m.SuperTopicsTab,
+  })),
+);
+const GatingTab = lazy(() =>
+  import("./workspace/tabs/GatingTab").then((m) => ({
+    default: m.GatingTab,
+  })),
+);
 import { UnmixingStat } from "./workspace/components/StatCard";
 
 const Scatter3D = lazy(() =>
@@ -1140,12 +1150,14 @@ function ExploreStep({
             </Suspense>
           )}
           {tab === "supertopics" && (
-            <SuperTopicsTab
-              sceneId={subsetId!}
-              isLoading={superTopicsQ.isLoading}
-              error={superTopicsQ.error as Error | null}
-              data={superTopicsQ.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <SuperTopicsTab
+                sceneId={subsetId!}
+                isLoading={superTopicsQ.isLoading}
+                error={superTopicsQ.error as Error | null}
+                data={superTopicsQ.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "anomaly" && (
             <Suspense fallback={<TabLoading />}>
@@ -1184,12 +1196,14 @@ function ExploreStep({
             />
           )}
           {tab === "gating" && (
-            <GatingTab
-              isLoading={embedded.isLoading || deepGate.isLoading}
-              error={(embedded.error as Error | null) ?? (deepGate.error as Error | null)}
-              embedded={embedded.data ?? null}
-              deepGate={deepGate.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <GatingTab
+                isLoading={embedded.isLoading || deepGate.isLoading}
+                error={(embedded.error as Error | null) ?? (deepGate.error as Error | null)}
+                embedded={embedded.data ?? null}
+                deepGate={deepGate.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "robust" && (
             <Suspense fallback={<TabLoading />}>
@@ -8879,384 +8893,7 @@ function NeuralSeedStabilityCard({ seedStability }: { seedStability: import("@/a
   );
 }
 
-function GatingTab({
-  isLoading,
-  error,
-  embedded,
-  deepGate,
-}: {
-  isLoading: boolean;
-  error: Error | null;
-  embedded: import("@/api/client").EmbeddedBaseline | null;
-  deepGate: import("@/api/client").TopicRoutedDeepGate | null;
-}) {
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading gating panels…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load gating data.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-6">
-      {embedded ? <EmbeddedBaselineCard embedded={embedded} /> : null}
-      {deepGate ? <DeepGateCard deepGate={deepGate} /> : null}
-    </div>
-  );
-}
 
-function EmbeddedBaselineCard({ embedded }: { embedded: import("@/api/client").EmbeddedBaseline }) {
-  const methods = Object.entries(embedded.method_metrics);
-  const sorted = embedded.ranking_by_macro_f1_mean
-    ? embedded.ranking_by_macro_f1_mean.map((r) => [r.method, embedded.method_metrics[r.method]] as const).filter(([, m]) => !!m)
-    : methods.sort((a, b) => (b[1].macro_f1.mean - a[1].macro_f1.mean));
-  const maxF1 = sorted[0]?.[1]?.macro_f1.mean ?? 1;
-
-  return (
-    <div
-      className="rounded-xl border p-5 relative overflow-hidden"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <div
-        aria-hidden
-        className="absolute top-0 left-0 right-0 h-1"
-        style={{ background: "linear-gradient(90deg, rgba(56,189,248,1) 0%, rgba(170,60,200,1) 100%)" }}
-      />
-      <h3 className="text-lg font-semibold tracking-tight mt-1 mb-1" style={{ color: "var(--color-fg)" }}>
-        Embedded baseline · {embedded.K}-dim concat with theta
-      </h3>
-      <p className="text-[12.5px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Does theta add signal beyond PCA at the same K? Trains a {embedded.head} on
-        (raw / pca_K / theta / theta⊕pca_K) features. {embedded.split} on{" "}
-        {embedded.n_documents.toLocaleString()} documents × {embedded.n_classes} classes. Honest
-        headline (cycles 53-54): the concat <em>theta_concat_pca_K_logistic</em> beats pca_K alone
-        only on Indian Pines (Δ F1 = +0.018, small effect); ties on the other 5 scenes.
-      </p>
-      {embedded.framework_axis ? (
-        <p className="text-[11.5px] italic mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          {embedded.framework_axis}
-        </p>
-      ) : null}
-      <div className="overflow-x-auto">
-        <table className="w-full text-[12.5px]" style={{ color: "var(--color-fg)" }}>
-          <thead>
-            <tr style={{ color: "var(--color-fg-faint)" }}>
-              <th className="text-left font-mono text-[11px] pb-1 pr-3">rank</th>
-              <th className="text-left font-mono text-[11px] pb-1 pr-3">method</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">macro F1</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">accuracy</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">balanced acc</th>
-              <th className="text-left font-mono text-[11px] pb-1">bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map(([m, mm], i) => {
-              if (!mm) return null;
-              const f1 = mm.macro_f1;
-              const norm = f1.mean / Math.max(1e-9, maxF1);
-              return (
-                <tr key={m} style={{ borderTop: "1px solid var(--color-border)" }}>
-                  <td className="py-1 pr-3 font-mono">{i + 1}</td>
-                  <td className="py-1 pr-3 font-mono">{m}</td>
-                  <td className="py-1 pr-3 text-right font-mono">
-                    {f1.mean.toFixed(3)}
-                    {f1.ci95_lo != null && f1.ci95_hi != null ? (
-                      <span className="opacity-70 ml-1 text-[10.5px]">[{f1.ci95_lo.toFixed(3)}, {f1.ci95_hi.toFixed(3)}]</span>
-                    ) : null}
-                  </td>
-                  <td className="py-1 pr-3 text-right font-mono">{mm.accuracy.mean.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono">
-                    {mm.balanced_accuracy ? mm.balanced_accuracy.mean.toFixed(3) : "—"}
-                  </td>
-                  <td className="py-1 w-[180px]">
-                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                      <div className="h-2 rounded" style={{ width: `${norm * 100}%`, backgroundColor: m.includes("concat") ? "rgba(170,60,200,0.9)" : "var(--color-accent)" }} />
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function DeepGateCard({ deepGate }: { deepGate: import("@/api/client").TopicRoutedDeepGate }) {
-  const ranking = deepGate.ranked_by_macro_f1_mean ?? [];
-  const max = ranking[0]?.macro_f1_mean ?? 1;
-  return (
-    <div
-      className="rounded-lg border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-        Routed gating · theta vs deep-encoder gates (axis B-3)
-      </h4>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        The routed classifier conditions on a gate vector. We compare four gates:{" "}
-        <span className="font-mono">{deepGate.gate_methods.join(" · ")}</span>. The question is
-        whether a deep latent (CAE-1D / β-VAE / PCA at the same K) outperforms theta when used as
-        the routing key. {deepGate.n_documents.toLocaleString()} documents × {deepGate.n_classes} classes.
-      </p>
-      <div className="overflow-x-auto">
-        <table className="w-full text-[12.5px]" style={{ color: "var(--color-fg)" }}>
-          <thead>
-            <tr style={{ color: "var(--color-fg-faint)" }}>
-              <th className="text-left font-mono text-[11px] pb-1 pr-3">rank</th>
-              <th className="text-left font-mono text-[11px] pb-1 pr-3">method</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">macro F1</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">CI95</th>
-              <th className="text-left font-mono text-[11px] pb-1">bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            {ranking.map((r, i) => {
-              const norm = r.macro_f1_mean / Math.max(1e-9, max);
-              const isRaw = r.method === "raw_logistic";
-              return (
-                <tr key={r.method} style={{ borderTop: "1px solid var(--color-border)" }}>
-                  <td className="py-1 pr-3 font-mono">{i + 1}</td>
-                  <td className="py-1 pr-3 font-mono">
-                    {r.method}
-                    {isRaw ? <span className="ml-1 text-[10px] uppercase tracking-widest" style={{ color: "var(--color-fg-faint)" }}>baseline</span> : null}
-                  </td>
-                  <td className="py-1 pr-3 text-right font-mono">{r.macro_f1_mean.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono text-[10.5px] opacity-80">
-                    [{r.macro_f1_ci95[0].toFixed(3)}, {r.macro_f1_ci95[1].toFixed(3)}]
-                  </td>
-                  <td className="py-1 w-[180px]">
-                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                      <div className="h-2 rounded" style={{ width: `${norm * 100}%`, backgroundColor: isRaw ? "rgba(214,140,40,0.85)" : "var(--color-accent)" }} />
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-      {deepGate.framework_axis ? (
-        <p className="mt-3 text-[11.5px] italic" style={{ color: "var(--color-fg-faint)" }}>
-          {deepGate.framework_axis}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-function SuperTopicsTab({
-  sceneId,
-  isLoading,
-  error,
-  data,
-}: {
-  sceneId: string;
-  isLoading: boolean;
-  error: Error | null;
-  data: import("@/api/client").SuperTopics | null;
-}) {
-  const [cutLevel, setCutLevel] = useState<number>(8);
-
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading super-topics…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load super-topics.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-  if (!data) return <TabEmpty />;
-
-  const cuts = data.cuts ?? [];
-  const availableCuts = cuts.map((c) => c.cut_level);
-  const selectedCut = cuts.find((c) => c.cut_level === cutLevel) ?? cuts[0];
-  const sceneTopics = data.members
-    .filter((m) => m.scene_id === sceneId)
-    .sort((a, b) => a.topic_k - b.topic_k);
-
-  // Build a map: topic_k -> cluster_id at selected cut
-  const topicToCluster = new Map<number, { clusterId: number; sceneSet: string[]; nMembers: number }>();
-  if (selectedCut) {
-    for (const cluster of selectedCut.clusters) {
-      for (const member of cluster.members) {
-        if (member.scene_id === sceneId) {
-          topicToCluster.set(member.topic_k, {
-            clusterId: cluster.cluster_id,
-            sceneSet: cluster.scene_set,
-            nMembers: cluster.n_members,
-          });
-        }
-      }
-    }
-  }
-
-  return (
-    <div className="space-y-6">
-      <div
-        className="rounded-xl border p-5 relative overflow-hidden"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <div
-          aria-hidden
-          className="absolute top-0 left-0 right-0 h-1"
-          style={{ background: "linear-gradient(90deg, rgba(56,189,248,1) 0%, rgba(170,60,200,1) 100%)" }}
-        />
-        <h3 className="text-lg font-semibold tracking-tight mt-1 mb-1" style={{ color: "var(--color-fg)" }}>
-          Super-topics · cross-scene clustering of all {data.n_topics_total} topics
-        </h3>
-        <p className="text-[12.5px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          Hierarchical clustering ({data.linkage_method} linkage, {data.distance}) over the
-          {" "}{data.n_topics_total} topics across {data.n_scenes} scenes on the common{" "}
-          {data.common_grid.low_nm}–{data.common_grid.high_nm} nm grid ({data.common_grid.n_bands} bands).
-          Shows how this scene's topics relate to topics from the other {data.n_scenes - 1} scenes
-          at the selected cut level.
-        </p>
-        <div className="flex items-baseline gap-1.5 flex-wrap">
-          <span className="text-[11px] uppercase tracking-widest font-semibold mr-2" style={{ color: "var(--color-fg-faint)" }}>
-            Cut level (n clusters)
-          </span>
-          {availableCuts.map((k) => (
-            <button
-              key={`cut-${k}`}
-              type="button"
-              onClick={() => setCutLevel(k)}
-              className="rounded border px-2 py-0.5 text-[11.5px] font-mono"
-              style={{
-                borderColor: cutLevel === k ? "var(--color-accent)" : "var(--color-border)",
-                color: cutLevel === k ? "var(--color-accent)" : "var(--color-fg-faint)",
-                backgroundColor: cutLevel === k ? "var(--color-accent-soft)" : "transparent",
-              }}
-            >
-              K_super = {k}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div
-        className="rounded-lg border p-4"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-          This scene's topics at K_super = {cutLevel}
-        </h4>
-        <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          For each topic of {sceneId}, the cluster it falls into and the other scenes whose topics
-          share that cluster. A cluster shared across many scenes = a generic spectral pattern
-          (vegetation, soil, water); a singleton cluster = scene-specific signature.
-        </p>
-        <div className="overflow-x-auto">
-          <table className="w-full text-[12.5px]" style={{ color: "var(--color-fg)" }}>
-            <thead>
-              <tr style={{ color: "var(--color-fg-faint)" }}>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">topic</th>
-                <th className="text-left font-mono text-[11px] pb-1 pr-3">cluster</th>
-                <th className="text-right font-mono text-[11px] pb-1 pr-3">cluster size</th>
-                <th className="text-left font-mono text-[11px] pb-1">shared with scenes</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sceneTopics.map((m) => {
-                const info = topicToCluster.get(m.topic_k);
-                const colour = TOPIC_COLORS[(m.topic_k - 1) % TOPIC_COLORS.length];
-                const otherScenes = (info?.sceneSet ?? []).filter((s) => s !== sceneId);
-                return (
-                  <tr key={`mt-${m.topic_k}`} style={{ borderTop: "1px solid var(--color-border)" }}>
-                    <td className="py-1 pr-3 font-mono">
-                      <span className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle" style={{ backgroundColor: colour }} />
-                      t{m.topic_k}
-                    </td>
-                    <td className="py-1 pr-3 font-mono">{info ? `#${info.clusterId}` : "—"}</td>
-                    <td className="py-1 pr-3 text-right font-mono">{info ? info.nMembers : "—"}</td>
-                    <td className="py-1">
-                      {otherScenes.length > 0 ? (
-                        <div className="flex flex-wrap gap-1">
-                          {otherScenes.map((sc) => (
-                            <span
-                              key={`os-${m.topic_k}-${sc}`}
-                              className="inline-block rounded px-1.5 py-0.5 text-[10.5px] font-mono"
-                              style={{ backgroundColor: "var(--color-accent-soft)", color: "var(--color-fg-subtle)" }}
-                            >
-                              {sc}
-                            </span>
-                          ))}
-                        </div>
-                      ) : (
-                        <span className="text-[11px] italic" style={{ color: "var(--color-fg-faint)" }}>
-                          singleton (no cross-scene match)
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div
-        className="rounded-lg border p-4"
-        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-      >
-        <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-          All clusters at K_super = {cutLevel}
-        </h4>
-        <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          Overview of every cluster at this cut level. Highlighted clusters contain at least one
-          topic from {sceneId}.
-        </p>
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {(selectedCut?.clusters ?? []).map((cluster) => {
-            const hasCurrent = cluster.scene_set.includes(sceneId);
-            return (
-              <div
-                key={`cluster-${cluster.cluster_id}`}
-                className="rounded-lg border p-3"
-                style={{
-                  borderColor: hasCurrent ? "var(--color-accent)" : "var(--color-border)",
-                  backgroundColor: hasCurrent ? "var(--color-accent-soft)" : "var(--color-panel)",
-                }}
-              >
-                <div className="flex items-baseline justify-between gap-2 mb-1">
-                  <span className="text-[13px] font-semibold font-mono" style={{ color: "var(--color-fg)" }}>
-                    cluster #{cluster.cluster_id}
-                  </span>
-                  <span className="text-[10.5px] font-mono" style={{ color: "var(--color-fg-faint)" }}>
-                    n = {cluster.n_members}
-                  </span>
-                </div>
-                <div className="text-[10.5px] uppercase tracking-widest font-semibold mb-1" style={{ color: "var(--color-fg-faint)" }}>
-                  scenes ({cluster.scene_set.length})
-                </div>
-                <div className="flex flex-wrap gap-1 mb-1">
-                  {cluster.scene_set.map((sc) => (
-                    <span
-                      key={`cl-${cluster.cluster_id}-${sc}`}
-                      className="inline-block rounded px-1.5 py-0.5 text-[10.5px] font-mono"
-                      style={{
-                        backgroundColor: sc === sceneId ? "var(--color-accent)" : "var(--color-bg)",
-                        color: sc === sceneId ? "white" : "var(--color-fg-subtle)",
-                        border: sc === sceneId ? "1px solid var(--color-accent)" : "1px solid var(--color-border)",
-                      }}
-                    >
-                      {sc}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 const TOPIC_AWARE_TABS: { id: ExploreTab; label: string }[] = [
   { id: "topics", label: "Topics" },

--- a/frontend/src/pages/workspace/tabs/GatingTab.tsx
+++ b/frontend/src/pages/workspace/tabs/GatingTab.tsx
@@ -1,0 +1,307 @@
+/**
+ * Routed-gating tab (extracted from Workspace.tsx in c278 as part of
+ * #441 P1 2.1).
+ *
+ * Renders two stacked cards:
+ *   1. EmbeddedBaselineCard — does θ add signal over PCA-K at the same K?
+ *      Trains a logistic head on raw / pca_K / theta / theta⊕pca_K
+ *      feature blocks and ranks them by macro F1.
+ *   2. DeepGateCard — does a deep latent (CAE-1D / β-VAE / PCA) beat
+ *      θ as the routing key in the topic-routed classifier?
+ *
+ * Both helper cards are module-local since only GatingTab consumes them.
+ */
+import type { EmbeddedBaseline, TopicRoutedDeepGate } from "@/api/client";
+
+export function GatingTab({
+  isLoading,
+  error,
+  embedded,
+  deepGate,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  embedded: EmbeddedBaseline | null;
+  deepGate: TopicRoutedDeepGate | null;
+}) {
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        Loading gating panels…
+      </p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load gating data.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      {embedded ? <EmbeddedBaselineCard embedded={embedded} /> : null}
+      {deepGate ? <DeepGateCard deepGate={deepGate} /> : null}
+    </div>
+  );
+}
+
+function EmbeddedBaselineCard({ embedded }: { embedded: EmbeddedBaseline }) {
+  const methods = Object.entries(embedded.method_metrics);
+  const sorted = embedded.ranking_by_macro_f1_mean
+    ? embedded.ranking_by_macro_f1_mean
+        .map(
+          (r) => [r.method, embedded.method_metrics[r.method]] as const,
+        )
+        .filter(([, m]) => !!m)
+    : methods.sort((a, b) => b[1].macro_f1.mean - a[1].macro_f1.mean);
+  const maxF1 = sorted[0]?.[1]?.macro_f1.mean ?? 1;
+
+  return (
+    <div
+      className="rounded-xl border p-5 relative overflow-hidden"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <div
+        aria-hidden
+        className="absolute top-0 left-0 right-0 h-1"
+        style={{
+          background:
+            "linear-gradient(90deg, rgba(56,189,248,1) 0%, rgba(170,60,200,1) 100%)",
+        }}
+      />
+      <h3
+        className="text-lg font-semibold tracking-tight mt-1 mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Embedded baseline · {embedded.K}-dim concat with theta
+      </h3>
+      <p
+        className="text-[12.5px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Does theta add signal beyond PCA at the same K? Trains a{" "}
+        {embedded.head} on (raw / pca_K / theta / theta⊕pca_K) features.{" "}
+        {embedded.split} on {embedded.n_documents.toLocaleString()} documents
+        × {embedded.n_classes} classes. Honest headline (cycles 53-54): the
+        concat <em>theta_concat_pca_K_logistic</em> beats pca_K alone only
+        on Indian Pines (Δ F1 = +0.018, small effect); ties on the other 5
+        scenes.
+      </p>
+      {embedded.framework_axis ? (
+        <p
+          className="text-[11.5px] italic mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {embedded.framework_axis}
+        </p>
+      ) : null}
+      <div className="overflow-x-auto">
+        <table
+          className="w-full text-[12.5px]"
+          style={{ color: "var(--color-fg)" }}
+        >
+          <thead>
+            <tr style={{ color: "var(--color-fg-faint)" }}>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                rank
+              </th>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                method
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                macro F1
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                accuracy
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                balanced acc
+              </th>
+              <th className="text-left font-mono text-[11px] pb-1">bar</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(([m, mm], i) => {
+              if (!mm) return null;
+              const f1 = mm.macro_f1;
+              const norm = f1.mean / Math.max(1e-9, maxF1);
+              return (
+                <tr
+                  key={m}
+                  style={{ borderTop: "1px solid var(--color-border)" }}
+                >
+                  <td className="py-1 pr-3 font-mono">{i + 1}</td>
+                  <td className="py-1 pr-3 font-mono">{m}</td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {f1.mean.toFixed(3)}
+                    {f1.ci95_lo != null && f1.ci95_hi != null ? (
+                      <span className="opacity-70 ml-1 text-[10.5px]">
+                        [{f1.ci95_lo.toFixed(3)}, {f1.ci95_hi.toFixed(3)}]
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {mm.accuracy.mean.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {mm.balanced_accuracy
+                      ? mm.balanced_accuracy.mean.toFixed(3)
+                      : "—"}
+                  </td>
+                  <td className="py-1 w-[180px]">
+                    <div
+                      className="w-full h-2 rounded"
+                      style={{ backgroundColor: "var(--color-border)" }}
+                    >
+                      <div
+                        className="h-2 rounded"
+                        style={{
+                          width: `${norm * 100}%`,
+                          backgroundColor: m.includes("concat")
+                            ? "rgba(170,60,200,0.9)"
+                            : "var(--color-accent)",
+                        }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function DeepGateCard({ deepGate }: { deepGate: TopicRoutedDeepGate }) {
+  const ranking = deepGate.ranked_by_macro_f1_mean ?? [];
+  const max = ranking[0]?.macro_f1_mean ?? 1;
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <h4
+        className="text-base font-semibold mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Routed gating · theta vs deep-encoder gates (axis B-3)
+      </h4>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        The routed classifier conditions on a gate vector. We compare four
+        gates:{" "}
+        <span className="font-mono">{deepGate.gate_methods.join(" · ")}</span>.
+        The question is whether a deep latent (CAE-1D / β-VAE / PCA at the
+        same K) outperforms theta when used as the routing key.{" "}
+        {deepGate.n_documents.toLocaleString()} documents ×{" "}
+        {deepGate.n_classes} classes.
+      </p>
+      <div className="overflow-x-auto">
+        <table
+          className="w-full text-[12.5px]"
+          style={{ color: "var(--color-fg)" }}
+        >
+          <thead>
+            <tr style={{ color: "var(--color-fg-faint)" }}>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                rank
+              </th>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                method
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                macro F1
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                CI95
+              </th>
+              <th className="text-left font-mono text-[11px] pb-1">bar</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ranking.map((r, i) => {
+              const norm = r.macro_f1_mean / Math.max(1e-9, max);
+              const isRaw = r.method === "raw_logistic";
+              return (
+                <tr
+                  key={r.method}
+                  style={{ borderTop: "1px solid var(--color-border)" }}
+                >
+                  <td className="py-1 pr-3 font-mono">{i + 1}</td>
+                  <td className="py-1 pr-3 font-mono">
+                    {r.method}
+                    {isRaw ? (
+                      <span
+                        className="ml-1 text-[10px] uppercase tracking-widest"
+                        style={{ color: "var(--color-fg-faint)" }}
+                      >
+                        baseline
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {r.macro_f1_mean.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono text-[10.5px] opacity-80">
+                    [{r.macro_f1_ci95[0].toFixed(3)},{" "}
+                    {r.macro_f1_ci95[1].toFixed(3)}]
+                  </td>
+                  <td className="py-1 w-[180px]">
+                    <div
+                      className="w-full h-2 rounded"
+                      style={{ backgroundColor: "var(--color-border)" }}
+                    >
+                      <div
+                        className="h-2 rounded"
+                        style={{
+                          width: `${norm * 100}%`,
+                          backgroundColor: isRaw
+                            ? "rgba(214,140,40,0.85)"
+                            : "var(--color-accent)",
+                        }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {deepGate.framework_axis ? (
+        <p
+          className="mt-3 text-[11.5px] italic"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {deepGate.framework_axis}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/workspace/tabs/SuperTopicsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/SuperTopicsTab.tsx
@@ -1,0 +1,342 @@
+/**
+ * Super-topics tab (extracted from Workspace.tsx in c278 as part of
+ * #441 P1 2.1).
+ *
+ * Renders the hierarchical-clustering super-topic view from
+ * `/api/super-topics`: a cut-level selector (4 / 6 / 8 / 10 / 12),
+ * a "this scene's topics" table mapping each topic of the current
+ * scene to the cluster it falls into (and which OTHER scenes share
+ * that cluster), and a grid of every cluster at the current cut
+ * with the current scene highlighted.
+ */
+import { useState } from "react";
+import type { SuperTopics } from "@/api/client";
+import { TOPIC_COLORS } from "@/components/plots/IntertopicMap";
+import { TabEmpty } from "../components/TabStates";
+
+export function SuperTopicsTab({
+  sceneId,
+  isLoading,
+  error,
+  data,
+}: {
+  sceneId: string;
+  isLoading: boolean;
+  error: Error | null;
+  data: SuperTopics | null;
+}) {
+  const [cutLevel, setCutLevel] = useState<number>(8);
+
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>Loading super-topics…</p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load super-topics.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+  if (!data) return <TabEmpty />;
+
+  const cuts = data.cuts ?? [];
+  const availableCuts = cuts.map((c) => c.cut_level);
+  const selectedCut = cuts.find((c) => c.cut_level === cutLevel) ?? cuts[0];
+  const sceneTopics = data.members
+    .filter((m) => m.scene_id === sceneId)
+    .sort((a, b) => a.topic_k - b.topic_k);
+
+  // Build a map: topic_k -> cluster_id at selected cut
+  const topicToCluster = new Map<
+    number,
+    { clusterId: number; sceneSet: string[]; nMembers: number }
+  >();
+  if (selectedCut) {
+    for (const cluster of selectedCut.clusters) {
+      for (const member of cluster.members) {
+        if (member.scene_id === sceneId) {
+          topicToCluster.set(member.topic_k, {
+            clusterId: cluster.cluster_id,
+            sceneSet: cluster.scene_set,
+            nMembers: cluster.n_members,
+          });
+        }
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div
+        className="rounded-xl border p-5 relative overflow-hidden"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <div
+          aria-hidden
+          className="absolute top-0 left-0 right-0 h-1"
+          style={{
+            background:
+              "linear-gradient(90deg, rgba(56,189,248,1) 0%, rgba(170,60,200,1) 100%)",
+          }}
+        />
+        <h3
+          className="text-lg font-semibold tracking-tight mt-1 mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Super-topics · cross-scene clustering of all {data.n_topics_total}{" "}
+          topics
+        </h3>
+        <p
+          className="text-[12.5px] mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          Hierarchical clustering ({data.linkage_method} linkage,{" "}
+          {data.distance}) over the {data.n_topics_total} topics across{" "}
+          {data.n_scenes} scenes on the common {data.common_grid.low_nm}–
+          {data.common_grid.high_nm} nm grid ({data.common_grid.n_bands}{" "}
+          bands). Shows how this scene's topics relate to topics from the
+          other {data.n_scenes - 1} scenes at the selected cut level.
+        </p>
+        <div className="flex items-baseline gap-1.5 flex-wrap">
+          <span
+            className="text-[11px] uppercase tracking-widest font-semibold mr-2"
+            style={{ color: "var(--color-fg-faint)" }}
+          >
+            Cut level (n clusters)
+          </span>
+          {availableCuts.map((k) => (
+            <button
+              key={`cut-${k}`}
+              type="button"
+              onClick={() => setCutLevel(k)}
+              className="rounded border px-2 py-0.5 text-[11.5px] font-mono"
+              style={{
+                borderColor:
+                  cutLevel === k
+                    ? "var(--color-accent)"
+                    : "var(--color-border)",
+                color:
+                  cutLevel === k
+                    ? "var(--color-accent)"
+                    : "var(--color-fg-faint)",
+                backgroundColor:
+                  cutLevel === k
+                    ? "var(--color-accent-soft)"
+                    : "transparent",
+              }}
+            >
+              K_super = {k}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <h4
+          className="text-base font-semibold mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          This scene&apos;s topics at K_super = {cutLevel}
+        </h4>
+        <p
+          className="text-[12px] mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          For each topic of {sceneId}, the cluster it falls into and the
+          other scenes whose topics share that cluster. A cluster shared
+          across many scenes = a generic spectral pattern (vegetation,
+          soil, water); a singleton cluster = scene-specific signature.
+        </p>
+        <div className="overflow-x-auto">
+          <table
+            className="w-full text-[12.5px]"
+            style={{ color: "var(--color-fg)" }}
+          >
+            <thead>
+              <tr style={{ color: "var(--color-fg-faint)" }}>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  topic
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                  cluster
+                </th>
+                <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                  cluster size
+                </th>
+                <th className="text-left font-mono text-[11px] pb-1">
+                  shared with scenes
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sceneTopics.map((m) => {
+                const info = topicToCluster.get(m.topic_k);
+                const colour =
+                  TOPIC_COLORS[(m.topic_k - 1) % TOPIC_COLORS.length];
+                const otherScenes = (info?.sceneSet ?? []).filter(
+                  (s) => s !== sceneId,
+                );
+                return (
+                  <tr
+                    key={`mt-${m.topic_k}`}
+                    style={{ borderTop: "1px solid var(--color-border)" }}
+                  >
+                    <td className="py-1 pr-3 font-mono">
+                      <span
+                        className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
+                        style={{ backgroundColor: colour }}
+                      />
+                      t{m.topic_k}
+                    </td>
+                    <td className="py-1 pr-3 font-mono">
+                      {info ? `#${info.clusterId}` : "—"}
+                    </td>
+                    <td className="py-1 pr-3 text-right font-mono">
+                      {info ? info.nMembers : "—"}
+                    </td>
+                    <td className="py-1">
+                      {otherScenes.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {otherScenes.map((sc) => (
+                            <span
+                              key={`os-${m.topic_k}-${sc}`}
+                              className="inline-block rounded px-1.5 py-0.5 text-[10.5px] font-mono"
+                              style={{
+                                backgroundColor: "var(--color-accent-soft)",
+                                color: "var(--color-fg-subtle)",
+                              }}
+                            >
+                              {sc}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <span
+                          className="text-[11px] italic"
+                          style={{ color: "var(--color-fg-faint)" }}
+                        >
+                          singleton (no cross-scene match)
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <h4
+          className="text-base font-semibold mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          All clusters at K_super = {cutLevel}
+        </h4>
+        <p
+          className="text-[12px] mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          Overview of every cluster at this cut level. Highlighted clusters
+          contain at least one topic from {sceneId}.
+        </p>
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {(selectedCut?.clusters ?? []).map((cluster) => {
+            const hasCurrent = cluster.scene_set.includes(sceneId);
+            return (
+              <div
+                key={`cluster-${cluster.cluster_id}`}
+                className="rounded-lg border p-3"
+                style={{
+                  borderColor: hasCurrent
+                    ? "var(--color-accent)"
+                    : "var(--color-border)",
+                  backgroundColor: hasCurrent
+                    ? "var(--color-accent-soft)"
+                    : "var(--color-panel)",
+                }}
+              >
+                <div className="flex items-baseline justify-between gap-2 mb-1">
+                  <span
+                    className="text-[13px] font-semibold font-mono"
+                    style={{ color: "var(--color-fg)" }}
+                  >
+                    cluster #{cluster.cluster_id}
+                  </span>
+                  <span
+                    className="text-[10.5px] font-mono"
+                    style={{ color: "var(--color-fg-faint)" }}
+                  >
+                    n = {cluster.n_members}
+                  </span>
+                </div>
+                <div
+                  className="text-[10.5px] uppercase tracking-widest font-semibold mb-1"
+                  style={{ color: "var(--color-fg-faint)" }}
+                >
+                  scenes ({cluster.scene_set.length})
+                </div>
+                <div className="flex flex-wrap gap-1 mb-1">
+                  {cluster.scene_set.map((sc) => (
+                    <span
+                      key={`cl-${cluster.cluster_id}-${sc}`}
+                      className="inline-block rounded px-1.5 py-0.5 text-[10.5px] font-mono"
+                      style={{
+                        backgroundColor:
+                          sc === sceneId
+                            ? "var(--color-accent)"
+                            : "var(--color-bg)",
+                        color:
+                          sc === sceneId ? "white" : "var(--color-fg-subtle)",
+                        border:
+                          sc === sceneId
+                            ? "1px solid var(--color-accent)"
+                            : "1px solid var(--color-border)",
+                      }}
+                    >
+                      {sc}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Two more tabs extracted from Workspace.tsx into their own lazy-loaded modules.

## Workspace.tsx impact

| | Before | After |
|---|---|---|
| LOC | 9,514 | **9,144 (-370)** |
| Entry chunk | 248 KB | **235 KB (-13 KB / -5.2%)** |

**Cumulative since c262: 311 → 235 KB (-24%). 11 tabs extracted + lazy**.

## Test plan

- [x] pnpm typecheck → clean
- [x] pnpm test → 30 passed
- [x] pnpm build → Workspace-Bx_rNg7Y.js

SpatialStructureTab + 3 helpers deferred to c284 (the spatial block
is larger / more interconnected and deserves its own focused cycle).