### PR TITLE
c323: extract Routed-classifier family from api/client.ts (#441 P1 2.4)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -37,6 +37,15 @@ export type {
   HidsagCovariateProbability,
 } from "./bandmask";
 
+// c323 Routed family slice — see api/routed.ts.
+import * as routed from "./routed";
+export type {
+  RoutedFoldMetric,
+  RoutedMethodMetrics,
+  TopicRoutedClassifier,
+  TopicRoutedDeepGate,
+} from "./routed";
+
 export type RawFile = {
   raw_dataset_id: string;
   source_group: string;
@@ -280,18 +289,12 @@ export const api = {
     request<TopicViews>(`/api/topic-views/${encodeURIComponent(sceneId)}`),
   topicToData: (sceneId: string) =>
     request<TopicToData>(`/api/topic-to-data/${encodeURIComponent(sceneId)}`),
-  topicRoutedClassifier: (sceneId: string) =>
-    request<TopicRoutedClassifier>(
-      `/api/topic-routed-classifier/${encodeURIComponent(sceneId)}`,
-    ),
+  topicRoutedClassifier: (sceneId: string) => routed.topicRoutedClassifier(sceneId),
   embeddedBaseline: (sceneId: string) =>
     request<EmbeddedBaseline>(
       `/api/embedded-baseline/${encodeURIComponent(sceneId)}`,
     ),
-  topicRoutedDeepGate: (sceneId: string) =>
-    request<TopicRoutedDeepGate>(
-      `/api/topic-routed-deep-gate/${encodeURIComponent(sceneId)}`,
-    ),
+  topicRoutedDeepGate: (sceneId: string) => routed.topicRoutedDeepGate(sceneId),
   neuralTopicComparison: (sceneId: string) =>
     request<NeuralTopicComparison>(
       `/api/neural-topic-comparison/${encodeURIComponent(sceneId)}`,
@@ -611,33 +614,6 @@ export type SpectralBrowserMeta = {
 };
 
 
-export type RoutedFoldMetric = {
-  per_fold: number[];
-  mean: number;
-  std: number;
-  ci95_lo: number;
-  ci95_hi: number;
-};
-
-export type RoutedMethodMetrics = {
-  macro_f1: RoutedFoldMetric;
-  accuracy: RoutedFoldMetric;
-  balanced_accuracy?: RoutedFoldMetric;
-};
-
-export type TopicRoutedClassifier = {
-  scene_id: string;
-  K: number;
-  n_classes: number;
-  n_documents: number;
-  method_metrics: Record<string, RoutedMethodMetrics>;
-  ranking_by_macro_f1_mean: {
-    method: string;
-    macro_f1_mean: number;
-    macro_f1_ci95: [number, number];
-  }[];
-};
-
 export type EmbeddedBaselineMetrics = {
   macro_f1: { per_fold?: number[]; mean: number; std?: number; ci95_lo?: number; ci95_hi?: number };
   accuracy: { per_fold?: number[]; mean: number; std?: number; ci95_lo?: number; ci95_hi?: number };
@@ -657,20 +633,6 @@ export type EmbeddedBaseline = {
   framework_axis?: string;
   generated_at?: string;
   builder_version?: string;
-};
-
-export type TopicRoutedDeepGate = {
-  scene_id: string;
-  n_documents: number;
-  n_classes: number;
-  gate_methods: string[];
-  method_metrics: Record<string, RoutedMethodMetrics>;
-  ranked_by_macro_f1_mean: {
-    method: string;
-    macro_f1_mean: number;
-    macro_f1_ci95: [number, number];
-  }[];
-  framework_axis?: string;
 };
 
 export type NeuralTopicComparisonMethod = {

--- a/frontend/src/api/routed.ts
+++ b/frontend/src/api/routed.ts
@@ -1,0 +1,70 @@
+/**
+ * Routed-classifier family API surface. Extracted from `api/client.ts`
+ * as the second-slice continuation of #441 P1 item 2.4
+ * ("api/client.ts split into per-family files").
+ *
+ * Endpoints (c323):
+ *   - GET /api/topic-routed-classifier/{scene}     → TopicRoutedClassifier
+ *   - GET /api/topic-routed-deep-gate/{scene}      → TopicRoutedDeepGate
+ *
+ * The runtime calls live here; `api/client.ts` re-exports for
+ * backwards compatibility so existing imports keep working.
+ */
+import { request } from "./_http";
+
+// ---- types ----------------------------------------------------------
+
+export type RoutedFoldMetric = {
+  per_fold: number[];
+  mean: number;
+  std: number;
+  ci95_lo: number;
+  ci95_hi: number;
+};
+
+export type RoutedMethodMetrics = {
+  macro_f1: RoutedFoldMetric;
+  accuracy: RoutedFoldMetric;
+  balanced_accuracy?: RoutedFoldMetric;
+};
+
+export type TopicRoutedClassifier = {
+  scene_id: string;
+  K: number;
+  n_classes: number;
+  n_documents: number;
+  method_metrics: Record<string, RoutedMethodMetrics>;
+  ranking_by_macro_f1_mean: {
+    method: string;
+    macro_f1_mean: number;
+    macro_f1_ci95: [number, number];
+  }[];
+};
+
+export type TopicRoutedDeepGate = {
+  scene_id: string;
+  n_documents: number;
+  n_classes: number;
+  gate_methods: string[];
+  method_metrics: Record<string, RoutedMethodMetrics>;
+  ranked_by_macro_f1_mean: {
+    method: string;
+    macro_f1_mean: number;
+    macro_f1_ci95: [number, number];
+  }[];
+  framework_axis?: string;
+};
+
+// ---- runtime --------------------------------------------------------
+
+export function topicRoutedClassifier(sceneId: string) {
+  return request<TopicRoutedClassifier>(
+    `/api/topic-routed-classifier/${encodeURIComponent(sceneId)}`,
+  );
+}
+
+export function topicRoutedDeepGate(sceneId: string) {
+  return request<TopicRoutedDeepGate>(
+    `/api/topic-routed-deep-gate/${encodeURIComponent(sceneId)}`,
+  );
+}


### PR DESCRIPTION
Second slice of api/client.ts after the original bandmask/eda/hidsag carve-outs.

- New file: `frontend/src/api/routed.ts` (70 LOC, types + runtime).
- Types extracted: RoutedFoldMetric, RoutedMethodMetrics, TopicRoutedClassifier, TopicRoutedDeepGate.
- Runtime methods: topicRoutedClassifier, topicRoutedDeepGate.
- client.ts 1133 → 1095 LOC. client.ts re-exports types and delegates the 2 runtime methods to routed.* under the hood (zero churn for existing consumers).
- typecheck clean, 44/44 tests pass, build clean.

Refs #441 P1 2.4.