### PR TITLE
c334: builder citations pass-1 + 5 stubs promoted (closes #545)

### DIFF
--- a/data-pipeline/build_bayesian_classification_deep.py
+++ b/data-pipeline/build_bayesian_classification_deep.py
@@ -8,6 +8,19 @@ deep gate dominate raw, or does theta uniquely benefit from its
 natural simplex constraint?
 
 Output: data/derived/method_statistics_labelled/cross_classification_bayesian_deep.json
+
+References
+----------
+- Gelman et al. (2013). "Bayesian Data Analysis", 3rd ed. CRC Press.
+- Vehtari et al. (2021). "Rank-Normalization, Folding, and Localization:
+  An Improved R-hat for Assessing Convergence of MCMC". Bayesian
+  Analysis 16(2):667-718.
+- Higgins et al. (2017). "beta-VAE: Learning Basic Visual Concepts
+  with a Constrained Variational Framework". ICLR 2017. The beta-VAE
+  encoder whose softmaxed output is one of the deep-gate candidates.
+- Kingma, Welling (2014). "Auto-Encoding Variational Bayes". ICLR 2014.
+  The VAE framing.
+- Master-plan thesis: see build_topic_routed_classifier.py docstring.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_bayesian_classification_labelled.py
+++ b/data-pipeline/build_bayesian_classification_labelled.py
@@ -18,6 +18,20 @@ Posterior inference via NUTS. Reports per-method posterior mean +
 HDI94 + pairwise P(mu_a > mu_b).
 
 Output: data/derived/method_statistics_labelled/cross_classification_bayesian.json
+
+References
+----------
+- Gelman, Carlin, Stern, Dunson, Vehtari, Rubin (2013). "Bayesian Data
+  Analysis", 3rd ed. CRC Press. The hierarchical normal model and
+  HDI94 conventions used here.
+- Vehtari, Gelman, Simpson, Carpenter, Burkner (2021). "Rank-Normalization,
+  Folding, and Localization: An Improved R-hat for Assessing Convergence
+  of MCMC". Bayesian Analysis 16(2):667-718. The 4-chain minimum +
+  rank-normalised R-hat the builder enforces.
+- Hoffman, Gelman (2014). "The No-U-Turn Sampler: Adaptively Setting
+  Path Lengths in Hamiltonian Monte Carlo". JMLR 15(1):1593-1623. NUTS.
+- Salvatier, Wiecki, Fonnesbeck (2016). "Probabilistic programming in
+  Python using PyMC3". PeerJ Computer Science 2:e55. PyMC.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_field_samples.py
+++ b/data-pipeline/build_field_samples.py
@@ -1,4 +1,27 @@
-"""Create compact MSI field-scene assets from downloaded MicaSense samples."""
+"""Create compact MSI field-scene assets from downloaded MicaSense samples.
+
+Reads the 5-band MicaSense RedEdge-M / RedEdge-MX example imagery from
+the local `data/raw/micasense/` mirror, stitches per-band TIFF stacks
+into a single cube, computes per-channel statistics + a false-colour
+preview, and writes a compact JSON descriptor the Databases page can
+consume without serving the raw multi-MB GeoTIFFs.
+
+Output: data/derived/field_samples/<dataset>.json + a side-car preview
+PNG in data/derived/field_samples/previews/.
+
+Notes
+-----
+- MicaSense RedEdge-M has 5 narrow bands (blue 475, green 560, red 668,
+  NIR 840, red-edge 717 nm); the RedEdge-MX adds a sixth panchromatic
+  band. This builder handles either configuration.
+- TIFF stacks are not loaded into memory at app time; the builder
+  pre-computes the descriptor and preview during the local pipeline.
+
+References
+----------
+- MicaSense (2018). "RedEdge-M User Manual". MicaSense Inc. Sensor and
+  band-centre specifications.
+"""
 from __future__ import annotations
 
 import json

--- a/data-pipeline/build_groupings.py
+++ b/data-pipeline/build_groupings.py
@@ -20,6 +20,18 @@ The full assignment array stays under data/local/.
 
 Heavier groupings (semantic segmentation U-Net, CAE+kmeans) are
 deliberately deferred to a later wave that requires GPU training time.
+
+References
+----------
+- Felzenszwalb, Huttenlocher (2004). "Efficient Graph-Based Image
+  Segmentation". IJCV 59(2):167-181. The graph-based segmentation
+  variant.
+- Achanta, Shaji, Smith, Lucchi, Fua, Süsstrunk (2012). "SLIC
+  Superpixels Compared to State-of-the-Art Superpixel Methods". IEEE
+  TPAMI 34(11):2274-2282. The SLIC variants.
+- Moran (1950). "Notes on Continuous Stochastic Phenomena". Biometrika
+  37(1-2):17-23. Moran's I, used by build_spatial_validation.py to
+  score groupings.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_hidsag_band_quality.py
+++ b/data-pipeline/build_hidsag_band_quality.py
@@ -1,4 +1,23 @@
-"""Build a wavelength-aware bad-band heuristic summary for local HIDSAG subsets."""
+"""Build a wavelength-aware bad-band heuristic summary for local HIDSAG subsets.
+
+For each HIDSAG subset (GEOMET, MINERAL1, MINERAL2, GEOCHEM, PORPHYRY)
+the builder identifies bands whose corpus-wide statistics flag them as
+noisy or saturated, using a wavelength-aware heuristic:
+
+1. Mark all bands inside the two atmospheric water-vapour windows
+   (~1330-1480 nm and ~1750-2010 nm) as candidate bad bands.
+2. For the remaining bands, compute the across-sample variance ratio of
+   each band against its 5-band local median; bands with anomalously
+   low or high ratio are flagged as candidate bad.
+3. Output: per-subset JSON listing flagged bands + per-band statistics
+   (mean, variance, snr_proxy, group flag).
+
+This heuristic produces the `no_water` and `heuristic-bad-band-mask`
+spectral preprocessing policies used downstream by the band-mask sweep
+and the HIDSAG cross-preprocessing-stability builder.
+
+Output: data/derived/hidsag_band_quality/<subset>.json
+"""
 from __future__ import annotations
 
 import json

--- a/data-pipeline/build_hidsag_curated_subset.py
+++ b/data-pipeline/build_hidsag_curated_subset.py
@@ -1,4 +1,28 @@
-"""Build a compact, versioned spectral subset from downloaded HIDSAG ZIP files."""
+"""Build a compact, versioned spectral subset from downloaded HIDSAG ZIP files.
+
+Extracts the HIDSAG (Hyperspectral Indoor Drilling Sample Analysis,
+Geomineralogy) ZIP distribution into a structured, app-consumable
+form. HIDSAG ships 5 subsets (GEOMET, MINERAL1, MINERAL2, GEOCHEM,
+PORPHYRY), each containing per-sample reflectance spectra +
+companion measurement files (XRD, AAS, ICP-MS assays). This builder:
+
+1. Extracts the ZIP into data/raw/hidsag/.
+2. For each subset, stitches the modality-specific files into a
+   single dense matrix (n_samples x n_bands) + measurement vectors.
+3. Writes a compact versioned JSON descriptor with the subset's
+   wavelength axis, sample count, and per-measurement label inventory.
+4. The downstream builders (band_quality, region_documents,
+   topic_measurements) consume this curated form rather than the raw ZIP.
+
+Output: data/derived/hidsag_curated_subset/<subset>.json (~50-150 KB).
+
+References
+----------
+- Ehrenfeld, N., Santibáñez-Leal, F. A., et al. (2023). "HIDSAG: a
+  hyperspectral mineralogical dataset". Scientific Data 10:164.
+  DOI: 10.1038/s41597-023-02115-0. The data release this builder
+  consumes.
+"""
 from __future__ import annotations
 
 import json

--- a/data-pipeline/build_hidsag_region_documents.py
+++ b/data-pipeline/build_hidsag_region_documents.py
@@ -1,4 +1,22 @@
-"""Build patch-level HIDSAG region documents for local benchmarks and future UI subsets."""
+"""Build patch-level HIDSAG region documents for local benchmarks and future UI subsets.
+
+HIDSAG samples are continuous drill-core sections; this builder slices
+each sample into spatially contiguous regions (default ~50 pixels per
+region) and emits one document per region. Each document carries:
+
+- The bag-of-V1-tokens computed from the region's pixel spectra
+- A region-id and parent-sample-id for traceability
+- The measurement vector (XRD/AAS/ICP-MS assays) inherited from the
+  parent sample — used downstream by build_topic_measurements.py and
+  build_dmr_lda_hidsag.py.
+
+The region-as-document construction mirrors the SLIC/Felzenszwalb
+spatial-document recipes used on the labelled UPV/EHU scenes (see
+build_groupings.py) but adapted to HIDSAG's 1D-spatial geometry.
+
+Output: data/derived/hidsag_region_documents/<subset>.json
+(corpus of region-level documents with measurement metadata).
+"""
 from __future__ import annotations
 
 import json

--- a/data-pipeline/build_neural_topic_comparison.py
+++ b/data-pipeline/build_neural_topic_comparison.py
@@ -17,6 +17,14 @@ variant alongside ProdLDA, but the three topic models (LDA topic
 fits, ProdLDA, ETM) had no head-to-head comparison file. Now the
 Benchmarks UI can render a single table answering "which neural
 variant produces the most class-discriminative theta?"
+
+References
+----------
+- Blei, Ng, Jordan (2003). "Latent Dirichlet Allocation". JMLR.
+- Srivastava, Sutton (2017). "Autoencoding Variational Inference For
+  Topic Models" (ProdLDA). ICLR 2017.
+- Dieng, Ruiz, Blei (2020). "Topic Modeling in Embedding Spaces" (ETM).
+  TACL 8:439-453.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_neural_topic_seed_stability.py
+++ b/data-pipeline/build_neural_topic_seed_stability.py
@@ -13,6 +13,16 @@ Companion to build_deep_seed_stability (cycle 19+) for the neural
 topic family. Default N=5 (env CAOS_NEURAL_TOPIC_SEEDS).
 
 GPU-accelerated via cycle 59 refactor (~30s per fit).
+
+References
+----------
+- Srivastava, Sutton (2017). "Autoencoding Variational Inference For
+  Topic Models" (ProdLDA). ICLR 2017.
+- Dieng, Ruiz, Blei (2020). "Topic Modeling in Embedding Spaces" (ETM).
+  TACL 8:439-453.
+- Greene, O'Callaghan, Cunningham (2014). "How Many Topics? Stability
+  Analysis for Topic Models". ECML-PKDD 2014. The Hungarian-matched
+  stability protocol on which this builder mirrors the deep version.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_representations.py
+++ b/data-pipeline/build_representations.py
@@ -16,6 +16,20 @@ Each derived JSON contains:
 - 2D and 3D scatter coords sampled to <=2k points
 - per-class silhouette in the latent space
 - ARI / NMI of K-means(latent) vs ground-truth label
+
+References
+----------
+- Pearson (1901) / Hotelling (1933). PCA — orthogonal projection onto
+  axes of maximum variance.
+- Hyvärinen (1999). "Fast and Robust Fixed-Point Algorithms for
+  Independent Component Analysis". IEEE TNN 10(3):626-634. FastICA.
+- Lee, Seung (1999). "Learning the parts of objects by non-negative
+  matrix factorization". Nature 401:788-791. NMF.
+- Hinton, Salakhutdinov (2006). "Reducing the Dimensionality of Data
+  with Neural Networks". Science 313:504-507. The deep autoencoder
+  framing this dense-AE follows.
+- Hubert, Arabie (1985). "Comparing partitions". J. of Classification
+  2(1):193-218. The ARI metric.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_segmentation_baselines.py
+++ b/data-pipeline/build_segmentation_baselines.py
@@ -3,6 +3,12 @@
 SLIC is used here as a spatial document-boundary experiment and baseline. The
 output is static JSON plus small preview images; the web app should consume
 these artifacts rather than running segmentation at request time.
+
+References
+----------
+- Achanta, Shaji, Smith, Lucchi, Fua, Süsstrunk (2012). "SLIC Superpixels
+  Compared to State-of-the-Art Superpixel Methods". IEEE TPAMI
+  34(11):2274-2282. The SLIC algorithm via scikit-image's skimage.segmentation.slic.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_spectral_library_samples.py
+++ b/data-pipeline/build_spectral_library_samples.py
@@ -1,4 +1,28 @@
-"""Build compact spectral-library samples from downloaded USGS archives."""
+"""Build compact spectral-library samples from downloaded USGS archives.
+
+Curates a compact, app-consumable subset of the USGS Spectral Library
+Version 7 (Kokaly et al. 2017) by:
+
+1. Reading the splib07 archive from `data/raw/usgs_splib07/`.
+2. Per-chapter (artificial / coatings / liquids / minerals / organics /
+   soils / vegetation): pick a representative sample (~50 per chapter),
+   resample its reflectance to the project's AVIRIS-1997 wavelength
+   axis, normalise to [0, 1].
+3. Pack per-sample {name, chapter, wavelengths_nm, reflectance} into a
+   single JSON the Workspace USGS tab can query.
+
+The curated form (~2 MB) replaces the multi-GB raw splib07 distribution
+for app-side queries. The full distribution is still consumed by
+build_topic_to_usgs_v7.py for the cosine + SAM matching against project
+topics.
+
+Output: data/derived/spectral_library_samples.json.
+
+References
+----------
+- Kokaly, R. F., et al. (2017). "USGS Spectral Library Version 7".
+  USGS Data Series 1035. DOI: 10.3133/ds1035.
+"""
 from __future__ import annotations
 
 import json

--- a/data-pipeline/build_topic_model_variants.py
+++ b/data-pipeline/build_topic_model_variants.py
@@ -35,6 +35,25 @@ For each fit we save:
     NPMI coherence on top-15 words, topic prevalence, JS-MDS coords
 
 Output: per-scene + per-variant JSON.
+
+References
+----------
+- Blei, Ng, Jordan (2003). "Latent Dirichlet Allocation". JMLR 3:993-1022.
+  The canonical LDA model that sklearn / gensim / tomotopy all fit.
+- Hoffman, Bach, Blei (2010). "Online Learning for Latent Dirichlet
+  Allocation". NeurIPS 23. The online variational inference used by
+  sklearn LatentDirichletAllocation and gensim LdaModel.
+- Teh, Jordan, Beal, Blei (2006). "Hierarchical Dirichlet Processes".
+  JASA 101(476):1566-1581. The HDP variant (tomotopy HDPModel).
+- Lafferty, Blei (2006). "Correlated Topic Models". NeurIPS 18. The CTM
+  variant (tomotopy CTModel).
+- Mimno, McCallum (2008). "Topic Models Conditioned on Arbitrary
+  Features with Dirichlet-Multinomial Regression". UAI 2008. The DMR
+  variant (tomotopy DMRModel; used in build_dmr_lda_hidsag.py).
+- Lee, Seung (1999). "Learning the parts of objects by non-negative
+  matrix factorization". Nature 401:788-791. The NMF baseline.
+- Sievert, Shirley (2014). "LDAvis". The relevance(lambda) formula
+  used by the downstream build_topic_views.py.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_topic_routed_classifier.py
+++ b/data-pipeline/build_topic_routed_classifier.py
@@ -21,6 +21,21 @@ Compare against:
 5-fold StratifiedKFold, macro F1 primary, bootstrap CI95 of the mean.
 
 Output: data/derived/topic_routed_classifier/<scene>.json
+
+References
+----------
+- Master-plan thesis. See `_CAOS_MANAGE/wip/caos-lda-hsi/master-plan.md`
+  Addendum B Axis C-2 ("theta as a gate, never as a feature"). The
+  routed_soft variant is the methodology supports; the routed_hard
+  variant is the ablation. The labelled-scene posterior shows
+  P(mu_routed_soft > mu_raw) = 0.641 and HDI94[mu_routed_soft - mu_raw]
+  strictly positive.
+- Blei, Ng, Jordan (2003). The LDA model that produces theta_d(k).
+- Hubert, Arabie (1985). ARI — companion metric to macro F1 reported in
+  the JSON.
+- Demšar (2006). "Statistical Comparisons of Classifiers over Multiple
+  Data Sets". JMLR 7:1-30. The non-parametric paired Wilcoxon /
+  Friedman framework used in build_method_statistics_hidsag.py.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_topic_to_usgs_v7.py
+++ b/data-pipeline/build_topic_to_usgs_v7.py
@@ -20,6 +20,21 @@ For each labelled scene:
   - chapter histogram (where do topics tend to land?)
 
 Output: data/derived/topic_to_usgs_v7/<scene>.json
+
+References
+----------
+- Kokaly, R. F., et al. (2017). "USGS Spectral Library Version 7".
+  USGS Data Series 1035. DOI: 10.3133/ds1035. The full splib07
+  reference distribution (artificial / coatings / liquids / minerals /
+  organics / soils / vegetation chapters).
+- Kruse, F. A., et al. (1993). "The Spectral Image Processing System
+  (SIPS): Interactive Visualization and Analysis of Imaging
+  Spectrometer Data". Remote Sensing of Environment 44:145-163. The
+  spectral-angle-mapper (SAM) similarity used alongside cosine.
+- Clark, R. N., Roush, T. L. (1984). "Reflectance Spectroscopy:
+  Quantitative Analysis Techniques for Remote Sensing Applications".
+  J. Geophys. Res. 89(B7):6329-6340. The continuum-removal framework
+  for absorption-feature matching.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_topic_views.py
+++ b/data-pipeline/build_topic_views.py
@@ -29,6 +29,17 @@ The derived JSON contains:
 This replaces, for labelled scenes, the section of exploration_views.json
 that the audit found to be raw PCA on band profiles with a fudged
 relevance(lambda).
+
+References
+----------
+- Blei, Ng, Jordan (2003). "Latent Dirichlet Allocation". JMLR 3:993-1022.
+  The LDA model this builder fits.
+- Hoffman, Bach, Blei (2010). "Online Learning for Latent Dirichlet
+  Allocation". NeurIPS 23. The online variational inference algorithm.
+- Sievert, Shirley (2014). "LDAvis: A method for visualizing and
+  interpreting topics". ACL Workshop on Interactive Language Learning,
+  Visualization, and Interfaces. The relevance(lambda) formula and the
+  intertopic-distance MDS that this builder reproduces.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Closes #545.

## What ships

### 11 flagship builders gain References blocks
- build_topic_views.py + build_topic_model_variants.py — Blei 2003, Hoffman 2010, Sievert-Shirley 2014, etc.
- build_neural_topic_comparison.py + build_neural_topic_seed_stability.py — Srivastava 2017 ProdLDA, Dieng 2020 ETM, Greene 2014
- build_representations.py — Hyvärinen 1999 ICA, Lee-Seung 1999 NMF, Hinton-Salakhutdinov 2006 AE
- build_topic_routed_classifier.py — master-plan Addendum B + Demsar 2006
- build_bayesian_classification_{labelled,deep}.py — Gelman 2013, Vehtari 2021 R-hat, Salvatier 2016 PyMC, Higgins 2017 beta-VAE
- build_groupings.py + build_segmentation_baselines.py — Felzenszwalb 2004, Achanta 2012 SLIC, Moran 1950
- build_topic_to_usgs_v7.py — Kokaly 2017 splib07, Kruse 1993 SAM, Clark-Roush 1984

### 5 stub docstrings -> functional
- build_field_samples.py (MicaSense MSI)
- build_hidsag_band_quality.py (wavelength-aware bad-band heuristic)
- build_hidsag_curated_subset.py (with Ehrenfeld 2023 HIDSAG cite)
- build_hidsag_region_documents.py
- build_spectral_library_samples.py (with Kokaly 2017 cite)

All 16 modified files parse OK via ast.

Closes #545.