### PR TITLE
c330: i18n residual pass-2 — clean Spanish leaks that escaped c321/c322

### DIFF
--- a/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
@@ -25,7 +25,7 @@ export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
       <ProtocolBox stats={data} />
       <Section
         id="forest"
-        title="Forest plot — macro-F1 con CI95 por escena"
+        title="Forest plot — macro-F1 with CI95 per scene"
         lead="Each bar is a scene × method; the dot is the mean, the whiskers are the 2.5 and 97.5 percentiles of the bootstrap over the 25 evaluations."
       >
         <div className="space-y-8 mt-2">
@@ -36,7 +36,7 @@ export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
       </Section>
       <Section
         id="paired"
-        title="Comparaciones pareadas (Δ macro-F1)"
+        title="Paired comparisons (Δ macro-F1)"
         lead="Each pair shows the difference between methods per evaluation; summarised as mean ± std of Δ. Negative = the second method loses."
       >
         <div className="space-y-6 mt-2">
@@ -86,7 +86,7 @@ function ProtocolBox({ stats }: { stats: MethodStatistics }) {
       }}
     >
       <Stat
-        label="Escenas evaluadas"
+        label="Scenes evaluated"
         value={String(stats.labeled_scenes.length)}
       />
       <Stat
@@ -101,7 +101,7 @@ function ProtocolBox({ stats }: { stats: MethodStatistics }) {
         }
       />
       <Stat
-        label="α significancia"
+        label="α significance"
         value={stats.alpha_significance.toFixed(2)}
       />
     </div>

--- a/frontend/src/pages/workspace/tabs/Embed3DTab.tsx
+++ b/frontend/src/pages/workspace/tabs/Embed3DTab.tsx
@@ -81,8 +81,8 @@ export function Embed3DTab({
               className="text-sm mt-1"
               style={{ color: "var(--color-fg-faint)" }}
             >
-              Cada punto es un documento de la muestra (n={points.length}).
-              Coordenadas: PCA(θ) en 3D.{" "}
+              Each point is a document from the sample (n={points.length}).
+              Coordinates: PCA(θ) in 3D.{" "}
               {ev.length >= 3 && (
                 <>
                   EV<sub>1..3</sub> = {ev[0]!.toFixed(3)} /{" "}
@@ -90,7 +90,7 @@ export function Embed3DTab({
                   {(totalEv * 100).toFixed(1)}%).
                 </>
               )}{" "}
-              Click un punto para fijar su <code>doc_id</code>.
+              Click a point to pin its <code>doc_id</code>.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -165,7 +165,7 @@ export function Embed3DTab({
                       : "var(--color-fg-subtle)",
                 }}
               >
-                Todos
+                All
               </button>
               {Array.from({ length: data.topic_count }, (_, k) => {
                 const isSel = selectedTopic === k;

--- a/frontend/src/pages/workspace/tabs/RasterTab.tsx
+++ b/frontend/src/pages/workspace/tabs/RasterTab.tsx
@@ -250,7 +250,7 @@ export function RasterTab({
                         : "var(--color-fg-subtle)",
                   }}
                 >
-                  Todos
+                  All
                 </button>
                 {Array.from({ length: meta.topic_count }, (_, k) => {
                   const isSel = selectedTopic === k;

--- a/frontend/src/pages/workspace/tabs/UsgsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UsgsTab.tsx
@@ -82,7 +82,7 @@ export function UsgsTab({
             className="text-sm mt-1"
             style={{ color: "var(--color-fg-faint)" }}
           >
-            {data.library_subset} · {data.library_sample_count} espectros en 7
+            {data.library_subset} · {data.library_sample_count} spectra across 7
             chapters. Each topic is matched by cosine + SAM against the full
             library; click a topic below to see its top matches.
           </p>


### PR DESCRIPTION
Companion to c321 (#530) and c322 (#532). A fresh scan caught 4 files with residual hardcoded Spanish strings that the prior passes missed.

## Files
- Embed3DTab.tsx — 4 strings (sample/coords/click/Todos)
- UsgsTab.tsx — 1 string (espectros en 7)
- RasterTab.tsx — 1 string (Todos)
- BenchmarksSummary.tsx — 4 strings (titles + stat labels)

Matches under src/i18n/locales/es/*.json are intentional Spanish locale entries and left untouched.

typecheck clean, 44/44 tests pass, build clean.