### PR TITLE
c322: i18n residual Spanish-leak cleanup (#441 P1 2.3 + P1 2.6)

### DIFF
--- a/frontend/src/pages/Benchmarks.tsx
+++ b/frontend/src/pages/Benchmarks.tsx
@@ -103,7 +103,7 @@ export default function Benchmarks() {
           }}
         >
           <p style={{ color: "var(--color-warn)" }}>
-            No se pudo cargar /api/method-statistics.
+            Could not load /api/method-statistics.
           </p>
           <p
             className="mt-2 text-sm"

--- a/frontend/src/pages/Databases.tsx
+++ b/frontend/src/pages/Databases.tsx
@@ -169,7 +169,7 @@ function FamilyTabs({
   return (
     <nav
       role="tablist"
-      aria-label="Familias de datasets"
+      aria-label="Dataset families"
       className="flex flex-wrap gap-2 mt-6 border-b pb-3"
       style={{ borderColor: "var(--color-border)" }}
     >

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -214,8 +214,8 @@ const FAMILY_DESCRIPTIONS: Record<string, string> = {
 };
 
 const STEPS: { id: string; key: keyof Steps; label: string }[] = [
-  { id: "family", key: "family", label: "Familia" },
-  { id: "subset", key: "subset", label: "Conjunto" },
+  { id: "family", key: "family", label: "Dataset family" },
+  { id: "subset", key: "subset", label: "Subset" },
   { id: "representation", key: "representation", label: "Representation" },
   { id: "explore", key: "explore", label: "Explore"},
 ];

--- a/frontend/src/pages/benchmarks/BenchmarksHidsag.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksHidsag.tsx
@@ -35,7 +35,7 @@ function HidsagCrossPreprocessingStability() {
   return (
     <Section
       id="hidsag-cross-preproc-stability"
-      title="HIDSAG — estabilidad cross-preprocessing (B-6 follow-up)"
+      title="HIDSAG — cross-preprocessing stability (B-6 follow-up)"
       lead="How stable LDA topics are when the preprocessing recipe changes. Reported as Hungarian-matched top-15 token Jaccard across the 4 policies (raw / heuristic-band-mask / SNV / SavGol+SNV). Low = topics change substantially across recipes; high = topics survive."
     >
       <div className="space-y-4 mt-2">
@@ -194,12 +194,12 @@ function HidsagPreprocessing() {
   return (
     <Section
       id="hidsag-preprocessing"
-      title="HIDSAG — sensibilidad al pre-procesamiento espectral"
+      title="HIDSAG — spectral preprocessing sensitivity"
       lead="Four preprocessing policies (raw / heuristic-bad-band-mask / SNV / Savitzky-Golay+SNV) over the 5 HIDSAG scenes. Measures how downstream performance (classification + regression) changes when the spectral cleaning recipe varies."
     >
       {isLoading && (
         <p style={{ color: "var(--color-fg-faint)" }}>
-          Cargando sensibilidad de pre-procesamiento…
+          Loading preprocessing sensitivity…
         </p>
       )}
       {error && (
@@ -211,7 +211,7 @@ function HidsagPreprocessing() {
           }}
         >
           <p style={{ color: "var(--color-warn)" }}>
-            No se pudo cargar /api/hidsag-preprocessing-sensitivity.
+            Could not load /api/hidsag-preprocessing-sensitivity.
           </p>
           <p
             className="mt-2 text-sm"
@@ -418,7 +418,7 @@ function HidsagBenchmarks() {
     >
       {loading && (
         <p style={{ color: "var(--color-fg-faint)" }}>
-          Cargando rankings HIDSAG…
+          Loading HIDSAG rankings…
         </p>
       )}
       <div className="space-y-6 mt-2">

--- a/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
@@ -164,7 +164,7 @@ function SceneForest({ scene }: { scene: SceneMethodStats }) {
         >
           K={scene.scene_summary.topic_count} · D=
           {scene.scene_summary.sampled_documents} ·{" "}
-          {scene.scene_summary.class_count} clases
+          {scene.scene_summary.class_count} classes
         </span>
       </header>
       <svg

--- a/frontend/src/pages/workspace/tabs/Embed3DTab.tsx
+++ b/frontend/src/pages/workspace/tabs/Embed3DTab.tsx
@@ -98,7 +98,7 @@ export function Embed3DTab({
               className="text-[11px] uppercase tracking-wider"
               style={{ color: "var(--color-fg-faint)" }}
             >
-              colouredr por
+              coloured by
             </span>
             <select
               value={colorBy}

--- a/frontend/src/pages/workspace/tabs/MetricsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/MetricsTab.tsx
@@ -287,7 +287,7 @@ function MutualInfoTable({ data }: { data: MutualInformation }) {
       >
         Label entropy H(y) = {data.label_entropy_nats.toFixed(3)} nats (
         {data.label_entropy_bits.toFixed(3)} bits) ·{" "}
-        {data.n_documents.toLocaleString()} documentos.
+        {data.n_documents.toLocaleString()} documents.
       </p>
       <table
         className="w-full text-[13.5px]"
@@ -303,7 +303,7 @@ function MutualInfoTable({ data }: { data: MutualInformation }) {
             <th className="text-left py-2 pr-4 font-semibold">Method</th>
             <th className="text-right py-2 pr-4 font-semibold">Latent dim</th>
             <th className="text-right py-2 pr-4 font-semibold">Joint MI</th>
-            <th className="text-right py-2 font-semibold">% H(y) recuperada</th>
+            <th className="text-right py-2 font-semibold">% H(y) recovered</th>
           </tr>
         </thead>
         <tbody>

--- a/frontend/src/pages/workspace/tabs/RasterTab.tsx
+++ b/frontend/src/pages/workspace/tabs/RasterTab.tsx
@@ -147,7 +147,7 @@ export function RasterTab({
             className="text-base font-semibold"
             style={{ color: "var(--color-fg)" }}
           >
-            Mapa espacial — topic dominante por pixel
+            Spatial map — dominant topic per pixel
           </h4>
           <p
             className="text-sm mt-1"

--- a/frontend/src/pages/workspace/tabs/RawTab.tsx
+++ b/frontend/src/pages/workspace/tabs/RawTab.tsx
@@ -351,11 +351,11 @@ function SceneStats({
       value: data.sensor,
     },
     {
-      label: "Forma",
+      label: "Shape",
       value: `${data.spatial_shape[0]} × ${data.spatial_shape[1]}`,
     },
     {
-      label: "Bandas",
+      label: "Bands",
       value: `${data.wavelengths_nm.length} (${Math.round(
         data.wavelengths_nm[0]!,
       )}–${Math.round(data.wavelengths_nm.at(-1)!)} nm)`,
@@ -365,11 +365,11 @@ function SceneStats({
       value: `${data.n_labelled_pixels.toLocaleString()} / ${data.n_pixels.toLocaleString()}`,
     },
     {
-      label: "Clases",
+      label: "Classes",
       value: String(data.n_classes),
     },
     {
-      label: "Gini desbalance",
+      label: "Gini imbalance",
       value: data.imbalance_gini.toFixed(3),
     },
   ];

--- a/frontend/src/pages/workspace/tabs/RoutedTab.tsx
+++ b/frontend/src/pages/workspace/tabs/RoutedTab.tsx
@@ -102,11 +102,10 @@ export function RoutedTab({
             className="text-sm mt-1"
             style={{ color: "var(--color-fg-faint)" }}
           >
-            K={data.K} topics · {data.n_classes} clases ·{" "}
+            K={data.K} topics · {data.n_classes} classes ·{" "}
             {data.n_documents.toLocaleString()} documents. Five methods
             compared; routed_soft is the one the methodology supports
-            (especialista por topic sobre el espectro crudo, mezclado por
-            theta).
+            (per-topic specialist over the raw spectrum, mixed by theta).
           </p>
         </header>
         <svg

--- a/frontend/src/pages/workspace/tabs/SpectralBrowserTab.tsx
+++ b/frontend/src/pages/workspace/tabs/SpectralBrowserTab.tsx
@@ -96,14 +96,14 @@ export function SpectralBrowserTab({
               className="text-base font-semibold"
               style={{ color: "var(--color-fg)" }}
             >
-              Browser espectral · {meta.N.toLocaleString()} espectros muestreados
+              Spectral browser · {meta.N.toLocaleString()} sampled spectra
             </h4>
             <p
               className="text-sm mt-1"
               style={{ color: "var(--color-fg-faint)" }}
             >
               Each line is a real pixel (not an average); subsample{" "}
-              {meta.sampling_strategy}. {meta.B} bandas (
+              {meta.sampling_strategy}. {meta.B} bands (
               {Math.round(meta.wavelengths_nm[0]!)}–
               {Math.round(meta.wavelengths_nm[meta.wavelengths_nm.length - 1]!)}{" "}
               nm). Click a class to isolate it; reduce the rendered line count
@@ -175,7 +175,7 @@ export function SpectralBrowserTab({
                   : "var(--color-fg-subtle)",
             }}
           >
-            Todas
+            All
           </button>
           {labels.map((l) => {
             const isSel = isolatedLabel === l.label_id;
@@ -198,7 +198,7 @@ export function SpectralBrowserTab({
                     ? "var(--color-fg)"
                     : "var(--color-fg-subtle)",
                 }}
-                title={`${l.count} espectros`}
+                title={`${l.count} spectra`}
               >
                 <span
                   aria-hidden

--- a/frontend/src/pages/workspace/tabs/StabilityTab.tsx
+++ b/frontend/src/pages/workspace/tabs/StabilityTab.tsx
@@ -607,7 +607,7 @@ function StabilityTabBody({
           className="text-base font-semibold mb-2"
           style={{ color: "var(--color-fg)" }}
         >
-          Estabilidad por topic · matched-cosine vs seed 0
+          Per-topic stability · matched-cosine vs seed 0
         </h4>
         <p
           className="text-sm mb-4"

--- a/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
+++ b/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
@@ -265,7 +265,7 @@ export function TopicLabelTab({
             className="text-base font-semibold mb-2"
             style={{ color: "var(--color-fg)" }}
           >
-            Detalle del topic {selectedTopic + 1}
+            Topic {selectedTopic + 1} · detail
           </h4>
           <ul className="grid sm:grid-cols-2 gap-x-6 gap-y-1.5 text-[13px]">
             {[...matrix[selectedTopic]!]

--- a/frontend/src/pages/workspace/tabs/TopicsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/TopicsTab.tsx
@@ -86,14 +86,14 @@ export function TopicsTab({
             className="text-base font-semibold mb-2"
             style={{ color: "var(--color-fg)" }}
           >
-            Mapa intertopic (LDAvis · JS-MDS 2D)
+            Intertopic map (LDAvis · JS-MDS 2D)
           </h4>
           <p
             className="text-sm mb-3"
             style={{ color: "var(--color-fg-faint)" }}
           >
             The bubble area is proportional to topic prevalence
-            (mean θ sobre el corpus). Click en un bubble para enfocar.
+            (mean θ across the corpus). Click a bubble to focus.
           </p>
           <IntertopicMap
             coords={data.topic_intertopic_2d_js}
@@ -116,7 +116,7 @@ export function TopicsTab({
               className="text-base font-semibold"
               style={{ color: "var(--color-fg)" }}
             >
-              Top-30 palabras —{" "}
+              Top-30 words —{" "}
               {selectedTopic !== null
                 ? `topic ${selectedTopic + 1}`
                 : "select a topic"}
@@ -151,8 +151,8 @@ export function TopicsTab({
             style={{ color: "var(--color-fg-faint)" }}
           >
             relevance(w | k) = λ · log P(w | k) + (1 − λ) · log [ P(w | k) /
-            P(w) ]. λ=1 ordena por probabilidad sin penalizar palabras
-            comunes; λ=0 ordena por lift puro.
+            P(w) ]. λ=1 sorts by probability without penalising common
+            words; λ=0 sorts by pure lift.
           </p>
           {focused ? (
             <ol
@@ -185,7 +185,7 @@ export function TopicsTab({
           className="text-base font-semibold mb-2"
           style={{ color: "var(--color-fg)" }}
         >
-          Perfiles espectrales por topic (φ_k)
+          Per-topic spectral profiles (φ_k)
         </h4>
         <p
           className="text-sm mb-3"
@@ -202,7 +202,7 @@ export function TopicsTab({
         <div
           className="mt-3 flex flex-wrap gap-1.5"
           role="group"
-          aria-label="Selector de topics"
+          aria-label="Topic selector"
         >
           {data.topic_band_profiles.map((_, k) => {
             const isSel = selectedTopic === k;

--- a/frontend/src/pages/workspace/tabs/UsgsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UsgsTab.tsx
@@ -83,7 +83,7 @@ export function UsgsTab({
             style={{ color: "var(--color-fg-faint)" }}
           >
             {data.library_subset} · {data.library_sample_count} espectros en 7
-            chapters. Cada topic se enmaridada por cosine + SAM contra the full
+            chapters. Each topic is matched by cosine + SAM against the full
             library; click a topic below to see its top matches.
           </p>
         </header>


### PR DESCRIPTION
Companion to c321 (#530) which caught the most-visible 5 files. This sweep catches the residual Spanish leaks across **15 page/tab files**:

- pages/Workspace.tsx: STEPS array Familia/Conjunto → Dataset family/Subset (the t() route at :1595 already uses these as a fallback)
- pages/Databases.tsx: aria-label
- pages/Benchmarks.tsx + benchmarks/BenchmarksSummary.tsx + benchmarks/BenchmarksHidsag.tsx: 2 section titles + 4 loading/error messages + 'clases'
- workspace/tabs/Embed3DTab.tsx: 'colouredr por' (typo too)
- workspace/tabs/MetricsTab.tsx: 'documentos' + '% H(y) recuperada'
- workspace/tabs/RawTab.tsx: stat labels Forma/Bandas/Clases/Gini desbalance
- workspace/tabs/{StabilityTab,TopicLabelTab,UsgsTab,SpectralBrowserTab,TopicsTab,RoutedTab,RasterTab}.tsx: section headers + helper strings

Net: 34 insertions / 35 deletions across 15 files. typecheck clean, 44/44 tests pass.

Closes **#441 P1 2.3 + #441 P1 2.6** (all hard-coded Spanish strings removed from page/tab UI surface).