### PR TITLE
Deploy cycles 284-288: spatial tab + agreement tab + 6 builders (#444 3.2 FULLY CLOSED)

### DIFF
--- a/data-pipeline/build_hidsag_band_quality.py
+++ b/data-pipeline/build_hidsag_band_quality.py
@@ -7,10 +7,13 @@ from pathlib import Path
 
 import numpy as np
 
+# c285: route through research_core.paths.CORE_DERIVED_DIR
+# (continues #444 P1 3.2 sweep).
+from research_core.paths import CORE_DERIVED_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-CURATED_PATH = ROOT / "data" / "derived" / "core" / "hidsag_curated_subset.json"
-OUTPUT_PATH = ROOT / "data" / "derived" / "core" / "hidsag_band_quality.json"
+
+CURATED_PATH = CORE_DERIVED_DIR / "hidsag_curated_subset.json"
+OUTPUT_PATH = CORE_DERIVED_DIR / "hidsag_band_quality.json"
 EDGE_TRIM_FRACTION = 0.01
 EDGE_TRIM_MIN = 4
 EDGE_TRIM_MAX = 12

--- a/data-pipeline/build_hidsag_curated_subset.py
+++ b/data-pipeline/build_hidsag_curated_subset.py
@@ -7,15 +7,17 @@ import tempfile
 import zipfile
 from collections import Counter
 from datetime import date
-from pathlib import Path
 
 import h5py
 import numpy as np
 
+# c285: route through research_core.paths (continues #444 P1 3.2 sweep).
+from research_core.paths import CORE_DERIVED_DIR
+from research_core.paths import RAW_DIR as _RC_RAW_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-RAW_DIR = ROOT / "data" / "raw" / "hidsag"
-OUTPUT_PATH = ROOT / "data" / "derived" / "core" / "hidsag_curated_subset.json"
+
+RAW_DIR = _RC_RAW_DIR / "hidsag"
+OUTPUT_PATH = CORE_DERIVED_DIR / "hidsag_curated_subset.json"
 HIDSAG_MODALITY_ORDER = ["swir_low", "vnir_low", "vnir_high"]
 
 

--- a/data-pipeline/build_hidsag_region_documents.py
+++ b/data-pipeline/build_hidsag_region_documents.py
@@ -12,12 +12,15 @@ from pathlib import Path
 import h5py
 import numpy as np
 
+# c285: route through research_core.paths (continues #444 P1 3.2 sweep).
+from research_core.paths import CORE_DERIVED_DIR
+from research_core.paths import RAW_DIR as _RC_RAW_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-RAW_DIR = ROOT / "data" / "raw" / "hidsag"
-CURATED_PATH = ROOT / "data" / "derived" / "core" / "hidsag_curated_subset.json"
-OUTPUT_JSON_PATH = ROOT / "data" / "derived" / "core" / "hidsag_region_documents.json"
-OUTPUT_NPZ_PATH = ROOT / "data" / "derived" / "core" / "hidsag_region_documents.npz"
+
+RAW_DIR = _RC_RAW_DIR / "hidsag"
+CURATED_PATH = CORE_DERIVED_DIR / "hidsag_curated_subset.json"
+OUTPUT_JSON_PATH = CORE_DERIVED_DIR / "hidsag_region_documents.json"
+OUTPUT_NPZ_PATH = CORE_DERIVED_DIR / "hidsag_region_documents.npz"
 HIDSAG_MODALITY_ORDER = ["swir_low", "vnir_low", "vnir_high"]
 PATCH_GRID_ROWS = 3
 PATCH_GRID_COLS = 3

--- a/data-pipeline/build_hidsag_topic_measurements.py
+++ b/data-pipeline/build_hidsag_topic_measurements.py
@@ -57,10 +57,13 @@ from pathlib import Path
 from statistics import mean, median, pstdev
 from typing import Any
 
-REPO = Path(__file__).resolve().parents[1]
-RAW = REPO / "data" / "raw" / "hidsag"
-BAND_MASK = REPO / "data" / "derived" / "band_masks_hidsag"
-OUT = REPO / "data" / "derived" / "hidsag_topic_measurements"
+# c288: route through research_core.paths (closes #444 P1 3.2).
+from research_core.paths import DERIVED_DIR
+from research_core.paths import RAW_DIR as _RC_RAW_DIR
+
+RAW = _RC_RAW_DIR / "hidsag"
+BAND_MASK = DERIVED_DIR / "band_masks_hidsag"
+OUT = DERIVED_DIR / "hidsag_topic_measurements"
 
 SUBSETS = ["GEOMET", "MINERAL1", "MINERAL2", "GEOCHEM", "PORPHYRY"]
 

--- a/data-pipeline/build_segmentation_baselines.py
+++ b/data-pipeline/build_segmentation_baselines.py
@@ -16,10 +16,13 @@ from PIL import Image
 from scipy.io import loadmat
 from skimage.segmentation import slic
 
+# c285: route through research_core.paths (continues #444 P1 3.2 sweep).
+from research_core.paths import DERIVED_DIR
+from research_core.paths import RAW_DIR as _RC_RAW_DIR
 
-ROOT = Path(__file__).resolve().parents[1]
-UPV_RAW_DIR = ROOT / "data" / "raw" / "upv_ehu"
-OUTPUT_DIR = ROOT / "data" / "derived" / "baselines"
+
+UPV_RAW_DIR = _RC_RAW_DIR / "upv_ehu"
+OUTPUT_DIR = DERIVED_DIR / "baselines"
 PREVIEW_DIR = OUTPUT_DIR / "previews"
 OUTPUT_PATH = OUTPUT_DIR / "segmentation_baselines.json"
 

--- a/data-pipeline/build_subset_cards.py
+++ b/data-pipeline/build_subset_cards.py
@@ -24,12 +24,13 @@ from __future__ import annotations
 
 import json
 from datetime import date
-from pathlib import Path
 from typing import Any, Iterable
 
-ROOT = Path(__file__).resolve().parent.parent
-MANIFESTS = ROOT / "data" / "manifests"
-DERIVED = ROOT / "data" / "derived"
+# c288: route through research_core.paths (closes #444 P1 3.2 fully).
+from research_core.paths import DERIVED_DIR as DERIVED
+from research_core.paths import MANIFESTS_DIR as MANIFESTS
+
+
 OUT_DIR = DERIVED / "subsets"
 
 

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -95,6 +95,11 @@ const GatingTab = lazy(() =>
     default: m.GatingTab,
   })),
 );
