### PR TITLE
c307: extract TopicLabelTab + share DocsPerTopicBar (#441 2.1)

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -13,8 +13,6 @@ import {
 import { IntertopicMap, TOPIC_COLORS } from "@/components/plots/IntertopicMap";
 import { TopicGraph } from "@/components/plots/TopicGraph";
 import { SpectralBrowser } from "@/components/plots/SpectralBrowser";
-import { TopicLabelHeatmap } from "@/components/plots/TopicLabelHeatmap";
-import { InverseLabelHeatmap } from "@/components/plots/InverseLabelHeatmap";
 import { TopicSpectrum } from "@/components/plots/TopicSpectrum";
 import { TopicSpectrumComparison } from "@/components/plots/TopicSpectrumComparison";
 import { workspaceMachine } from "@/state/workspaceMachine";
@@ -155,6 +153,11 @@ const RepresentationFitTab = lazy(() =>
 const RawTab = lazy(() =>
   import("./workspace/tabs/RawTab").then((m) => ({
     default: m.RawTab,
+  })),
+);
+const TopicLabelTab = lazy(() =>
+  import("./workspace/tabs/TopicLabelTab").then((m) => ({
+    default: m.TopicLabelTab,
   })),
 );
 import { UnmixingStat } from "./workspace/components/StatCard";
@@ -1137,13 +1140,15 @@ function ExploreStep({
             />
           )}
           {tab === "topiclabel" && (
-            <TopicLabelTab
-              isLoading={topicToData.isLoading}
-              error={topicToData.error as Error | null}
-              data={topicToData.data ?? null}
-              selectedTopic={selectedTopic}
-              setSelectedTopic={setSelectedTopic}
-            />
+            <Suspense fallback={<TabLoading />}>
+              <TopicLabelTab
+                isLoading={topicToData.isLoading}
+                error={topicToData.error as Error | null}
+                data={topicToData.data ?? null}
+                selectedTopic={selectedTopic}
+                setSelectedTopic={setSelectedTopic}
+              />
+            </Suspense>
           )}
           {tab === "routed" && (
             <Suspense fallback={<TabLoading />}>
@@ -2115,303 +2120,6 @@ function DistinguishingWordsColumn({
 }
 
 
-function TopicLabelTab({
-  isLoading,
-  error,
-  data,
-  selectedTopic,
-  setSelectedTopic,
-}: {
-  isLoading: boolean;
-  error: Error | null;
-  data: import("@/api/client").TopicToData | null;
-  selectedTopic: number | null;
-  setSelectedTopic: (k: number | null) => void;
-}) {
-  const [direction, setDirection] = useState<"forward" | "inverse">(
-    "forward",
-  );
-
-  const inverse = useMemo(() => {
-    if (!data) return null;
-    const fwd = data.p_label_given_topic_dominant;
-    const counts = data.docs_per_topic_dominant;
-    const K = fwd.length;
-    const L = fwd[0]?.length ?? 0;
-    if (K === 0 || L === 0) return null;
-    const rows: number[][] = [];
-    const labelMeta: { label_id: number; name: string; color: string }[] = [];
-    for (let l = 0; l < L; l++) {
-      const cell0 = fwd[0]![l]!;
-      labelMeta.push({
-        label_id: cell0.label_id,
-        name: cell0.name,
-        color: cell0.color,
-      });
-      const row = new Array<number>(K).fill(0);
-      let denom = 0;
-      for (let k = 0; k < K; k++) {
-        const p = fwd[k]?.[l]?.p ?? 0;
-        const n = counts[k] ?? 0;
-        const joint = n * p;
-        row[k] = joint;
-        denom += joint;
-      }
-      if (denom > 0) {
-        for (let k = 0; k < K; k++) row[k] = row[k]! / denom;
-      }
-      rows.push(row);
-    }
-    return { matrix: rows, labels: labelMeta, K };
-  }, [data]);
-
-  if (isLoading)
-    return <p style={{ color: "var(--color-fg-faint)" }}>Loading topic–label matrix…</p>;
-  if (error)
-    return (
-      <div
-        className="rounded-lg border p-6"
-        style={{
-          borderColor: "var(--color-border)",
-          backgroundColor: "var(--color-panel)",
-          boxShadow: "var(--color-shadow)",
-        }}
-      >
-        <p style={{ color: "var(--color-warn)" }}>
-          Could not load topic_to_data.
-        </p>
-        <p
-          className="mt-2 text-sm"
-          style={{ color: "var(--color-fg-faint)" }}
-        >
-          {error.message}
-        </p>
-      </div>
-    );
-  if (!data) return <TabEmpty />;
-
-  const matrix = data.p_label_given_topic_dominant;
-
-  return (
-    <div className="space-y-6">
-      <div
-        className="rounded-lg border p-5"
-        style={{
-          borderColor: "var(--color-border)",
-          backgroundColor: "var(--color-panel)",
-          boxShadow: "var(--color-shadow)",
-        }}
-      >
-        <div className="flex items-start justify-between gap-4 mb-2">
-          <h4
-            className="text-base font-semibold"
-            style={{ color: "var(--color-fg)" }}
-          >
-            {direction === "forward"
-              ? "P(label | topic) · dominant assignment"
-              : "P(topic | label) · dominant assignment"}
-          </h4>
-          <div
-            role="tablist"
-            aria-label="Heatmap direction"
-            className="inline-flex rounded-md border"
-            style={{
-              borderColor: "var(--color-border)",
-              backgroundColor: "var(--color-bg)",
-            }}
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={direction === "forward"}
-              onClick={() => setDirection("forward")}
-              className="px-2.5 py-1 text-[12px] rounded-l-md"
-              style={{
-                backgroundColor:
-                  direction === "forward"
-                    ? "var(--color-accent-soft)"
-                    : "transparent",
-                color:
-                  direction === "forward"
-                    ? "var(--color-accent)"
-                    : "var(--color-fg-subtle)",
-              }}
-            >
-              P(label | topic)
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={direction === "inverse"}
-              onClick={() => setDirection("inverse")}
-              className="px-2.5 py-1 text-[12px] rounded-r-md"
-              style={{
-                backgroundColor:
-                  direction === "inverse"
-                    ? "var(--color-accent-soft)"
-                    : "transparent",
-                color:
-                  direction === "inverse"
-                    ? "var(--color-accent)"
-                    : "var(--color-fg-subtle)",
-                borderLeft: "1px solid var(--color-border)",
-              }}
-            >
-              P(topic | label)
-            </button>
-          </div>
-        </div>
-        <p
-          className="text-sm mb-4"
-          style={{ color: "var(--color-fg-faint)" }}
-        >
-          {direction === "forward"
-            ? "Each row is one topic; cells show the fraction of pixels assigned to that topic (by dominant θ) that carry each label. The bordered cell is the dominant per row. Click a row to highlight it and see the detail below."
-            : "Each row is one label; cells show the fraction of pixels carrying that label whose dominant topic is k. Computed as P(t|L) = N_t · P(L|t) / Σ_t' N_t' · P(L|t'). Click a column to select that topic."}
-        </p>
-        <div className="overflow-x-auto">
-          {direction === "forward" ? (
-            <TopicLabelHeatmap
-              matrix={matrix}
-              selectedTopic={selectedTopic}
-              onSelectTopic={(k) =>
-                setSelectedTopic(k === selectedTopic ? null : k)
-              }
-            />
-          ) : inverse ? (
-            <InverseLabelHeatmap
-              matrix={inverse.matrix}
-              labels={inverse.labels}
-              topicCount={inverse.K}
-              selectedTopic={selectedTopic}
-              onSelectTopic={(k) =>
-                setSelectedTopic(k === selectedTopic ? null : k)
-              }
-            />
-          ) : (
-            <p style={{ color: "var(--color-fg-faint)" }}>
-              No inverse matrix to render.
-            </p>
-          )}
-        </div>
-      </div>
-
-      <div
-        className="grid lg:grid-cols-2 gap-5"
-        style={{ color: "var(--color-fg-subtle)" }}
-      >
-        <div
-          className="rounded-lg border p-5"
-          style={{
-            borderColor: "var(--color-border)",
-            backgroundColor: "var(--color-panel)",
-            boxShadow: "var(--color-shadow)",
-          }}
-        >
-          <h4
-            className="text-base font-semibold mb-2"
-            style={{ color: "var(--color-fg)" }}
-          >
-            Documents per topic (dominant assignment)
-          </h4>
-          <p
-            className="text-[12.5px] mb-3"
-            style={{ color: "var(--color-fg-faint)" }}
-          >
-            How many pixels fall into each topic when we apply arg-max over θ.
-            The bar shows the absolute count.
-          </p>
-          <DocsPerTopicBar
-            counts={data.docs_per_topic_dominant}
-            selected={selectedTopic}
-            onSelect={(k) =>
-              setSelectedTopic(k === selectedTopic ? null : k)
-            }
-          />
-        </div>
-        <div
-          className="rounded-lg border p-5"
-          style={{
-            borderColor: "var(--color-border)",
-            backgroundColor: "var(--color-panel)",
-            boxShadow: "var(--color-shadow)",
-          }}
-        >
-          <h4
-            className="text-base font-semibold mb-2"
-            style={{ color: "var(--color-fg)" }}
-          >
-            KL(P(label | topic) ‖ P(label))
-          </h4>
-          <p
-            className="text-[12.5px] mb-3"
-            style={{ color: "var(--color-fg-faint)" }}
-          >
-            KL divergence of P(label | topic) against the global label prior.
-            Topics with high KL are informative about labels; with KL ≈ 0 they
-            are unspecific.
-          </p>
-          <DocsPerTopicBar
-            counts={data.kl_to_label_prior_per_topic}
-            selected={selectedTopic}
-            onSelect={(k) =>
-              setSelectedTopic(k === selectedTopic ? null : k)
-            }
-            isFloat
-          />
-        </div>
-      </div>
-
-      {selectedTopic !== null && matrix[selectedTopic] && (
-        <div
-          className="rounded-lg border p-5"
-          style={{
-            borderColor: "var(--color-border)",
-            backgroundColor: "var(--color-panel)",
-            boxShadow: "var(--color-shadow)",
-          }}
-        >
-          <h4
-            className="text-base font-semibold mb-2"
-            style={{ color: "var(--color-fg)" }}
-          >
-            Detalle del topic {selectedTopic + 1}
-          </h4>
-          <ul className="grid sm:grid-cols-2 gap-x-6 gap-y-1.5 text-[13px]">
-            {[...matrix[selectedTopic]!]
-              .sort((a, b) => b.p - a.p)
-              .map((c) => (
-                <li
-                  key={c.label_id}
-                  className="flex items-center gap-2"
-                  style={{ color: "var(--color-fg-subtle)" }}
-                >
-                  <span
-                    aria-hidden
-                    className="inline-block w-3 h-3 rounded-sm shrink-0"
-                    style={{ backgroundColor: c.color }}
-                  />
-                  <span className="flex-1 truncate">{c.name}</span>
-                  <span
-                    className="font-mono"
-                    style={{ color: "var(--color-fg)" }}
-                  >
-                    {(c.p * 100).toFixed(1)}%
-                  </span>
-                  <span
-                    className="font-mono text-[12px]"
-                    style={{ color: "var(--color-fg-faint)" }}
-                  >
-                    ({c.count})
-                  </span>
-                </li>
-              ))}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
-}
 
 
 function RasterTab({
@@ -3833,67 +3541,6 @@ function FalseColorBandPicker({
           </p>
         </div>
       </div>
-    </div>
-  );
-}
-
-function DocsPerTopicBar({
-  counts,
-  selected,
-  onSelect,
-  isFloat = false,
-}: {
-  counts: number[];
-  selected: number | null;
-  onSelect: (k: number) => void;
-  isFloat?: boolean;
-}) {
-  const max = Math.max(...counts, 1);
-  return (
-    <div className="space-y-1.5">
-      {counts.map((c, k) => {
-        const pct = (c / max) * 100;
-        const isSel = selected === k;
-        const color = TOPIC_COLORS[k % TOPIC_COLORS.length] ?? "#0ea5e9";
-        return (
-          <button
-            key={k}
-            type="button"
-            onClick={() => onSelect(k)}
-            className="w-full flex items-center gap-2 text-left"
-            style={{ cursor: "pointer" }}
-          >
-            <span
-              className="text-[11.5px] font-mono shrink-0 w-16"
-              style={{
-                color: isSel ? "var(--color-accent)" : "var(--color-fg-subtle)",
-                fontWeight: isSel ? 600 : 400,
-              }}
-            >
-              topic {k + 1}
-            </span>
-            <span
-              className="flex-1 h-4 rounded-sm relative overflow-hidden"
-              style={{ backgroundColor: "var(--color-bg)" }}
-            >
-              <span
-                className="absolute inset-y-0 left-0 rounded-sm"
-                style={{
-                  width: `${pct}%`,
-                  backgroundColor: color,
-                  opacity: isSel ? 0.95 : 0.65,
-                }}
-              />
-            </span>
-            <span
-              className="text-[11.5px] font-mono shrink-0 w-16 text-right"
-              style={{ color: "var(--color-fg-subtle)" }}
-            >
-              {isFloat ? c.toFixed(2) : c.toLocaleString()}
-            </span>
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/frontend/src/pages/workspace/components/DocsPerTopicBar.tsx
+++ b/frontend/src/pages/workspace/components/DocsPerTopicBar.tsx
@@ -1,0 +1,64 @@
+import { TOPIC_COLORS } from "@/components/plots/IntertopicMap";
+
+export function DocsPerTopicBar({
+  counts,
+  selected,
+  onSelect,
+  isFloat = false,
+}: {
+  counts: number[];
+  selected: number | null;
+  onSelect: (k: number) => void;
+  isFloat?: boolean;
+}) {
+  const max = Math.max(...counts, 1);
+  return (
+    <div className="space-y-1.5">
+      {counts.map((c, k) => {
+        const pct = (c / max) * 100;
+        const isSel = selected === k;
+        const color = TOPIC_COLORS[k % TOPIC_COLORS.length] ?? "#0ea5e9";
+        return (
+          <button
+            key={k}
+            type="button"
+            onClick={() => onSelect(k)}
+            className="w-full flex items-center gap-2 text-left"
+            style={{ cursor: "pointer" }}
+          >
+            <span
+              className="text-[11.5px] font-mono shrink-0 w-16"
+              style={{
+                color: isSel
+                  ? "var(--color-accent)"
+                  : "var(--color-fg-subtle)",
+                fontWeight: isSel ? 600 : 400,
+              }}
+            >
+              topic {k + 1}
+            </span>
+            <span
+              className="flex-1 h-4 rounded-sm relative overflow-hidden"
+              style={{ backgroundColor: "var(--color-bg)" }}
+            >
+              <span
+                className="absolute inset-y-0 left-0 rounded-sm"
+                style={{
+                  width: `${pct}%`,
+                  backgroundColor: color,
+                  opacity: isSel ? 0.95 : 0.65,
+                }}
+              />
+            </span>
+            <span
+              className="text-[11.5px] font-mono shrink-0 w-16 text-right"
+              style={{ color: "var(--color-fg-subtle)" }}
+            >
+              {isFloat ? c.toFixed(2) : c.toLocaleString()}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
+++ b/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
@@ -1,0 +1,304 @@
+import { useMemo, useState } from "react";
+import type { TopicToData } from "@/api/client";
+import { TopicLabelHeatmap } from "@/components/plots/TopicLabelHeatmap";
+import { InverseLabelHeatmap } from "@/components/plots/InverseLabelHeatmap";
+import { TabEmpty } from "../components/TabStates";
+import { DocsPerTopicBar } from "../components/DocsPerTopicBar";
+
+export function TopicLabelTab({
+  isLoading,
+  error,
+  data,
+  selectedTopic,
+  setSelectedTopic,
+}: {
+  isLoading: boolean;
+  error: Error | null;
+  data: TopicToData | null;
+  selectedTopic: number | null;
+  setSelectedTopic: (k: number | null) => void;
+}) {
+  const [direction, setDirection] = useState<"forward" | "inverse">(
+    "forward",
+  );
+
+  const inverse = useMemo(() => {
+    if (!data) return null;
+    const fwd = data.p_label_given_topic_dominant;
+    const counts = data.docs_per_topic_dominant;
+    const K = fwd.length;
+    const L = fwd[0]?.length ?? 0;
+    if (K === 0 || L === 0) return null;
+    const rows: number[][] = [];
+    const labelMeta: { label_id: number; name: string; color: string }[] = [];
+    for (let l = 0; l < L; l++) {
+      const cell0 = fwd[0]![l]!;
+      labelMeta.push({
+        label_id: cell0.label_id,
+        name: cell0.name,
+        color: cell0.color,
+      });
+      const row = new Array<number>(K).fill(0);
+      let denom = 0;
+      for (let k = 0; k < K; k++) {
+        const p = fwd[k]?.[l]?.p ?? 0;
+        const n = counts[k] ?? 0;
+        const joint = n * p;
+        row[k] = joint;
+        denom += joint;
+      }
+      if (denom > 0) {
+        for (let k = 0; k < K; k++) row[k] = row[k]! / denom;
+      }
+      rows.push(row);
+    }
+    return { matrix: rows, labels: labelMeta, K };
+  }, [data]);
+
+  if (isLoading)
+    return <p style={{ color: "var(--color-fg-faint)" }}>Loading topic–label matrix…</p>;
+  if (error)
+    return (
+      <div
+        className="rounded-lg border p-6"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <p style={{ color: "var(--color-warn)" }}>
+          Could not load topic_to_data.
+        </p>
+        <p
+          className="mt-2 text-sm"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {error.message}
+        </p>
+      </div>
+    );
+  if (!data) return <TabEmpty />;
+
+  const matrix = data.p_label_given_topic_dominant;
+
+  return (
+    <div className="space-y-6">
+      <div
+        className="rounded-lg border p-5"
+        style={{
+          borderColor: "var(--color-border)",
+          backgroundColor: "var(--color-panel)",
+          boxShadow: "var(--color-shadow)",
+        }}
+      >
+        <div className="flex items-start justify-between gap-4 mb-2">
+          <h4
+            className="text-base font-semibold"
+            style={{ color: "var(--color-fg)" }}
+          >
+            {direction === "forward"
+              ? "P(label | topic) · dominant assignment"
+              : "P(topic | label) · dominant assignment"}
+          </h4>
+          <div
+            role="tablist"
+            aria-label="Heatmap direction"
+            className="inline-flex rounded-md border"
+            style={{
+              borderColor: "var(--color-border)",
+              backgroundColor: "var(--color-bg)",
+            }}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={direction === "forward"}
+              onClick={() => setDirection("forward")}
+              className="px-2.5 py-1 text-[12px] rounded-l-md"
+              style={{
+                backgroundColor:
+                  direction === "forward"
+                    ? "var(--color-accent-soft)"
+                    : "transparent",
+                color:
+                  direction === "forward"
+                    ? "var(--color-accent)"
+                    : "var(--color-fg-subtle)",
+              }}
+            >
+              P(label | topic)
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={direction === "inverse"}
+              onClick={() => setDirection("inverse")}
+              className="px-2.5 py-1 text-[12px] rounded-r-md"
+              style={{
+                backgroundColor:
+                  direction === "inverse"
+                    ? "var(--color-accent-soft)"
+                    : "transparent",
+                color:
+                  direction === "inverse"
+                    ? "var(--color-accent)"
+                    : "var(--color-fg-subtle)",
+                borderLeft: "1px solid var(--color-border)",
+              }}
+            >
+              P(topic | label)
+            </button>
+          </div>
+        </div>
+        <p
+          className="text-sm mb-4"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {direction === "forward"
+            ? "Each row is one topic; cells show the fraction of pixels assigned to that topic (by dominant θ) that carry each label. The bordered cell is the dominant per row. Click a row to highlight it and see the detail below."
+            : "Each row is one label; cells show the fraction of pixels carrying that label whose dominant topic is k. Computed as P(t|L) = N_t · P(L|t) / Σ_t' N_t' · P(L|t'). Click a column to select that topic."}
+        </p>
+        <div className="overflow-x-auto">
+          {direction === "forward" ? (
+            <TopicLabelHeatmap
+              matrix={matrix}
+              selectedTopic={selectedTopic}
+              onSelectTopic={(k) =>
+                setSelectedTopic(k === selectedTopic ? null : k)
+              }
+            />
+          ) : inverse ? (
+            <InverseLabelHeatmap
+              matrix={inverse.matrix}
+              labels={inverse.labels}
+              topicCount={inverse.K}
+              selectedTopic={selectedTopic}
+              onSelectTopic={(k) =>
+                setSelectedTopic(k === selectedTopic ? null : k)
+              }
+            />
+          ) : (
+            <p style={{ color: "var(--color-fg-faint)" }}>
+              No inverse matrix to render.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div
+        className="grid lg:grid-cols-2 gap-5"
+        style={{ color: "var(--color-fg-subtle)" }}
+      >
+        <div
+          className="rounded-lg border p-5"
+          style={{
+            borderColor: "var(--color-border)",
+            backgroundColor: "var(--color-panel)",
+            boxShadow: "var(--color-shadow)",
+          }}
+        >
+          <h4
+            className="text-base font-semibold mb-2"
+            style={{ color: "var(--color-fg)" }}
+          >
+            Documents per topic (dominant assignment)
+          </h4>
+          <p
+            className="text-[12.5px] mb-3"
+            style={{ color: "var(--color-fg-faint)" }}
+          >
+            How many pixels fall into each topic when we apply arg-max over θ.
+            The bar shows the absolute count.
+          </p>
+          <DocsPerTopicBar
+            counts={data.docs_per_topic_dominant}
+            selected={selectedTopic}
+            onSelect={(k) =>
+              setSelectedTopic(k === selectedTopic ? null : k)
+            }
+          />
+        </div>
+        <div
+          className="rounded-lg border p-5"
+          style={{
+            borderColor: "var(--color-border)",
+            backgroundColor: "var(--color-panel)",
+            boxShadow: "var(--color-shadow)",
+          }}
+        >
+          <h4
+            className="text-base font-semibold mb-2"
+            style={{ color: "var(--color-fg)" }}
+          >
+            KL(P(label | topic) ‖ P(label))
+          </h4>
+          <p
+            className="text-[12.5px] mb-3"
+            style={{ color: "var(--color-fg-faint)" }}
+          >
+            KL divergence of P(label | topic) against the global label prior.
+            Topics with high KL are informative about labels; with KL ≈ 0 they
+            are unspecific.
+          </p>
+          <DocsPerTopicBar
+            counts={data.kl_to_label_prior_per_topic}
+            selected={selectedTopic}
+            onSelect={(k) =>
+              setSelectedTopic(k === selectedTopic ? null : k)
+            }
+            isFloat
+          />
+        </div>
+      </div>
+
+      {selectedTopic !== null && matrix[selectedTopic] && (
+        <div
+          className="rounded-lg border p-5"
+          style={{
+            borderColor: "var(--color-border)",
+            backgroundColor: "var(--color-panel)",
+            boxShadow: "var(--color-shadow)",
+          }}
+        >
+          <h4
+            className="text-base font-semibold mb-2"
+            style={{ color: "var(--color-fg)" }}
+          >
+            Detalle del topic {selectedTopic + 1}
+          </h4>
+          <ul className="grid sm:grid-cols-2 gap-x-6 gap-y-1.5 text-[13px]">
+            {[...matrix[selectedTopic]!]
+              .sort((a, b) => b.p - a.p)
+              .map((c) => (
+                <li
+                  key={c.label_id}
+                  className="flex items-center gap-2"
+                  style={{ color: "var(--color-fg-subtle)" }}
+                >
+                  <span
+                    aria-hidden
+                    className="inline-block w-3 h-3 rounded-sm shrink-0"
+                    style={{ backgroundColor: c.color }}
+                  />
+                  <span className="flex-1 truncate">{c.name}</span>
+                  <span
+                    className="font-mono"
+                    style={{ color: "var(--color-fg)" }}
+                  >
+                    {(c.p * 100).toFixed(1)}%
+                  </span>
+                  <span
+                    className="font-mono text-[12px]"
+                    style={{ color: "var(--color-fg-faint)" }}
+                  >
+                    ({c.count})
+                  </span>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Lazy-load TopicLabelTab (P(label|topic) and P(topic|label) heatmaps + per-topic detail). Shares DocsPerTopicBar helper to workspace/components/DocsPerTopicBar.tsx so future TopicsTab extraction can import it from the shared module.

Workspace.tsx 5544 → 5183 LOC. Entry chunk **143.26 → 133.37 KB** (-9.9 KB). 25 of 28 tabs extracted + lazy.

- typecheck clean, 44/44 tests pass
- removed newly-unused TopicLabelHeatmap + InverseLabelHeatmap + DocsPerTopicBar imports from Workspace.tsx
- new chunk: TopicLabelTab--cVro3AH.js 10.49 KB

Refs #441 P1 2.1.