### PR TITLE
c325: extract LdaSweep family from api/client.ts (#441 P1 2.4)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -55,6 +55,10 @@ export type {
   MutualInformation,
 } from "./rate-distortion";
 
+// c325 LdaSweep slice — see api/lda-sweep.ts.
+import * as ldaSweepApi from "./lda-sweep";
+export type { LdaSweepEntry, LdaSweep } from "./lda-sweep";
+
 export type RawFile = {
   raw_dataset_id: string;
   source_group: string;
@@ -430,8 +434,7 @@ export const api = {
     request<QuantizationSensitivity>(
       `/generated/quantization_sensitivity/${encodeURIComponent(sceneId)}.json`,
     ),
-  ldaSweep: (sceneId: string) =>
-    request<LdaSweep>(`/api/lda-sweep/${encodeURIComponent(sceneId)}`),
+  ldaSweep: (sceneId: string) => ldaSweepApi.ldaSweep(sceneId),
   felzenszwalbGroupings: (sceneId: string) =>
     request<FelzenszwalbGroupings>(
       `/generated/groupings/felzenszwalb/${encodeURIComponent(sceneId)}.json`,
@@ -457,39 +460,6 @@ export const api = {
       `/api/deep-anomaly/${encodeURIComponent(sceneId)}`,
     ),
   buffer: (path: string) => requestBuffer(path),
-};
-
-export type LdaSweepEntry = {
-  K: number;
-  n_seeds: number;
-  perplexity_test_mean: number;
-  perplexity_test_std: number;
-  npmi_mean?: number | null;
-  topic_diversity_mean: number;
-  matched_cosine_mean?: number;
-  matched_cosine_min?: number;
-  per_seed?: {
-    seed: number;
-    perplexity_train: number;
-    perplexity_test: number;
-    npmi: number | null;
-    topic_diversity: number;
-  }[];
-};
-
-export type LdaSweep = {
-  scene_id: string;
-  K_grid: number[];
-  seeds: number[];
-  samples_per_class: number;
-  wordification: string;
-  quantization_scale: number;
-  train_fraction: number;
-  grid: LdaSweepEntry[];
-  recommended_K?: number;
-  recommendation_method?: string;
-  generated_at?: string;
-  builder_version?: string;
 };
 
 export type UsgsMatch = {

--- a/frontend/src/api/lda-sweep.ts
+++ b/frontend/src/api/lda-sweep.ts
@@ -1,0 +1,52 @@
+/**
+ * LDA-sweep family API surface. Extracted from `api/client.ts` (#441
+ * P1 item 2.4, c325).
+ *
+ * Endpoint:
+ *   - GET /api/lda-sweep/{scene} → LdaSweep
+ *
+ * Backs the canonical-K recommendation grid (per-seed perplexity +
+ * topic diversity + matched-cosine).
+ */
+import { request } from "./_http";
+
+// ---- types ----------------------------------------------------------
+
+export type LdaSweepEntry = {
+  K: number;
+  n_seeds: number;
+  perplexity_test_mean: number;
+  perplexity_test_std: number;
+  npmi_mean?: number | null;
+  topic_diversity_mean: number;
+  matched_cosine_mean?: number;
+  matched_cosine_min?: number;
+  per_seed?: {
+    seed: number;
+    perplexity_train: number;
+    perplexity_test: number;
+    npmi: number | null;
+    topic_diversity: number;
+  }[];
+};
+
+export type LdaSweep = {
+  scene_id: string;
+  K_grid: number[];
+  seeds: number[];
+  samples_per_class: number;
+  wordification: string;
+  quantization_scale: number;
+  train_fraction: number;
+  grid: LdaSweepEntry[];
+  recommended_K?: number;
+  recommendation_method?: string;
+  generated_at?: string;
+  builder_version?: string;
+};
+
+// ---- runtime --------------------------------------------------------
+
+export function ldaSweep(sceneId: string) {
+  return request<LdaSweep>(`/api/lda-sweep/${encodeURIComponent(sceneId)}`);
+}


### PR DESCRIPTION
Fourth and last of the audit-called-out trio (Routed/RateDistortion/LdaSweep).

- New file: `frontend/src/api/lda-sweep.ts` (52 LOC).
- Types: LdaSweepEntry, LdaSweep.
- Runtime: ldaSweep.
- client.ts 1059 → 1029 LOC.

**#441 P1 2.4 audit-called-out scope closed**: c261 (bandmask + eda + hidsag) + c323 (Routed) + c324 (RateDistortion + MutualInformation) + c325 (LdaSweep). api/client.ts: 1392 LOC original → 1029 LOC now (-26%). Other families that could still be split (Topic*, Hidsag*, Neural*) are not called out by the audit; deferred.

typecheck clean, 44/44 tests pass, build clean.

Refs #441 P1 2.4.