+const SpatialStructureTab = lazy(() =>
+  import("./workspace/tabs/SpatialStructureTab").then((m) => ({
+    default: m.SpatialStructureTab,
+  })),
+);
 import { UnmixingStat } from "./workspace/components/StatCard";
 
 const Scatter3D = lazy(() =>
@@ -1246,14 +1251,16 @@ function ExploreStep({
             </Suspense>
           )}
           {tab === "spatial" && (
-            <SpatialStructureTab
-              isLoading={topicSpatial.isLoading || groupings.isLoading || groupingsEda.isLoading || topicSpatialFullQ.isLoading}
-              error={(topicSpatial.error as Error | null) ?? (groupings.error as Error | null)}
-              spatial={topicSpatial.data ?? null}
-              spatialFull={topicSpatialFullQ.data ?? null}
-              groupings={groupings.data ?? null}
-              eda={groupingsEda.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <SpatialStructureTab
+                isLoading={topicSpatial.isLoading || groupings.isLoading || groupingsEda.isLoading || topicSpatialFullQ.isLoading}
+                error={(topicSpatial.error as Error | null) ?? (groupings.error as Error | null)}
+                spatial={topicSpatial.data ?? null}
+                spatialFull={topicSpatialFullQ.data ?? null}
+                groupings={groupings.data ?? null}
+                eda={groupingsEda.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "agreement" && (
             <CrossMethodAgreementTab
@@ -7915,285 +7922,6 @@ function InterpretDocumentSample({ docs, K }: { docs: import("@/api/client").Doc
 
 
 
-function SpatialStructureTab({
-  isLoading,
-  error,
-  spatial,
-  spatialFull,
-  groupings,
-  eda,
-}: {
-  isLoading: boolean;
-  error: Error | null;
-  spatial: import("@/api/client").TopicSpatialContinuous | null;
-  spatialFull: import("@/api/client").TopicSpatialFull | null;
-  groupings: import("@/api/client").FelzenszwalbGroupings | null;
-  eda: import("@/api/client").ScenePerScene | null;
-}) {
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading spatial structure…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load spatial data.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-6">
-      {spatial ? <SpatialAutocorrelationCard spatial={spatial} /> : null}
-      {spatialFull ? <SpatialFullCard spatialFull={spatialFull} /> : null}
-      {groupings ? <FelzenszwalbCard groupings={groupings} eda={eda} /> : null}
-    </div>
-  );
-}
-
-function SpatialFullCard({ spatialFull }: { spatialFull: import("@/api/client").TopicSpatialFull }) {
-  const ts = spatialFull.per_topic_continuous_spatial_full;
-  const maxI = Math.max(...ts.map((t) => Math.abs(t.morans_I_continuous_full ?? 0)), 1);
-  const maxC = Math.max(...ts.map((t) => t.gearys_C_continuous_full ?? 0), 1);
-  return (
-    <div
-      className="rounded-lg border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-        Spatial autocorrelation · full labelled set ({spatialFull.n_labelled_pixels.toLocaleString()} pixels)
-      </h4>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Same Moran's I and Geary's C as the previous card, but computed on the LDA refit over the
-        full labelled pixel set (max_iter=40, batch_size=1024) rather than the 220-per-class
-        sub-sample. Values are spatially faithful — useful for honest reporting of cluster
-        compactness. Aggregated Moran's I (mean over topics) ={" "}
-        {spatialFull.aggregated_morans_I_mean_over_topics.toFixed(3)}.
-        {spatialFull.aggregated_gearys_C_mean_over_topics != null ? (
-          <> · Aggregated Geary's C = {spatialFull.aggregated_gearys_C_mean_over_topics.toFixed(3)}.</>
-        ) : null}
-        {spatialFull.boundary_displacement_error != null ? (
-          <> · BDE = {spatialFull.boundary_displacement_error.toFixed(3)}.</>
-        ) : null}
-      </p>
-      {spatialFull.lda_refit_note ? (
-        <p className="text-[11.5px] italic mb-3" style={{ color: "var(--color-fg-faint)" }}>
-          {spatialFull.lda_refit_note}
-        </p>
-      ) : null}
-      <div className="overflow-x-auto">
-        <table className="w-full text-[12px]" style={{ color: "var(--color-fg)" }}>
-          <thead>
-            <tr style={{ color: "var(--color-fg-faint)" }}>
-              <th className="text-left font-mono text-[11px] pb-1 pr-3">topic</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">Moran's I (full)</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">Geary's C (full)</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">mean θ in mask</th>
-              <th className="text-left font-mono text-[11px] pb-1">I bar</th>
-              <th className="text-left font-mono text-[11px] pb-1">C bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            {ts.map((t) => {
-              const I = t.morans_I_continuous_full ?? 0;
-              const C = t.gearys_C_continuous_full ?? 0;
-              const m = t.mean_abundance_in_mask ?? 0;
-              return (
-                <tr key={`full-${t.topic_id}`} style={{ borderTop: "1px solid var(--color-border)" }}>
-                  <td className="py-1 pr-3 font-mono">
-                    <span className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle" style={{ backgroundColor: TOPIC_COLORS[(t.topic_id - 1) % TOPIC_COLORS.length] }} />
-                    t{t.topic_id}
-                  </td>
-                  <td className="py-1 pr-3 text-right font-mono">{I.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono">{C.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono">{m.toFixed(3)}</td>
-                  <td className="py-1 w-[110px]">
-                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                      <div className="h-2 rounded" style={{ width: `${(Math.abs(I) / maxI) * 100}%`, backgroundColor: I >= 0 ? "rgba(40,160,80,0.85)" : "rgba(214,39,40,0.85)" }} />
-                    </div>
-                  </td>
-                  <td className="py-1 w-[110px]">
-                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                      <div className="h-2 rounded" style={{ width: `${(C / maxC) * 100}%`, backgroundColor: "rgba(170,60,200,0.85)" }} />
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function SpatialAutocorrelationCard({ spatial }: { spatial: import("@/api/client").TopicSpatialContinuous }) {
-  const ts = spatial.per_topic_continuous_spatial;
-  const maxI = Math.max(...ts.map((t) => Math.abs(t.morans_I_continuous ?? 0)), 1);
-  const maxC = Math.max(...ts.map((t) => t.gearys_C_continuous ?? 0), 1);
-  return (
-    <div
-      className="rounded-lg border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-        Spatial autocorrelation per topic · {spatial.spatial_shape[0]}×{spatial.spatial_shape[1]} grid
-      </h4>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Moran's I {">"} 0 ⇒ topic clusters spatially (high values cluster with high). Geary's C {"<"} 1
-        ⇒ similar. n_sampled_pixels = {spatial.n_sampled_pixels} on the topic-θ mask. Aggregated
-        Moran's I (mean over topics) = {spatial.aggregated_morans_I_mean_over_topics?.toFixed(3) ?? "—"}.
-      </p>
-      <div className="overflow-x-auto">
-        <table className="w-full text-[12px]" style={{ color: "var(--color-fg)" }}>
-          <thead>
-            <tr style={{ color: "var(--color-fg-faint)" }}>
-              <th className="text-left font-mono text-[11px] pb-1 pr-3">topic</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">Moran's I</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">Geary's C</th>
-              <th className="text-right font-mono text-[11px] pb-1 pr-3">mean θ in mask</th>
-              <th className="text-left font-mono text-[11px] pb-1">I bar</th>
-              <th className="text-left font-mono text-[11px] pb-1">C bar</th>
-            </tr>
-          </thead>
-          <tbody>
-            {ts.map((t) => {
-              const I = t.morans_I_continuous ?? 0;
-              const C = t.gearys_C_continuous ?? 0;
-              const m = t.mean_abundance_in_mask ?? 0;
-              return (
-                <tr key={t.topic_id} style={{ borderTop: "1px solid var(--color-border)" }}>
-                  <td className="py-1 pr-3 font-mono">
-                    <span className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle" style={{ backgroundColor: TOPIC_COLORS[(t.topic_id - 1) % TOPIC_COLORS.length] }} />
-                    t{t.topic_id}
-                  </td>
-                  <td className="py-1 pr-3 text-right font-mono">{I.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono">{C.toFixed(3)}</td>
-                  <td className="py-1 pr-3 text-right font-mono">{m.toFixed(3)}</td>
-                  <td className="py-1 w-[110px]">
-                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                      <div className="h-2 rounded" style={{ width: `${(Math.abs(I) / maxI) * 100}%`, backgroundColor: I >= 0 ? "rgba(40,160,80,0.85)" : "rgba(214,39,40,0.85)" }} />
-                    </div>
-                  </td>
-                  <td className="py-1 w-[110px]">
-                    <div className="w-full h-2 rounded" style={{ backgroundColor: "var(--color-border)" }}>
-                      <div className="h-2 rounded" style={{ width: `${(C / maxC) * 100}%`, backgroundColor: "rgba(56,189,248,0.85)" }} />
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function FelzenszwalbCard({
-  groupings,
-  eda,
-}: {
-  groupings: import("@/api/client").FelzenszwalbGroupings;
-  eda: import("@/api/client").ScenePerScene | null;
-}) {
-  const palette = ["#0072B2", "#D55E00", "#009E73", "#CC79A7", "#F0E442", "#56B4E9", "#E69F00", "#999999"];
-  const showGroups = groupings.mean_spectrum_per_group.slice(0, 8);
-
-  const W = 720;
-  const H = 240;
-  const pad = { l: 44, r: 16, t: 12, b: 32 };
-  const innerW = W - pad.l - pad.r;
-  const innerH = H - pad.t - pad.b;
-
-  const ys = showGroups.flatMap((g) => g.mean);
-  const yLo = ys.length ? Math.min(...ys) : 0;
-  const yHi = ys.length ? Math.max(...ys) : 1;
-  const span = yHi - yLo || 1;
-  const yMin = yLo - span * 0.05;
-  const yMax = yHi + span * 0.05;
-
-  const wavelengths = eda?.wavelengths_nm ?? [];
-  const xMin = wavelengths[0] ?? 0;
-  const xMax = wavelengths[wavelengths.length - 1] ?? (showGroups[0]?.mean.length ?? 1);
-
-  const xScale = (x: number) => pad.l + ((x - xMin) / Math.max(1e-9, xMax - xMin)) * innerW;
-  const yScale = (y: number) => pad.t + innerH - ((y - yMin) / Math.max(1e-9, yMax - yMin)) * innerH;
-
-  return (
-    <div
-      className="rounded-lg border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-        Felzenszwalb groupings · {groupings.n_groups} segments
-      </h4>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Spatial segmentation produces {groupings.n_groups} groups. Between/within variance ratio =
-        {" "}{groupings.between_within_variance_ratio.toFixed(3)} (higher = groups are well-separated
-        compared to their internal scatter). Agreement vs label ARI =
-        {" "}{groupings.agreement_vs_label.ari.toFixed(3)} · NMI =
-        {" "}{groupings.agreement_vs_label.nmi.toFixed(3)} on{" "}
-        {groupings.agreement_vs_label.n_labelled_pixels.toLocaleString()} labelled pixels.
-      </p>
-
-      <div className="grid sm:grid-cols-2 md:grid-cols-5 gap-3 mb-4">
-        <UnmixingStat label="n groups" value={String(groupings.n_groups)} />
-        <UnmixingStat label="size · min / p50 / max" value={`${groupings.group_size_distribution.min} / ${groupings.group_size_distribution.p50} / ${groupings.group_size_distribution.max}`} />
-        <UnmixingStat label="BWVR" value={groupings.between_within_variance_ratio.toFixed(3)} />
-        <UnmixingStat label="ARI vs label" value={groupings.agreement_vs_label.ari.toFixed(3)} />
-        <UnmixingStat label="NMI vs label" value={groupings.agreement_vs_label.nmi.toFixed(3)} />
-      </div>
-
-      <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 900 }}>
-          <line x1={pad.l} y1={pad.t + innerH} x2={pad.l + innerW} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
-          <line x1={pad.l} y1={pad.t} x2={pad.l} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
-          {[0, 0.25, 0.5, 0.75, 1].map((f) => {
-            const wv = xMin + f * (xMax - xMin);
-            const x = pad.l + f * innerW;
-            return (
-              <g key={`xt-${f}`}>
-                <line x1={x} y1={pad.t + innerH} x2={x} y2={pad.t + innerH + 4} stroke="currentColor" opacity={0.4} />
-                <text x={x} y={pad.t + innerH + 16} fontSize="10" textAnchor="middle" fill="currentColor" opacity={0.7} fontFamily="ui-monospace, monospace">
-                  {wavelengths.length > 0 ? `${Math.round(wv)} nm` : Math.round(wv)}
-                </text>
-              </g>
-            );
-          })}
-          {showGroups.map((g, idx) => {
-            const points = g.mean
-              .map((v, i) => {
-                const xv = wavelengths[i] ?? i;
-                return `${xScale(xv).toFixed(2)},${yScale(v).toFixed(2)}`;
-              })
-              .join(" ");
-            return (
-              <polyline
-                key={`g-${g.group_id}`}
-                points={points}
-                fill="none"
-                stroke={palette[idx % palette.length]}
-                strokeWidth={1.4}
-                opacity={0.85}
-              />
-            );
-          })}
-        </svg>
-      </div>
-      <div className="flex flex-wrap gap-1.5 mt-1">
-        {showGroups.map((g, idx) => (
-          <span key={`leg-${g.group_id}`} className="inline-flex items-baseline gap-1 rounded px-1.5 py-0.5 text-[10.5px] font-mono" style={{ backgroundColor: "var(--color-accent-soft)" }}>
-            <span className="inline-block rounded-full w-2 h-2" style={{ backgroundColor: palette[idx % palette.length] }} />
-            group {g.group_id} (n={g.size})
-          </span>
-        ))}
-        {groupings.mean_spectrum_per_group.length > showGroups.length ? (
-          <span className="text-[10.5px] font-mono" style={{ color: "var(--color-fg-faint)" }}>
-            +{groupings.mean_spectrum_per_group.length - showGroups.length} more
-          </span>
-        ) : null}
-      </div>
-    </div>
-  );
-}
 
 function CrossMethodAgreementTab({
   isLoading,

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -100,6 +100,11 @@ const SpatialStructureTab = lazy(() =>
     default: m.SpatialStructureTab,
   })),
 );
+const CrossMethodAgreementTab = lazy(() =>
+  import("./workspace/tabs/CrossMethodAgreementTab").then((m) => ({
+    default: m.CrossMethodAgreementTab,
+  })),
+);
 import { UnmixingStat } from "./workspace/components/StatCard";
 
 const Scatter3D = lazy(() =>
@@ -1263,12 +1268,14 @@ function ExploreStep({
             </Suspense>
           )}
           {tab === "agreement" && (
-            <CrossMethodAgreementTab
-              isLoading={crossMethod.isLoading || narratives.isLoading}
-              error={(crossMethod.error as Error | null) ?? (narratives.error as Error | null)}
-              agreement={crossMethod.data ?? null}
-              narratives={narratives.data ?? null}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <CrossMethodAgreementTab
+                isLoading={crossMethod.isLoading || narratives.isLoading}
+                error={(crossMethod.error as Error | null) ?? (narratives.error as Error | null)}
+                agreement={crossMethod.data ?? null}
+                narratives={narratives.data ?? null}
+              />
+            </Suspense>
           )}
           {tab === "applydoc" && (
             <Suspense fallback={<TabLoading />}>
@@ -7923,204 +7930,6 @@ function InterpretDocumentSample({ docs, K }: { docs: import("@/api/client").Doc
 
 
 
-function CrossMethodAgreementTab({
-  isLoading,
-  error,
-  agreement,
-  narratives,
-}: {
-  isLoading: boolean;
-  error: Error | null;
-  agreement: import("@/api/client").CrossMethodAgreement | null;
-  narratives: import("@/api/client").MethodNarratives | null;
-}) {
-  const [metric, setMetric] = useState<"ari" | "nmi" | "v_measure">("ari");
-  if (isLoading) return <p style={{ color: "var(--color-fg-faint)" }}>Loading cross-method agreement…</p>;
-  if (error) {
-    return (
-      <div className="rounded-lg border p-6" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-        <p style={{ color: "var(--color-warn)" }}>Could not load cross-method agreement.</p>
-        <p className="mt-2 text-sm" style={{ color: "var(--color-fg-faint)" }}>{error.message}</p>
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-6">
-      {agreement ? <AgreementMatrixCard agreement={agreement} metric={metric} setMetric={setMetric} /> : null}
-      {narratives ? <NarrativesGrid narratives={narratives} /> : null}
-    </div>
-  );
-}
-
-function AgreementMatrixCard({
-  agreement,
-  metric,
-  setMetric,
-}: {
-  agreement: import("@/api/client").CrossMethodAgreement;
-  metric: "ari" | "nmi" | "v_measure";
-  setMetric: (m: "ari" | "nmi" | "v_measure") => void;
-}) {
-  const N = agreement.method_names.length;
-  const labelW = 110;
-  const cell = 60;
-  const cellH = 38;
-  const W = labelW + N * cell + 8;
-  const H = labelW + N * cellH + 8;
-  const mat =
-    metric === "ari" ? agreement.ari_matrix
-    : metric === "nmi" ? agreement.nmi_matrix
-    : agreement.v_measure_matrix;
-  const colour = (v: number) => {
-    const t = Math.max(0, Math.min(1, v));
-    const r = Math.round(255 * (1 - t));
-    const g = Math.round(180 * t + 60 * (1 - t));
-    const b = Math.round(60 * t + 60 * (1 - t));
-    return `rgb(${r}, ${g}, ${b})`;
-  };
-  return (
-    <div
-      className="rounded-lg border p-4"
-      style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-    >
-      <div className="flex items-baseline justify-between gap-3 flex-wrap mb-1">
-        <h4 className="text-base font-semibold" style={{ color: "var(--color-fg)" }}>
-          Cross-method agreement · {N}×{N} {metric.toUpperCase()} matrix
-        </h4>
-        <div className="flex items-baseline gap-1.5">
-          {(["ari", "nmi", "v_measure"] as const).map((m) => (
-            <button
-              key={m}
-              type="button"
-              onClick={() => setMetric(m)}
-              className="rounded border px-2 py-0.5 text-[11px] font-mono"
-              style={{
-                borderColor: metric === m ? "var(--color-accent)" : "var(--color-border)",
-                color: metric === m ? "var(--color-accent)" : "var(--color-fg-faint)",
-                backgroundColor: metric === m ? "var(--color-accent-soft)" : "transparent",
-              }}
-            >
-              {m}
-            </button>
-          ))}
-        </div>
-      </div>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Compares dominant-cluster assignments across {N} segmentation/topic methods on the same{" "}
-        {agreement.n_compared_pixels.toLocaleString()} pixels (grid {agreement.spatial_shape[0]}×{agreement.spatial_shape[1]}). High off-diagonal ⇒ methods agree on partition; low ⇒ they
-        disagree.
-      </p>
-      <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 1080 }}>
-          {agreement.method_names.map((m, j) => (
-            <text
-              key={`c-${m}`}
-              x={labelW + j * cell + cell / 2}
-              y={labelW - 4}
-              fontSize="10"
-              textAnchor="end"
-              transform={`rotate(-30 ${labelW + j * cell + cell / 2} ${labelW - 4})`}
-              fill="currentColor"
-              opacity={0.7}
-              fontFamily="ui-monospace, monospace"
-            >
-              {m}
-            </text>
-          ))}
-          {agreement.method_names.map((m, i) => (
-            <text
-              key={`r-${m}`}
-              x={labelW - 6}
-              y={labelW + i * cellH + cellH / 2 + 4}
-              fontSize="10"
-              textAnchor="end"
-              fill="currentColor"
-              opacity={0.7}
-              fontFamily="ui-monospace, monospace"
-            >
-              {m}
-            </text>
-          ))}
-          {mat.map((row, i) =>
-            row.map((v, j) => (
-              <g key={`${i}-${j}`}>
-                <rect x={labelW + j * cell} y={labelW + i * cellH} width={cell - 1} height={cellH - 1} fill={colour(v)} />
-                <text
-                  x={labelW + j * cell + cell / 2}
-                  y={labelW + i * cellH + cellH / 2 + 2}
-                  fontSize="10.5"
-                  textAnchor="middle"
-                  fill={v > 0.5 ? "white" : "var(--color-fg)"}
-                  fontFamily="ui-monospace, monospace"
-                  fontWeight={i === j ? 600 : 400}
-                >
-                  {v.toFixed(2)}
-                </text>
-              </g>
-            )),
-          )}
-        </svg>
-      </div>
-    </div>
-  );
-}
-
-function NarrativesGrid({ narratives }: { narratives: import("@/api/client").MethodNarratives }) {
-  const entries = Object.entries(narratives.method_narratives);
-  return (
-    <div>
-      <h4 className="text-base font-semibold mb-1" style={{ color: "var(--color-fg)" }}>
-        Method narratives · what each method captures
-      </h4>
-      <p className="text-[12px] mb-3" style={{ color: "var(--color-fg-faint)" }}>
-        Per-method summary of what the segmentation/topic method captures: spectral silhouette
-        (via label-as-cluster), agreement vs label (ARI / NMI / V), spatial Moran's I and max-IoU
-        against topic-dominant. "separates / unites / enables" are reserved for narrative text
-        when populated by the builder.
-      </p>
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {entries.map(([method, e]) => {
-          const caps = e.captures || {};
-          const fmt = (v: unknown) =>
-            typeof v === "number" ? (Number.isFinite(v) ? v.toFixed(3) : "—")
-            : v == null ? "—"
-            : String(v);
-          return (
-            <div
-              key={method}
-              className="rounded-lg border p-3"
-              style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)", boxShadow: "var(--color-shadow)" }}
-            >
-              <div className="flex items-baseline justify-between gap-2 mb-1">
-                <span className="text-[13px] font-semibold font-mono" style={{ color: "var(--color-fg)" }}>{method}</span>
-                {typeof caps["ari_vs_label"] === "number" ? (
-                  <span className="text-[10.5px] font-mono px-1.5 py-0.5 rounded" style={{ backgroundColor: "var(--color-accent-soft)", color: "var(--color-accent)" }}>
-                    ARI {fmt(caps["ari_vs_label"])}
-                  </span>
-                ) : null}
-              </div>
-              <div className="space-y-0.5 text-[11.5px] font-mono" style={{ color: "var(--color-fg-faint)" }}>
-                {Object.entries(caps).map(([k, v]) => (
-                  <div key={k} className="flex items-baseline justify-between gap-2">
-                    <span className="truncate" title={k}>{k}</span>
-                    <span style={{ color: "var(--color-fg)" }}>{fmt(v)}</span>
-                  </div>
-                ))}
-              </div>
-              {(e.separates || e.unites || e.enables) ? (
-                <div className="mt-2 space-y-1 text-[11px]" style={{ color: "var(--color-fg)" }}>
-                  {e.separates ? <div><span style={{ color: "var(--color-fg-faint)" }}>separates: </span>{e.separates}</div> : null}
-                  {e.unites ? <div><span style={{ color: "var(--color-fg-faint)" }}>unites: </span>{e.unites}</div> : null}
-                  {e.enables ? <div><span style={{ color: "var(--color-fg-faint)" }}>enables: </span>{e.enables}</div> : null}
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 
 const COMPARE_METHODS = ["pca_8", "nmf_8", "dense_ae_8", "cae_1d_8", "cae_3d_8", "beta_vae_8"] as const;
 type CompareMethod = typeof COMPARE_METHODS[number];

--- a/frontend/src/pages/workspace/tabs/CrossMethodAgreementTab.tsx
+++ b/frontend/src/pages/workspace/tabs/CrossMethodAgreementTab.tsx
@@ -1,0 +1,330 @@
+/**
+ * Cross-method agreement tab (extracted from Workspace.tsx in c287 as
+ * part of #441 P1 2.1).
+ *
+ * Two stacked cards:
+ *   1. AgreementMatrixCard — N×N {ARI, NMI, V-measure} heatmap for
+ *      every method-vs-method comparison on the same pixels.
+ *   2. NarrativesGrid — per-method "what does it capture" card grid.
+ *
+ * Both helpers are module-local; only this tab consumes them.
+ */
+import { useState } from "react";
+import type {
+  CrossMethodAgreement,
+  MethodNarratives,
+} from "@/api/client";
+
+export function CrossMethodAgreementTab({
+  isLoading,
+  error,
+  agreement,
+  narratives,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  agreement: CrossMethodAgreement | null;
+  narratives: MethodNarratives | null;
+}) {
+  const [metric, setMetric] = useState<"ari" | "nmi" | "v_measure">("ari");
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        Loading cross-method agreement…
+      </p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load cross-method agreement.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      {agreement ? (
+        <AgreementMatrixCard
+          agreement={agreement}
+          metric={metric}
+          setMetric={setMetric}
+        />
+      ) : null}
+      {narratives ? <NarrativesGrid narratives={narratives} /> : null}
+    </div>
+  );
+}
+
+function AgreementMatrixCard({
+  agreement,
+  metric,
+  setMetric,
+}: {
+  agreement: CrossMethodAgreement;
+  metric: "ari" | "nmi" | "v_measure";
+  setMetric: (m: "ari" | "nmi" | "v_measure") => void;
+}) {
+  const N = agreement.method_names.length;
+  const labelW = 110;
+  const cell = 60;
+  const cellH = 38;
+  const W = labelW + N * cell + 8;
+  const H = labelW + N * cellH + 8;
+  const mat =
+    metric === "ari"
+      ? agreement.ari_matrix
+      : metric === "nmi"
+        ? agreement.nmi_matrix
+        : agreement.v_measure_matrix;
+  const colour = (v: number) => {
+    const t = Math.max(0, Math.min(1, v));
+    const r = Math.round(255 * (1 - t));
+    const g = Math.round(180 * t + 60 * (1 - t));
+    const b = Math.round(60 * t + 60 * (1 - t));
+    return `rgb(${r}, ${g}, ${b})`;
+  };
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <div className="flex items-baseline justify-between gap-3 flex-wrap mb-1">
+        <h4
+          className="text-base font-semibold"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Cross-method agreement · {N}×{N} {metric.toUpperCase()} matrix
+        </h4>
+        <div className="flex items-baseline gap-1.5">
+          {(["ari", "nmi", "v_measure"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMetric(m)}
+              className="rounded border px-2 py-0.5 text-[11px] font-mono"
+              style={{
+                borderColor:
+                  metric === m
+                    ? "var(--color-accent)"
+                    : "var(--color-border)",
+                color:
+                  metric === m
+                    ? "var(--color-accent)"
+                    : "var(--color-fg-faint)",
+                backgroundColor:
+                  metric === m
+                    ? "var(--color-accent-soft)"
+                    : "transparent",
+              }}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </div>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Compares dominant-cluster assignments across {N} segmentation/topic
+        methods on the same {agreement.n_compared_pixels.toLocaleString()}{" "}
+        pixels (grid {agreement.spatial_shape[0]}×
+        {agreement.spatial_shape[1]}). High off-diagonal ⇒ methods agree on
+        partition; low ⇒ they disagree.
+      </p>
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="max-w-full h-auto"
+          style={{ maxWidth: 1080 }}
+        >
+          {agreement.method_names.map((m, j) => (
+            <text
+              key={`c-${m}`}
+              x={labelW + j * cell + cell / 2}
+              y={labelW - 4}
+              fontSize="10"
+              textAnchor="end"
+              transform={`rotate(-30 ${labelW + j * cell + cell / 2} ${labelW - 4})`}
+              fill="currentColor"
+              opacity={0.7}
+              fontFamily="ui-monospace, monospace"
+            >
+              {m}
+            </text>
+          ))}
+          {agreement.method_names.map((m, i) => (
+            <text
+              key={`r-${m}`}
+              x={labelW - 6}
+              y={labelW + i * cellH + cellH / 2 + 4}
+              fontSize="10"
+              textAnchor="end"
+              fill="currentColor"
+              opacity={0.7}
+              fontFamily="ui-monospace, monospace"
+            >
+              {m}
+            </text>
+          ))}
+          {mat.map((row, i) =>
+            row.map((v, j) => (
+              <g key={`${i}-${j}`}>
+                <rect
+                  x={labelW + j * cell}
+                  y={labelW + i * cellH}
+                  width={cell - 1}
+                  height={cellH - 1}
+                  fill={colour(v)}
+                />
+                <text
+                  x={labelW + j * cell + cell / 2}
+                  y={labelW + i * cellH + cellH / 2 + 2}
+                  fontSize="10.5"
+                  textAnchor="middle"
+                  fill={v > 0.5 ? "white" : "var(--color-fg)"}
+                  fontFamily="ui-monospace, monospace"
+                  fontWeight={i === j ? 600 : 400}
+                >
+                  {v.toFixed(2)}
+                </text>
+              </g>
+            )),
+          )}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function NarrativesGrid({ narratives }: { narratives: MethodNarratives }) {
+  const entries = Object.entries(narratives.method_narratives);
+  return (
+    <div>
+      <h4
+        className="text-base font-semibold mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Method narratives · what each method captures
+      </h4>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Per-method summary of what the segmentation/topic method captures:
+        spectral silhouette (via label-as-cluster), agreement vs label
+        (ARI / NMI / V), spatial Moran&apos;s I and max-IoU against
+        topic-dominant. &quot;separates / unites / enables&quot; are reserved
+        for narrative text when populated by the builder.
+      </p>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {entries.map(([method, e]) => {
+          const caps = e.captures || {};
+          const fmt = (v: unknown) =>
+            typeof v === "number"
+              ? Number.isFinite(v)
+                ? v.toFixed(3)
+                : "—"
+              : v == null
+                ? "—"
+                : String(v);
+          return (
+            <div
+              key={method}
+              className="rounded-lg border p-3"
+              style={{
+                borderColor: "var(--color-border)",
+                backgroundColor: "var(--color-panel)",
+                boxShadow: "var(--color-shadow)",
+              }}
+            >
+              <div className="flex items-baseline justify-between gap-2 mb-1">
+                <span
+                  className="text-[13px] font-semibold font-mono"
+                  style={{ color: "var(--color-fg)" }}
+                >
+                  {method}
+                </span>
+                {typeof caps["ari_vs_label"] === "number" ? (
+                  <span
+                    className="text-[10.5px] font-mono px-1.5 py-0.5 rounded"
+                    style={{
+                      backgroundColor: "var(--color-accent-soft)",
+                      color: "var(--color-accent)",
+                    }}
+                  >
+                    ARI {fmt(caps["ari_vs_label"])}
+                  </span>
+                ) : null}
+              </div>
+              <div
+                className="space-y-0.5 text-[11.5px] font-mono"
+                style={{ color: "var(--color-fg-faint)" }}
+              >
+                {Object.entries(caps).map(([k, v]) => (
+                  <div
+                    key={k}
+                    className="flex items-baseline justify-between gap-2"
+                  >
+                    <span className="truncate" title={k}>
+                      {k}
+                    </span>
+                    <span style={{ color: "var(--color-fg)" }}>{fmt(v)}</span>
+                  </div>
+                ))}
+              </div>
+              {e.separates || e.unites || e.enables ? (
+                <div
+                  className="mt-2 space-y-1 text-[11px]"
+                  style={{ color: "var(--color-fg)" }}
+                >
+                  {e.separates ? (
+                    <div>
+                      <span style={{ color: "var(--color-fg-faint)" }}>
+                        separates:{" "}
+                      </span>
+                      {e.separates}
+                    </div>
+                  ) : null}
+                  {e.unites ? (
+                    <div>
+                      <span style={{ color: "var(--color-fg-faint)" }}>
+                        unites:{" "}
+                      </span>
+                      {e.unites}
+                    </div>
+                  ) : null}
+                  {e.enables ? (
+                    <div>
+                      <span style={{ color: "var(--color-fg-faint)" }}>
+                        enables:{" "}
+                      </span>
+                      {e.enables}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/workspace/tabs/SpatialStructureTab.tsx
+++ b/frontend/src/pages/workspace/tabs/SpatialStructureTab.tsx
@@ -1,0 +1,550 @@
+/**
+ * Spatial-structure tab (extracted from Workspace.tsx in c284 as part
+ * of #441 P1 2.1). Combines three stacked cards:
+ *
+ *   1. SpatialAutocorrelationCard — Moran's I + Geary's C per topic
+ *      on the 220-per-class sub-sample (canonical fit).
+ *   2. SpatialFullCard — same metrics on the LDA refit over the FULL
+ *      labelled pixel set (max_iter=40, batch_size=1024). Used to
+ *      check that the canonical sub-sample numbers don't drift.
+ *   3. FelzenszwalbCard — graph-based image segmentation produced
+ *      from the band-frequency wordification + a 720x240 SVG of
+ *      mean spectra per group.
+ *
+ * The three card components are module-local — only SpatialStructureTab
+ * consumes them.
+ */
+import type {
+  FelzenszwalbGroupings,
+  ScenePerScene,
+  TopicSpatialContinuous,
+  TopicSpatialFull,
+} from "@/api/client";
+import { TOPIC_COLORS } from "@/components/plots/IntertopicMap";
+import { UnmixingStat } from "../components/StatCard";
+
+export function SpatialStructureTab({
+  isLoading,
+  error,
+  spatial,
+  spatialFull,
+  groupings,
+  eda,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  spatial: TopicSpatialContinuous | null;
+  spatialFull: TopicSpatialFull | null;
+  groupings: FelzenszwalbGroupings | null;
+  eda: ScenePerScene | null;
+}) {
+  if (isLoading)
+    return (
+      <p style={{ color: "var(--color-fg-faint)" }}>
+        Loading spatial structure…
+      </p>
+    );
+  if (error) {
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load spatial data.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      {spatial ? <SpatialAutocorrelationCard spatial={spatial} /> : null}
+      {spatialFull ? <SpatialFullCard spatialFull={spatialFull} /> : null}
+      {groupings ? (
+        <FelzenszwalbCard groupings={groupings} eda={eda} />
+      ) : null}
+    </div>
+  );
+}
+
+function SpatialFullCard({
+  spatialFull,
+}: {
+  spatialFull: TopicSpatialFull;
+}) {
+  const ts = spatialFull.per_topic_continuous_spatial_full;
+  const maxI = Math.max(
+    ...ts.map((t) => Math.abs(t.morans_I_continuous_full ?? 0)),
+    1,
+  );
+  const maxC = Math.max(
+    ...ts.map((t) => t.gearys_C_continuous_full ?? 0),
+    1,
+  );
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <h4
+        className="text-base font-semibold mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Spatial autocorrelation · full labelled set (
+        {spatialFull.n_labelled_pixels.toLocaleString()} pixels)
+      </h4>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Same Moran&apos;s I and Geary&apos;s C as the previous card, but
+        computed on the LDA refit over the full labelled pixel set
+        (max_iter=40, batch_size=1024) rather than the 220-per-class
+        sub-sample. Values are spatially faithful — useful for honest
+        reporting of cluster compactness. Aggregated Moran&apos;s I (mean
+        over topics) ={" "}
+        {spatialFull.aggregated_morans_I_mean_over_topics.toFixed(3)}.
+        {spatialFull.aggregated_gearys_C_mean_over_topics != null ? (
+          <>
+            {" "}
+            · Aggregated Geary&apos;s C ={" "}
+            {spatialFull.aggregated_gearys_C_mean_over_topics.toFixed(3)}.
+          </>
+        ) : null}
+        {spatialFull.boundary_displacement_error != null ? (
+          <> · BDE = {spatialFull.boundary_displacement_error.toFixed(3)}.</>
+        ) : null}
+      </p>
+      {spatialFull.lda_refit_note ? (
+        <p
+          className="text-[11.5px] italic mb-3"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {spatialFull.lda_refit_note}
+        </p>
+      ) : null}
+      <div className="overflow-x-auto">
+        <table
+          className="w-full text-[12px]"
+          style={{ color: "var(--color-fg)" }}
+        >
+          <thead>
+            <tr style={{ color: "var(--color-fg-faint)" }}>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                topic
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                Moran&apos;s I (full)
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                Geary&apos;s C (full)
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                mean θ in mask
+              </th>
+              <th className="text-left font-mono text-[11px] pb-1">I bar</th>
+              <th className="text-left font-mono text-[11px] pb-1">C bar</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ts.map((t) => {
+              const I = t.morans_I_continuous_full ?? 0;
+              const C = t.gearys_C_continuous_full ?? 0;
+              const m = t.mean_abundance_in_mask ?? 0;
+              return (
+                <tr
+                  key={`full-${t.topic_id}`}
+                  style={{ borderTop: "1px solid var(--color-border)" }}
+                >
+                  <td className="py-1 pr-3 font-mono">
+                    <span
+                      className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
+                      style={{
+                        backgroundColor:
+                          TOPIC_COLORS[(t.topic_id - 1) % TOPIC_COLORS.length],
+                      }}
+                    />
+                    t{t.topic_id}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {I.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {C.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {m.toFixed(3)}
+                  </td>
+                  <td className="py-1 w-[110px]">
+                    <div
+                      className="w-full h-2 rounded"
+                      style={{ backgroundColor: "var(--color-border)" }}
+                    >
+                      <div
+                        className="h-2 rounded"
+                        style={{
+                          width: `${(Math.abs(I) / maxI) * 100}%`,
+                          backgroundColor:
+                            I >= 0
+                              ? "rgba(40,160,80,0.85)"
+                              : "rgba(214,39,40,0.85)",
+                        }}
+                      />
+                    </div>
+                  </td>
+                  <td className="py-1 w-[110px]">
+                    <div
+                      className="w-full h-2 rounded"
+                      style={{ backgroundColor: "var(--color-border)" }}
+                    >
+                      <div
+                        className="h-2 rounded"
+                        style={{
+                          width: `${(C / maxC) * 100}%`,
+                          backgroundColor: "rgba(170,60,200,0.85)",
+                        }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function SpatialAutocorrelationCard({
+  spatial,
+}: {
+  spatial: TopicSpatialContinuous;
+}) {
+  const ts = spatial.per_topic_continuous_spatial;
+  const maxI = Math.max(
+    ...ts.map((t) => Math.abs(t.morans_I_continuous ?? 0)),
+    1,
+  );
+  const maxC = Math.max(...ts.map((t) => t.gearys_C_continuous ?? 0), 1);
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <h4
+        className="text-base font-semibold mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Spatial autocorrelation per topic · {spatial.spatial_shape[0]}×
+        {spatial.spatial_shape[1]} grid
+      </h4>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Moran&apos;s I {">"} 0 ⇒ topic clusters spatially (high values cluster
+        with high). Geary&apos;s C {"<"} 1 ⇒ similar. n_sampled_pixels ={" "}
+        {spatial.n_sampled_pixels} on the topic-θ mask. Aggregated Moran&apos;s
+        I (mean over topics) ={" "}
+        {spatial.aggregated_morans_I_mean_over_topics?.toFixed(3) ?? "—"}.
+      </p>
+      <div className="overflow-x-auto">
+        <table
+          className="w-full text-[12px]"
+          style={{ color: "var(--color-fg)" }}
+        >
+          <thead>
+            <tr style={{ color: "var(--color-fg-faint)" }}>
+              <th className="text-left font-mono text-[11px] pb-1 pr-3">
+                topic
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                Moran&apos;s I
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                Geary&apos;s C
+              </th>
+              <th className="text-right font-mono text-[11px] pb-1 pr-3">
+                mean θ in mask
+              </th>
+              <th className="text-left font-mono text-[11px] pb-1">I bar</th>
+              <th className="text-left font-mono text-[11px] pb-1">C bar</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ts.map((t) => {
+              const I = t.morans_I_continuous ?? 0;
+              const C = t.gearys_C_continuous ?? 0;
+              const m = t.mean_abundance_in_mask ?? 0;
+              return (
+                <tr
+                  key={t.topic_id}
+                  style={{ borderTop: "1px solid var(--color-border)" }}
+                >
+                  <td className="py-1 pr-3 font-mono">
+                    <span
+                      className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
+                      style={{
+                        backgroundColor:
+                          TOPIC_COLORS[(t.topic_id - 1) % TOPIC_COLORS.length],
+                      }}
+                    />
+                    t{t.topic_id}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {I.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {C.toFixed(3)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono">
+                    {m.toFixed(3)}
+                  </td>
+                  <td className="py-1 w-[110px]">
+                    <div
+                      className="w-full h-2 rounded"
+                      style={{ backgroundColor: "var(--color-border)" }}
+                    >
+                      <div
+                        className="h-2 rounded"
+                        style={{
+                          width: `${(Math.abs(I) / maxI) * 100}%`,
+                          backgroundColor:
+                            I >= 0
+                              ? "rgba(40,160,80,0.85)"
+                              : "rgba(214,39,40,0.85)",
+                        }}
+                      />
+                    </div>
+                  </td>
+                  <td className="py-1 w-[110px]">
+                    <div
+                      className="w-full h-2 rounded"
+                      style={{ backgroundColor: "var(--color-border)" }}
+                    >
+                      <div
+                        className="h-2 rounded"
+                        style={{
+                          width: `${(C / maxC) * 100}%`,
+                          backgroundColor: "rgba(56,189,248,0.85)",
+                        }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function FelzenszwalbCard({
+  groupings,
+  eda,
+}: {
+  groupings: FelzenszwalbGroupings;
+  eda: ScenePerScene | null;
+}) {
+  const palette = [
+    "#0072B2",
+    "#D55E00",
+    "#009E73",
+    "#CC79A7",
+    "#F0E442",
+    "#56B4E9",
+    "#E69F00",
+    "#999999",
+  ];
+  const showGroups = groupings.mean_spectrum_per_group.slice(0, 8);
+
+  const W = 720;
+  const H = 240;
+  const pad = { l: 44, r: 16, t: 12, b: 32 };
+  const innerW = W - pad.l - pad.r;
+  const innerH = H - pad.t - pad.b;
+
+  const ys = showGroups.flatMap((g) => g.mean);
+  const yLo = ys.length ? Math.min(...ys) : 0;
+  const yHi = ys.length ? Math.max(...ys) : 1;
+  const span = yHi - yLo || 1;
+  const yMin = yLo - span * 0.05;
+  const yMax = yHi + span * 0.05;
+
+  const wavelengths = eda?.wavelengths_nm ?? [];
+  const xMin = wavelengths[0] ?? 0;
+  const xMax =
+    wavelengths[wavelengths.length - 1] ??
+    (showGroups[0]?.mean.length ?? 1);
+
+  const xScale = (x: number) =>
+    pad.l + ((x - xMin) / Math.max(1e-9, xMax - xMin)) * innerW;
+  const yScale = (y: number) =>
+    pad.t + innerH - ((y - yMin) / Math.max(1e-9, yMax - yMin)) * innerH;
+
+  return (
+    <div
+      className="rounded-lg border p-4"
+      style={{
+        borderColor: "var(--color-border)",
+        backgroundColor: "var(--color-panel)",
+        boxShadow: "var(--color-shadow)",
+      }}
+    >
+      <h4
+        className="text-base font-semibold mb-1"
+        style={{ color: "var(--color-fg)" }}
+      >
+        Felzenszwalb groupings · {groupings.n_groups} segments
+      </h4>
+      <p
+        className="text-[12px] mb-3"
+        style={{ color: "var(--color-fg-faint)" }}
+      >
+        Spatial segmentation produces {groupings.n_groups} groups.
+        Between/within variance ratio ={" "}
+        {groupings.between_within_variance_ratio.toFixed(3)} (higher = groups
+        are well-separated compared to their internal scatter). Agreement vs
+        label ARI = {groupings.agreement_vs_label.ari.toFixed(3)} · NMI ={" "}
+        {groupings.agreement_vs_label.nmi.toFixed(3)} on{" "}
+        {groupings.agreement_vs_label.n_labelled_pixels.toLocaleString()}{" "}
+        labelled pixels.
+      </p>
+
+      <div className="grid sm:grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+        <UnmixingStat label="n groups" value={String(groupings.n_groups)} />
+        <UnmixingStat
+          label="size · min / p50 / max"
+          value={`${groupings.group_size_distribution.min} / ${groupings.group_size_distribution.p50} / ${groupings.group_size_distribution.max}`}
+        />
+        <UnmixingStat
+          label="BWVR"
+          value={groupings.between_within_variance_ratio.toFixed(3)}
+        />
+        <UnmixingStat
+          label="ARI vs label"
+          value={groupings.agreement_vs_label.ari.toFixed(3)}
+        />
+        <UnmixingStat
+          label="NMI vs label"
+          value={groupings.agreement_vs_label.nmi.toFixed(3)}
+        />
+      </div>
+
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="max-w-full h-auto"
+          style={{ maxWidth: 900 }}
+        >
+          <line
+            x1={pad.l}
+            y1={pad.t + innerH}
+            x2={pad.l + innerW}
+            y2={pad.t + innerH}
+            stroke="currentColor"
+            opacity={0.3}
+          />
+          <line
+            x1={pad.l}
+            y1={pad.t}
+            x2={pad.l}
+            y2={pad.t + innerH}
+            stroke="currentColor"
+            opacity={0.3}
+          />
+          {[0, 0.25, 0.5, 0.75, 1].map((f) => {
+            const wv = xMin + f * (xMax - xMin);
+            const x = pad.l + f * innerW;
+            return (
+              <g key={`xt-${f}`}>
+                <line
+                  x1={x}
+                  y1={pad.t + innerH}
+                  x2={x}
+                  y2={pad.t + innerH + 4}
+                  stroke="currentColor"
+                  opacity={0.4}
+                />
+                <text
+                  x={x}
+                  y={pad.t + innerH + 16}
+                  fontSize="10"
+                  textAnchor="middle"
+                  fill="currentColor"
+                  opacity={0.7}
+                  fontFamily="ui-monospace, monospace"
+                >
+                  {wavelengths.length > 0
+                    ? `${Math.round(wv)} nm`
+                    : Math.round(wv)}
+                </text>
+              </g>
+            );
+          })}
+          {showGroups.map((g, idx) => {
+            const points = g.mean
+              .map((v, i) => {
+                const xv = wavelengths[i] ?? i;
+                return `${xScale(xv).toFixed(2)},${yScale(v).toFixed(2)}`;
+              })
+              .join(" ");
+            return (
+              <polyline
+                key={`g-${g.group_id}`}
+                points={points}
+                fill="none"
+                stroke={palette[idx % palette.length]}
+                strokeWidth={1.4}
+                opacity={0.85}
+              />
+            );
+          })}
+        </svg>
+      </div>
+      <div className="flex flex-wrap gap-1.5 mt-1">
+        {showGroups.map((g, idx) => (
+          <span
+            key={`leg-${g.group_id}`}
+            className="inline-flex items-baseline gap-1 rounded px-1.5 py-0.5 text-[10.5px] font-mono"
+            style={{ backgroundColor: "var(--color-accent-soft)" }}
+          >
+            <span
+              className="inline-block rounded-full w-2 h-2"
+              style={{ backgroundColor: palette[idx % palette.length] }}
+            />
+            group {g.group_id} (n={g.size})
+          </span>
+        ))}
+        {groupings.mean_spectrum_per_group.length > showGroups.length ? (
+          <span
+            className="text-[10.5px] font-mono"
+            style={{ color: "var(--color-fg-faint)" }}
+          >
+            +{groupings.mean_spectrum_per_group.length - showGroups.length} more
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Four code-side cycles since c278+280 deploy (PR #495):

- **c284** PR #496 — Extract SpatialStructureTab + 3 helpers
  (SpatialFullCard, SpatialAutocorrelationCard, FelzenszwalbCard).
  Workspace.tsx 9151 → 8872 LOC; entry chunk 235 → 225 KB.
- **c285** PR #497 — Route 4 more builders through research_core.paths
  (hidsag_band_quality, hidsag_curated_subset, hidsag_region_documents,
  segmentation_baselines). #444 P1 3.2: 7/13 → 11/13.
- **c287** PR #499 — Extract CrossMethodAgreementTab + 2 helpers.
  Workspace.tsx 8872 → 8681 LOC; entry chunk 225 → 220 KB.
- **c288** PR #498 — **Route final 2 builders through research_core
  (hidsag_topic_measurements + subset_cards). #444 P1 3.2 FULLY
  CLOSED at 13/13**.

Cumulative since c262: **Workspace entry chunk 311 → 220 KB (-29%)**;
**13 tabs total extracted + lazy** (out of 28).

## #444 status

All P0/P1 items now closed:
- 3.1 envelope ✅ (c229 + c264)
- 3.2 research_core ✅ **CLOSED** (c274 + c280 + c285 + c288 = 13/13)
- 3.4 wordifications ✅ (c275)
- 4.1 smoke gaps ✅ (c260)
- 4.2 scene-locked smoke ✅ partial (c260)
- 4.3 BASE_URL env ✅ (c260)
- 5.1 zero tests ✅ (c242 + c256)

**Issue #444 ready to close after deploy verifies.**

## Test plan

- [x] pnpm typecheck + test + build → clean
- [x] pytest tests/ → 57 passed
- [ ] update.sh on Hetzner
- [ ] Smoke 133/133 live