### PR TITLE
c331: reconcile headline numbers + per-finding source anchors (#544 batch 1)

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -125,7 +125,7 @@
       "repr_tag": "V1..V12 + Deep",
       "repr_title": "Representations",
       "repr_body": "Twelve wordification recipes (V1 band → V12 GMM-token), three schemes (uniform/quantile/equalised), Q ∈ {8, 16, 32}. Plus five deep encoders: CAE-1D / CAE-2D / CAE-3D anchor and full-patch / β-VAE. PCA, NMF, ICA as fair K-dim baselines.",
-      "pipe_tag": "57 builders",
+      "pipe_tag": "69 builders",
       "pipe_title": "Pipeline",
       "pipe_body": "Diagram of the 12 stages of the data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Five torch builders detect GPU automatically with CPU fallback.",
       "app_tag": "direct · routed · embedded",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -125,7 +125,7 @@
       "repr_tag": "V1..V12 + Deep",
       "repr_title": "Representaciones",
       "repr_body": "Doce recetas de wordificación (V1 banda → V12 GMM-token), tres esquemas (uniform/quantile/equalised), Q ∈ {8, 16, 32}. Más cinco encoders profundos: CAE-1D / CAE-2D / CAE-3D anchor & full-patch / β-VAE. PCA, NMF, ICA como baselines K-dim de comparación justa.",
-      "pipe_tag": "57 builders",
+      "pipe_tag": "69 builders",
       "pipe_title": "Pipeline",
       "pipe_body": "Diagrama de las 12 etapas del data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Cinco builders torch detectan GPU automáticamente con fallback CPU.",
       "app_tag": "directo · routed · embedded",

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -103,7 +103,7 @@ const STAGES: Stage[] = [
     command: "scripts/local curate-for-web",
     produces: "data/derived/manifests/index.json",
     notes:
-      "Packs everything above into the contract the web app reads. 1118 artifacts, 35 builders, 60 claims_allowed, ~74 MB.",
+      "Packs everything above into the contract the web app reads. 1734 artifacts, 69 builders, 82 endpoints, ~449 MB. (Numbers verified 2026-05-24; the manifest is the contract — when these change, update the HeadlineNumbers card in Overview.)",
   },
   {
     id: "audit",

--- a/frontend/src/pages/overview/FindingsCarousel.tsx
+++ b/frontend/src/pages/overview/FindingsCarousel.tsx
@@ -1,48 +1,68 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
+// Source-anchor convention (added per #544 audit, 2026-05-23):
+//   `href`     deep-links to the Benchmarks tab that visualises the finding.
+//   `kind`     "benchmark" → has a tab anchor, click reveals the supporting plot.
+//              "operational" → engineering / runtime claim with no benchmark
+//              tab. Marked exploratory on-card.
 const FINDINGS = [
   {
     badge: "B-3",
     title: "θ as a gate beats raw on labelled scenes",
     body: "topic_routed_soft matches or beats raw_logistic on all 6 labelled scenes; theta_logistic (θ as a flat feature) loses by 30–50 pp everywhere. The framing 'θ is a gate, not a feature' is empirically validated.",
     accent: "rgba(40, 160, 80, 1)",
+    href: "/benchmarks#gating",
+    kind: "benchmark" as const,
   },
   {
     badge: "B-3 follow-up",
     title: "No deep encoder can replace θ as the gate",
-    body: "Cycle 54 hierarchical Bayesian: raw > θ > {pca_8, cae_1d_8, beta_vae_8} at P(μ_a > μ_b) ≥ 0.999. Softmaxed deep latents satisfy the simplex constraint geometrically but not structurally — the gating mechanism does not transfer.",
+    body: "Hierarchical Bayesian: raw > θ > {pca_8, cae_1d_8, beta_vae_8} at P(μ_a > μ_b) ≥ 0.999. Softmaxed deep latents satisfy the simplex constraint geometrically but not structurally — the gating mechanism does not transfer.",
     accent: "rgba(214, 39, 40, 1)",
+    href: "/benchmarks#gating",
+    kind: "benchmark" as const,
   },
   {
     badge: "Topic family",
     title: "LDA wins ARI · ProdLDA wins coherence · ETM is the safe middle",
-    body: "Cycles 61–63 head-to-head on 220-per-class stratified samples: LDA wins KMeans-vs-label ARI on 4/6 scenes; ProdLDA wins c_v topic coherence 6/6; ETM beats ProdLDA on ARI 6/6 (multi-seed N=5).",
+    body: "Head-to-head on 220-per-class stratified samples: LDA wins KMeans-vs-label ARI on 4/6 scenes; ProdLDA wins c_v topic coherence 6/6; ETM beats ProdLDA on ARI 6/6 (multi-seed N=5).",
     accent: "rgba(31, 119, 180, 1)",
+    href: "/benchmarks#gating",
+    kind: "benchmark" as const,
   },
   {
     badge: "Decoder design",
     title: "Decoder reconstruction target is itself a hyperparameter",
-    body: "CAE-3D anchor-only vs full-patch (cycles 52, 55) gives net mean ΔARI ≈ +0.003 (K=8) and +0.011 (K=4) — neutral on average, scene-dependent direction. Pavia U inverts with capacity.",
+    body: "CAE-3D anchor-only vs full-patch gives net mean ΔARI ≈ +0.003 (K=8) and +0.011 (K=4) — neutral on average, scene-dependent direction. Pavia U inverts with capacity.",
     accent: "rgba(170, 60, 200, 1)",
+    href: "/benchmarks#deep",
+    kind: "benchmark" as const,
   },
   {
-    badge: "GPU stack",
+    badge: "GPU stack · operational",
     title: "50–120× speedup on the deep / neural family",
-    body: "RTX 4070 Laptop CUDA 12.6: cae_3d_full K=32 single scene goes from ~60 min CPU to ~30 s GPU. Full K-curve {4, 8, 16, 32} × 6 scenes from 9–12 h CPU to ~10 min GPU. Determinism drift ±0.010 ARI is below per-seed σ ≈ 0.05.",
+    body: "RTX 4070 Laptop CUDA 12.6: cae_3d_full K=32 single scene goes from ~60 min CPU to ~30 s GPU. Full K-curve {4, 8, 16, 32} × 6 scenes from 9–12 h CPU to ~10 min GPU. Determinism drift ±0.010 ARI is below per-seed σ ≈ 0.05. Engineering claim — runtime / determinism only, not a methodological result.",
     accent: "rgba(214, 140, 40, 1)",
+    href: "/methodology/pipeline",
+    kind: "operational" as const,
   },
   {
     badge: "Stability",
     title: "9-method × 6-scene seed stability ladder",
     body: "PCA = ICA (1.000 deterministic) > LDA > NMF > CAE-2D > CAE-1D > CAE-3D > dense-AE > β-VAE. KSC β-VAE off-diag ≈ 0.18 — KL stochasticity overwhelms the inter-seed signal.",
     accent: "rgba(140, 86, 75, 1)",
+    href: "/benchmarks#axes",
+    kind: "benchmark" as const,
   },
   {
     badge: "Posterior collapse",
     title: "β-VAE Salinas at β ≥ 8 — textbook failure mode",
-    body: "Salinas β-VAE at β=8 and β=16 collapses to ARI = 0.000: the encoder converges to q(z|x) ≈ p(z) regardless of input; the latent is uninformative. Salinas-A's compact 6-class structure resists the same regulariser. Visible black cells in the Benchmarks β-sweep heatmap.",
+    body: "Salinas β-VAE at β=8 and β=16 collapses to ARI = 0.000: the encoder converges to q(z|x) ≈ p(z) regardless of input; the latent is uninformative. Salinas-A's compact 6-class structure resists the same regulariser.",
     accent: "rgba(120, 50, 50, 1)",
+    href: "/benchmarks#deep",
+    kind: "benchmark" as const,
   },
 ];
 
@@ -104,6 +124,17 @@ export function FindingsCarousel() {
         >
           {cur.body}
         </p>
+        <div className="mt-4 pl-3">
+          <Link
+            to={cur.href}
+            className="inline-flex items-center gap-1.5 text-[13px] font-medium underline-offset-4 hover:underline"
+            style={{ color: cur.accent }}
+          >
+            {cur.kind === "operational"
+              ? "See the pipeline page →"
+              : "See the supporting Benchmarks panel →"}
+          </Link>
+        </div>
         <div className="mt-4 flex gap-1.5 pl-3">
           {FINDINGS.map((f, i) => (
             <button

--- a/frontend/src/pages/overview/HeadlineNumbers.tsx
+++ b/frontend/src/pages/overview/HeadlineNumbers.tsx
@@ -1,12 +1,19 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+// Numbers verified against current ground truth on 2026-05-24:
+//   builders   = `ls data-pipeline/build_*.py | wc -l`     → 69
+//   artefacts  = `find data/derived -type f | wc -l`       → 1734
+//   endpoints  = `grep -cE '^@router\.(get|post)' app/routers/content.py` → 82
+// Datasets / recipes / variants do not drift across components — fixed grid.
+// If these counts change, update the audit anchor block in
+// `_CAOS_MANAGE/wip/caos-lda-hsi/audits/2026-05-23-audit-index.md` too.
 const HEADLINE_DEFS = [
   { keyLabel: "datasets_label", keySub: "datasets_sub", value: "21", href: "/databases" },
   { keyLabel: "recipes_label", keySub: "recipes_sub", value: "12", href: "/methodology/representations" },
-  { keyLabel: "builders_label", keySub: "builders_sub", value: "67", href: "/methodology/pipeline" },
-  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1706", href: "/workspace" },
-  { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "86", href: "/benchmarks" },
+  { keyLabel: "builders_label", keySub: "builders_sub", value: "69", href: "/methodology/pipeline" },
+  { keyLabel: "artifacts_label", keySub: "artifacts_sub", value: "1734", href: "/workspace" },
+  { keyLabel: "endpoints_label", keySub: "endpoints_sub", value: "82", href: "/benchmarks" },
   { keyLabel: "variants_label", keySub: "variants_sub", value: "11", href: "/methodology/representations" },
 ] as const;
 


### PR DESCRIPTION
First batch of fixes for issue #544. Two of the six Tier-1 items.

## What ships

### Numbers reconciliation
Ground-truth verified 2026-05-24:
- 69 builders (was 67/35/57 across three components)
- 1734 derived artefacts (was 1706/1118)
- 82 API endpoints (was 86 in HeadlineNumbers, 60 in Pipeline)
- 449 MB derived (was ~74 MB)

Propagated to:
- `pages/overview/HeadlineNumbers.tsx` + comment block with verification commands
- `pages/methodology/Pipeline.tsx` curate-stage notes
- `i18n/locales/{en,es}/pages.json` `methodology.index.pipe_tag`

### FindingsCarousel source anchors
All 7 cards now carry an `href` to the supporting panel; visible CTA renders on-card. The GPU-speedup card is marked `operational` (not a methodological result) and its badge prefix + body wording reflect that.

typecheck clean, 44/44 tests pass, build clean.

## Tier-1 remaining in #544 (next batches)
- V1-V12 token recipe formal definitions
- Q-scheme + doc-construction definitions
- B-3 thesis paragraph
- F-framework one-paragraph definition