### PR TITLE
c280: route 4 more builders through research_core.paths (#444 P1 3.2 — 7/13)

### DIFF
--- a/data-pipeline/build_exploration_views.py
+++ b/data-pipeline/build_exploration_views.py
@@ -31,10 +31,11 @@ from typing import Any, Iterable
 
 import numpy as np
 
-ROOT = Path(__file__).resolve().parents[1]
-DERIVED = ROOT / "data" / "derived"
-OUT_PATH = DERIVED / "core" / "exploration_views.json"
+# c280: route through research_core.paths.DERIVED_DIR instead of
+# redefining ROOT locally (continues #444 P1 3.2 sweep).
+from research_core.paths import DERIVED_DIR as DERIVED  # noqa: E402
 
+OUT_PATH = DERIVED / "core" / "exploration_views.json"
 REAL_PATH = DERIVED / "real" / "real_samples.json"
 LIBRARY_PATH = DERIVED / "spectral" / "library_samples.json"
 HIDSAG_CURATED_PATH = DERIVED / "core" / "hidsag_curated_subset.json"

--- a/data-pipeline/build_field_samples.py
+++ b/data-pipeline/build_field_samples.py
@@ -5,19 +5,22 @@ import json
 from datetime import datetime, timezone
 import warnings
 from dataclasses import dataclass
-from pathlib import Path
 
 import numpy as np
 from PIL import Image
 from sklearn.decomposition import LatentDirichletAllocation
 from tifffile import imread
 
+# c280: route through research_core.paths instead of redefining ROOT
+# locally (continues #444 P1 3.2 sweep).
+from research_core.paths import DERIVED_DIR
+from research_core.paths import RAW_DIR as _RC_RAW_DIR
+
 
 warnings.filterwarnings("ignore", message=".*GDAL_NODATA.*")
 
-ROOT = Path(__file__).resolve().parents[1]
-RAW_DIR = ROOT / "data" / "raw" / "micasense"
-OUTPUT_DIR = ROOT / "data" / "derived" / "field"
+RAW_DIR = _RC_RAW_DIR / "micasense"
+OUTPUT_DIR = DERIVED_DIR / "field"
 PREVIEW_DIR = OUTPUT_DIR / "previews"
 OUTPUT_PATH = OUTPUT_DIR / "field_samples.json"
 

--- a/data-pipeline/build_real_samples.py
+++ b/data-pipeline/build_real_samples.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Literal
 
 import numpy as np
@@ -18,11 +17,15 @@ from PIL import Image
 from scipy.io import loadmat
 from sklearn.decomposition import LatentDirichletAllocation
 
+# c280: route through research_core.paths instead of redefining ROOT
+# locally (continues #444 P1 3.2 sweep).
+from research_core.paths import DERIVED_DIR
+from research_core.paths import RAW_DIR as _RC_RAW_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-UPV_RAW_DIR = ROOT / "data" / "raw" / "upv_ehu"
-UNMIXING_RAW_DIR = ROOT / "data" / "raw" / "borsoi_mua"
-OUTPUT_DIR = ROOT / "data" / "derived" / "real"
+
+UPV_RAW_DIR = _RC_RAW_DIR / "upv_ehu"
+UNMIXING_RAW_DIR = _RC_RAW_DIR / "borsoi_mua"
+OUTPUT_DIR = DERIVED_DIR / "real"
 PREVIEW_DIR = OUTPUT_DIR / "previews"
 OUTPUT_PATH = OUTPUT_DIR / "real_samples.json"
 

--- a/data-pipeline/build_spectral_library_samples.py
+++ b/data-pipeline/build_spectral_library_samples.py
@@ -5,14 +5,17 @@ import json
 from datetime import datetime, timezone
 import re
 import zipfile
-from pathlib import Path
 
 import numpy as np
 
+# c280: route through research_core.paths instead of redefining ROOT
+# locally (continues #444 P1 3.2 sweep).
+from research_core.paths import DERIVED_DIR
+from research_core.paths import RAW_DIR as _RC_RAW_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-RAW_DIR = ROOT / "data" / "raw" / "usgs_splib07"
-OUTPUT_DIR = ROOT / "data" / "derived" / "spectral"
+
+RAW_DIR = _RC_RAW_DIR / "usgs_splib07"
+OUTPUT_DIR = DERIVED_DIR / "spectral"
 OUTPUT_PATH = OUTPUT_DIR / "library_samples.json"
 
 AVIRIS_WAVELENGTHS_NM = np.linspace(400.0, 2500.0, 224)


### PR DESCRIPTION
## Summary

Continues c274. 4 more of 13 builders now consume research_core.paths
instead of locally redefining ROOT.

## Builders

- build_field_samples
- build_real_samples
- build_spectral_library_samples
- build_exploration_views

## #444 P1 3.2 progress

| Cycle | Builders | Cumulative |
|---|---|---|
| c274 | 3 | 3/13 |
| **c280** | **4** | **7/13** |

Remaining 6: build_hidsag_band_quality, build_hidsag_curated_subset,
build_hidsag_region_documents, build_hidsag_topic_measurements,
build_segmentation_baselines, build_subset_cards.

## Test plan

- [x] py_compile on all 4 → clean
- [x] pytest tests/ → 57 passed