### PR TITLE
Deploy c323-c326: api/client.ts split into 3 more per-family files (#441 P1 2.4 closed)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -55,6 +55,10 @@ export type {
   MutualInformation,
 } from "./rate-distortion";
 
+// c325 LdaSweep slice — see api/lda-sweep.ts.
+import * as ldaSweepApi from "./lda-sweep";
+export type { LdaSweepEntry, LdaSweep } from "./lda-sweep";
+
 export type RawFile = {
   raw_dataset_id: string;
   source_group: string;
@@ -430,8 +434,7 @@ export const api = {
     request<QuantizationSensitivity>(
       `/generated/quantization_sensitivity/${encodeURIComponent(sceneId)}.json`,
     ),
-  ldaSweep: (sceneId: string) =>
-    request<LdaSweep>(`/api/lda-sweep/${encodeURIComponent(sceneId)}`),
+  ldaSweep: (sceneId: string) => ldaSweepApi.ldaSweep(sceneId),
   felzenszwalbGroupings: (sceneId: string) =>
     request<FelzenszwalbGroupings>(
       `/generated/groupings/felzenszwalb/${encodeURIComponent(sceneId)}.json`,
@@ -457,39 +460,6 @@ export const api = {
       `/api/deep-anomaly/${encodeURIComponent(sceneId)}`,
     ),
   buffer: (path: string) => requestBuffer(path),
-};
-
-export type LdaSweepEntry = {
-  K: number;
-  n_seeds: number;
-  perplexity_test_mean: number;
-  perplexity_test_std: number;
-  npmi_mean?: number | null;
-  topic_diversity_mean: number;
-  matched_cosine_mean?: number;
-  matched_cosine_min?: number;
-  per_seed?: {
-    seed: number;
-    perplexity_train: number;
-    perplexity_test: number;
-    npmi: number | null;
-    topic_diversity: number;
-  }[];
-};
-
-export type LdaSweep = {
-  scene_id: string;
-  K_grid: number[];
-  seeds: number[];
-  samples_per_class: number;
-  wordification: string;
-  quantization_scale: number;
-  train_fraction: number;
-  grid: LdaSweepEntry[];
-  recommended_K?: number;
-  recommendation_method?: string;
-  generated_at?: string;
-  builder_version?: string;
 };
 
 export type UsgsMatch = {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -37,6 +37,15 @@ export type {
   HidsagCovariateProbability,
 } from "./bandmask";
 
+// c323 Routed family slice — see api/routed.ts.
+import * as routed from "./routed";
+export type {
+  RoutedFoldMetric,
+  RoutedMethodMetrics,
+  TopicRoutedClassifier,
+  TopicRoutedDeepGate,
+} from "./routed";
+
 export type RawFile = {
   raw_dataset_id: string;
   source_group: string;
@@ -280,18 +289,12 @@ export const api = {
     request<TopicViews>(`/api/topic-views/${encodeURIComponent(sceneId)}`),
   topicToData: (sceneId: string) =>
     request<TopicToData>(`/api/topic-to-data/${encodeURIComponent(sceneId)}`),
-  topicRoutedClassifier: (sceneId: string) =>
-    request<TopicRoutedClassifier>(
-      `/api/topic-routed-classifier/${encodeURIComponent(sceneId)}`,
-    ),
+  topicRoutedClassifier: (sceneId: string) => routed.topicRoutedClassifier(sceneId),
   embeddedBaseline: (sceneId: string) =>
     request<EmbeddedBaseline>(
       `/api/embedded-baseline/${encodeURIComponent(sceneId)}`,
     ),
-  topicRoutedDeepGate: (sceneId: string) =>
-    request<TopicRoutedDeepGate>(
-      `/api/topic-routed-deep-gate/${encodeURIComponent(sceneId)}`,
-    ),
+  topicRoutedDeepGate: (sceneId: string) => routed.topicRoutedDeepGate(sceneId),
   neuralTopicComparison: (sceneId: string) =>
     request<NeuralTopicComparison>(
       `/api/neural-topic-comparison/${encodeURIComponent(sceneId)}`,
@@ -611,33 +614,6 @@ export type SpectralBrowserMeta = {
 };
 
 
-export type RoutedFoldMetric = {
-  per_fold: number[];
-  mean: number;
-  std: number;
-  ci95_lo: number;
-  ci95_hi: number;
-};
-
-export type RoutedMethodMetrics = {
-  macro_f1: RoutedFoldMetric;
-  accuracy: RoutedFoldMetric;
-  balanced_accuracy?: RoutedFoldMetric;
-};
-
-export type TopicRoutedClassifier = {
-  scene_id: string;
-  K: number;
-  n_classes: number;
-  n_documents: number;
-  method_metrics: Record<string, RoutedMethodMetrics>;
-  ranking_by_macro_f1_mean: {
-    method: string;
-    macro_f1_mean: number;
-    macro_f1_ci95: [number, number];
-  }[];
-};
-
 export type EmbeddedBaselineMetrics = {
   macro_f1: { per_fold?: number[]; mean: number; std?: number; ci95_lo?: number; ci95_hi?: number };
   accuracy: { per_fold?: number[]; mean: number; std?: number; ci95_lo?: number; ci95_hi?: number };
@@ -657,20 +633,6 @@ export type EmbeddedBaseline = {
   framework_axis?: string;
   generated_at?: string;
   builder_version?: string;
-};
-
-export type TopicRoutedDeepGate = {
-  scene_id: string;
-  n_documents: number;
-  n_classes: number;
-  gate_methods: string[];
-  method_metrics: Record<string, RoutedMethodMetrics>;
-  ranked_by_macro_f1_mean: {
-    method: string;
-    macro_f1_mean: number;
-    macro_f1_ci95: [number, number];
-  }[];
-  framework_axis?: string;
 };
 
 export type NeuralTopicComparisonMethod = {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -46,6 +46,15 @@ export type {
   TopicRoutedDeepGate,
 } from "./routed";
 
+// c324 RateDistortion + MutualInformation slice — see api/rate-distortion.ts.
+import * as rateDistortion from "./rate-distortion";
+export type {
+  RateDistortionCurvePoint,
+  RateDistortionCurve,
+  MutualInformationMethod,
+  MutualInformation,
+} from "./rate-distortion";
+
 export type RawFile = {
   raw_dataset_id: string;
   source_group: string;
@@ -347,14 +356,8 @@ export const api = {
     request<TopicToUsgsV7>(
       `/api/topic-to-usgs-v7/${encodeURIComponent(sceneId)}`,
     ),
-  rateDistortionCurve: (sceneId: string) =>
-    request<RateDistortionCurve>(
-      `/api/rate-distortion-curve/${encodeURIComponent(sceneId)}`,
-    ),
-  mutualInformation: (sceneId: string) =>
-    request<MutualInformation>(
-      `/api/mutual-information/${encodeURIComponent(sceneId)}`,
-    ),
+  rateDistortionCurve: (sceneId: string) => rateDistortion.rateDistortionCurve(sceneId),
+  mutualInformation: (sceneId: string) => rateDistortion.mutualInformation(sceneId),
   llmTeaLeaves: (sceneId: string) =>
     request<LlmTeaLeaves>(
       `/api/llm-tea-leaves/${encodeURIComponent(sceneId)}`,
@@ -456,14 +459,6 @@ export const api = {
   buffer: (path: string) => requestBuffer(path),
 };
 
-export type RateDistortionCurvePoint = {
-  K: number;
-  rmse_train: number;
-  rmse_test: number;
-  rmse_test_normalised?: number;
-  perplexity_test?: number;
-};
-
 export type LdaSweepEntry = {
   K: number;
   n_seeds: number;
@@ -495,37 +490,6 @@ export type LdaSweep = {
   recommendation_method?: string;
   generated_at?: string;
   builder_version?: string;
-};
-
-export type RateDistortionCurve = {
-  scene_id: string;
-  K_grid: number[];
-  doc_term_shape: [number, number];
-  method_curves: Record<string, RateDistortionCurvePoint[]>;
-};
-
-export type MutualInformationMethod = {
-  label_entropy_nats: number;
-  per_feature_mi_sum_nats: number;
-  joint_mi_clipped_to_label_entropy: number;
-  conditional_entropy_proxy_H_y_given_x: number;
-  per_feature_mi: number[];
-  latent_dim: number;
-};
-
-export type MutualInformation = {
-  scene_id: string;
-  topic_count: number;
-  n_documents: number;
-  label_entropy_nats: number;
-  label_entropy_bits: number;
-  method_mi: Record<string, MutualInformationMethod>;
-  ranking_by_joint_mi: {
-    method: string;
-    latent_dim: number;
-    joint_mi_clipped: number;
-    fraction_of_label_entropy_recovered: number;
-  }[];
 };
 
 export type UsgsMatch = {

--- a/frontend/src/api/lda-sweep.ts
+++ b/frontend/src/api/lda-sweep.ts
@@ -1,0 +1,52 @@
+/**
+ * LDA-sweep family API surface. Extracted from `api/client.ts` (#441
+ * P1 item 2.4, c325).
+ *
+ * Endpoint:
+ *   - GET /api/lda-sweep/{scene} → LdaSweep
+ *
+ * Backs the canonical-K recommendation grid (per-seed perplexity +
+ * topic diversity + matched-cosine).
+ */
+import { request } from "./_http";
+
+// ---- types ----------------------------------------------------------
+
+export type LdaSweepEntry = {
+  K: number;
+  n_seeds: number;
+  perplexity_test_mean: number;
+  perplexity_test_std: number;
+  npmi_mean?: number | null;
+  topic_diversity_mean: number;
+  matched_cosine_mean?: number;
+  matched_cosine_min?: number;
+  per_seed?: {
+    seed: number;
+    perplexity_train: number;
+    perplexity_test: number;
+    npmi: number | null;
+    topic_diversity: number;
+  }[];
+};
+
+export type LdaSweep = {
+  scene_id: string;
+  K_grid: number[];
+  seeds: number[];
+  samples_per_class: number;
+  wordification: string;
+  quantization_scale: number;
+  train_fraction: number;
+  grid: LdaSweepEntry[];
+  recommended_K?: number;
+  recommendation_method?: string;
+  generated_at?: string;
+  builder_version?: string;
+};
+
+// ---- runtime --------------------------------------------------------
+
+export function ldaSweep(sceneId: string) {
+  return request<LdaSweep>(`/api/lda-sweep/${encodeURIComponent(sceneId)}`);
+}

--- a/frontend/src/api/rate-distortion.ts
+++ b/frontend/src/api/rate-distortion.ts
@@ -1,0 +1,70 @@
+/**
+ * Rate-distortion + Mutual-information family API surface. Extracted
+ * from `api/client.ts` (#441 P1 item 2.4, c324).
+ *
+ * Endpoints:
+ *   - GET /api/rate-distortion-curve/{scene} → RateDistortionCurve
+ *   - GET /api/mutual-information/{scene}    → MutualInformation
+ *
+ * Both surfaces back the Benchmarks "axes" tab + the Workspace
+ * Metrics tab; they share no callers with the Routed family but live
+ * adjacent because both are scalar-per-K curves.
+ */
+import { request } from "./_http";
+
+// ---- rate-distortion types ----------------------------------------
+
+export type RateDistortionCurvePoint = {
+  K: number;
+  rmse_train: number;
+  rmse_test: number;
+  rmse_test_normalised?: number;
+  perplexity_test?: number;
+};
+
+export type RateDistortionCurve = {
+  scene_id: string;
+  K_grid: number[];
+  doc_term_shape: [number, number];
+  method_curves: Record<string, RateDistortionCurvePoint[]>;
+};
+
+// ---- mutual-information types -------------------------------------
+
+export type MutualInformationMethod = {
+  label_entropy_nats: number;
+  per_feature_mi_sum_nats: number;
+  joint_mi_clipped_to_label_entropy: number;
+  conditional_entropy_proxy_H_y_given_x: number;
+  per_feature_mi: number[];
+  latent_dim: number;
+};
+
+export type MutualInformation = {
+  scene_id: string;
+  topic_count: number;
+  n_documents: number;
+  label_entropy_nats: number;
+  label_entropy_bits: number;
+  method_mi: Record<string, MutualInformationMethod>;
+  ranking_by_joint_mi: {
+    method: string;
+    latent_dim: number;
+    joint_mi_clipped: number;
+    fraction_of_label_entropy_recovered: number;
+  }[];
+};
+
+// ---- runtime --------------------------------------------------------
+
+export function rateDistortionCurve(sceneId: string) {
+  return request<RateDistortionCurve>(
+    `/api/rate-distortion-curve/${encodeURIComponent(sceneId)}`,
+  );
+}
+
+export function mutualInformation(sceneId: string) {
+  return request<MutualInformation>(
+    `/api/mutual-information/${encodeURIComponent(sceneId)}`,
+  );
+}

--- a/frontend/src/api/routed.ts
+++ b/frontend/src/api/routed.ts
@@ -1,0 +1,70 @@
+/**
+ * Routed-classifier family API surface. Extracted from `api/client.ts`
+ * as the second-slice continuation of #441 P1 item 2.4
+ * ("api/client.ts split into per-family files").
+ *
+ * Endpoints (c323):
+ *   - GET /api/topic-routed-classifier/{scene}     → TopicRoutedClassifier
+ *   - GET /api/topic-routed-deep-gate/{scene}      → TopicRoutedDeepGate
+ *
+ * The runtime calls live here; `api/client.ts` re-exports for
+ * backwards compatibility so existing imports keep working.
+ */
+import { request } from "./_http";
+
+// ---- types ----------------------------------------------------------
+
+export type RoutedFoldMetric = {
+  per_fold: number[];
+  mean: number;
+  std: number;
+  ci95_lo: number;
+  ci95_hi: number;
+};
+
+export type RoutedMethodMetrics = {
+  macro_f1: RoutedFoldMetric;
+  accuracy: RoutedFoldMetric;
+  balanced_accuracy?: RoutedFoldMetric;
+};
+
+export type TopicRoutedClassifier = {
+  scene_id: string;
+  K: number;
+  n_classes: number;
+  n_documents: number;
+  method_metrics: Record<string, RoutedMethodMetrics>;
+  ranking_by_macro_f1_mean: {
+    method: string;
+    macro_f1_mean: number;
+    macro_f1_ci95: [number, number];
+  }[];
+};
+
+export type TopicRoutedDeepGate = {
+  scene_id: string;
+  n_documents: number;
+  n_classes: number;
+  gate_methods: string[];
+  method_metrics: Record<string, RoutedMethodMetrics>;
+  ranked_by_macro_f1_mean: {
+    method: string;
+    macro_f1_mean: number;
+    macro_f1_ci95: [number, number];
+  }[];
+  framework_axis?: string;
+};
+
+// ---- runtime --------------------------------------------------------
+
+export function topicRoutedClassifier(sceneId: string) {
+  return request<TopicRoutedClassifier>(
+    `/api/topic-routed-classifier/${encodeURIComponent(sceneId)}`,
+  );
+}
+
+export function topicRoutedDeepGate(sceneId: string) {
+  return request<TopicRoutedDeepGate>(
+    `/api/topic-routed-deep-gate/${encodeURIComponent(sceneId)}`,
+  );
+}


### PR DESCRIPTION
Three-cycle sweep closes the last audit-called-out item from #441.

- c323 (#534): Routed-classifier family → `api/routed.ts`
- c324 (#535): RateDistortion + MutualInformation → `api/rate-distortion.ts`
- c325 (#536): LdaSweep → `api/lda-sweep.ts`

api/client.ts: 1392 LOC original → 1029 LOC now (-26% since c261). The three audit-called-out families (Routed + LdaSweep + RateDistortion) plus the earlier bandmask/eda/hidsag carve-outs cover the scope of #441 P1 2.4.

Pattern: each new file owns its types + runtime; client.ts re-exports types for back-compat and delegates the api.* methods to the family modules under the hood — zero churn for any existing consumer.

typecheck clean on every task PR, 44/44 tests pass, build clean.

Refs #441 P1 2.4 (closes).