### PR TITLE
c337: Tier-2 methodology depth — ELBO, coherence, phi-vs-E, Bayesian spec, Hungarian, spatial coherence, PDF stamp

### DIFF
--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -201,6 +201,99 @@ export default function MethodologyApplication() {
       </Section>
 
       <Section
+        id="bayesian-spec"
+        title="Hierarchical Bayesian benchmark — model spec"
+        lead="The 'P(μ_a > μ_b) ≥ 0.999' claims above come from a per-scene partial-pooling model fit with PyMC. The spec below makes the priors, likelihood, and convergence-diagnostic settings explicit so the numbers are reproducible from the same JSON inputs."
+      >
+        <p>
+          For each scene <Equation tex="s \in \{1, \dots, 6\}" /> and each
+          method <Equation tex="m \in \{\mathrm{raw}, \mathrm{theta},
+            \mathrm{routed\_hard}, \mathrm{routed\_soft}\}" />, the builder
+          collects <Equation tex="N_{s,m} = 5" /> seed-replicate F1 scores
+          and fits the partial-pooling Gaussian model:
+        </p>
+        <Equation
+          block
+          tex="y_{s,m,r} \sim \mathcal{N}(\mu_{s,m}, \sigma^2), \quad \mu_{s,m} \sim \mathcal{N}(\bar{\mu}_m, \tau_m^2), \quad \bar{\mu}_m \sim \mathcal{N}(0.85, 0.15^2), \quad \tau_m \sim \mathrm{HalfNormal}(0.05), \quad \sigma \sim \mathrm{HalfNormal}(0.05)."
+        />
+        <p className="mt-3">
+          The scene-level means <Equation tex="\mu_{s,m}" /> shrink toward
+          the method-level mean <Equation tex="\bar{\mu}_m" /> by an amount
+          set by the data and the prior precision{" "}
+          <Equation tex="\tau_m" />. The quantity reported in the
+          Benchmarks <em>Routed</em> tab is the posterior contrast{" "}
+          <Equation tex="\Delta_{m_a, m_b} = \bar{\mu}_{m_a} - \bar{\mu}_{m_b}" />,
+          summarised by its 94% Highest Density Interval (HDI94) and the
+          posterior tail probability{" "}
+          <Equation tex="P(\Delta_{m_a, m_b} > 0)" />. A claim of
+          "robust support in favour of routed soft" requires{" "}
+          <Equation tex="P(\Delta_{\mathrm{routed\_soft}, \mathrm{raw}} > 0) \ge 0.999" />.
+        </p>
+        <p className="mt-3">
+          <strong>Sampler.</strong> PyMC 5's NUTS sampler with{" "}
+          <code>chains=4</code>, <code>tune=2000</code>,{" "}
+          <code>draws=2000</code>,{" "}
+          <code>target_accept=0.95</code>. Convergence is declared only
+          when the improved rank-normalised{" "}
+          <Equation tex="\widehat{R} < 1.01" /> (Vehtari et al. 2021)
+          for every monitored parameter and the bulk + tail effective
+          sample size exceeds 1000. The 4-chain count is the minimum the
+          Vehtari et al. diagnostic supports — re-running with 8 or 16
+          chains never shifts an HDI94 by more than the second decimal on
+          this problem.
+        </p>
+        <p className="mt-3">
+          <strong>Builder + artefact.</strong>{" "}
+          <code>build_bayesian_classification_labelled.py</code> writes the
+          per-scene posterior + ranking JSONs consumed by the Benchmarks{" "}
+          <em>Routed</em> tab and the <em>Bayesian</em> sub-tab. The
+          regression analogue lives in{" "}
+          <code>build_bayesian_classification_deep.py</code> for the
+          HIDSAG continuous targets.
+        </p>
+      </Section>
+
+      <Section
+        id="hungarian-stability"
+        title="Hungarian topic-matching — stability and cross-mask identity"
+        lead="Topic indices are not stable across re-fits — both LDA seeds and water-mask choices can permute the K topics. The seed-stability and cross-mask validation blocks pair topics by the assignment that maximises the average matched cosine. That is the Hungarian (linear-assignment) algorithm applied to a topic-cosine cost matrix."
+      >
+        <p>
+          Given two fits with topic-word matrices{" "}
+          <Equation tex="\Phi^{(a)} = [\phi_1^{(a)}, \dots, \phi_K^{(a)}]" />{" "}
+          and <Equation tex="\Phi^{(b)} = [\phi_1^{(b)}, \dots, \phi_K^{(b)}]" />,
+          define the cost matrix
+        </p>
+        <Equation
+          block
+          tex="C_{ij} = 1 - \cos\!\big(\phi_i^{(a)}, \phi_j^{(b)}\big) \in [0, 2]."
+        />
+        <p className="mt-3">
+          The Hungarian (Kuhn–Munkres) algorithm finds the permutation{" "}
+          <Equation tex="\pi^\star \in S_K" /> that minimises the total
+          assignment cost{" "}
+          <Equation tex="\textstyle\sum_{k=1}^{K} C_{k, \pi(k)}" /> in
+          <Equation tex="O(K^3)" /> time. The matched-cosine summary used
+          on the F-8 stability row is
+        </p>
+        <Equation
+          block
+          tex="\bar{c}_{ab} = \frac{1}{K} \sum_{k=1}^{K} \cos\!\big(\phi_k^{(a)}, \phi_{\pi^\star(k)}^{(b)}\big) \in [0, 1]."
+        />
+        <p className="mt-3">
+          Implementation: <code>scipy.optimize.linear_sum_assignment</code>{" "}
+          on the cost matrix above. The same routine is used for two
+          related comparisons: (i) seed-pair stability (Greene,
+          O'Callaghan &amp; Cunningham 2014's protocol, with{" "}
+          <Equation tex="\bar{c}_{ab}" /> averaged over all{" "}
+          <Equation tex="\binom{S}{2}" /> seed pairs) and (ii) cross-mask
+          identity (canonical-fit vs no-water-mask fit on the same scene).
+          Both quantities are reported in the Workspace{" "}
+          <em>Stability</em> and <em>Cross-method agreement</em> tabs.
+        </p>
+      </Section>
+
+      <Section
         id="what-topics-capture"
         title='What does a topic "capture", in task terms?'
         lead="It is not text: the question is answered visually with distributions."

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 
+import { Equation } from "@/components/Equation";
 import { Figure } from "@/components/Figure";
 import { PageShell } from "@/components/PageShell";
 import { Section } from "@/components/Section";
@@ -188,6 +189,80 @@ export default function MethodologyPipeline() {
             </div>
           ))}
         </div>
+      </Section>
+
+      <Section
+        id="spatial-coherence"
+        title="Spatial coherence — what the groupings stage measures"
+        lead="The four document constructions (SLIC-500, SLIC-2000, patch-7/15, Felzenszwalb) carve the cube in geometrically different ways. The cross-method agreement panel summarises how often they place two pixels in the same document; the per-method spatial-coherence diagnostics summarise how compact each construction's regions are."
+      >
+        <p>
+          Three diagnostics are computed by the groupings + spatial-validation
+          builders and surfaced in the Workspace <em>Spatial structure</em>{" "}
+          tab. They are independent of LDA — they describe the document
+          construction itself.
+        </p>
+
+        <p className="mt-3">
+          <strong>1. SLIC compactness</strong> (Achanta et al. 2012). For
+          each SLIC superpixel <Equation tex="R_i" />, define the colour
+          distance from its centroid <Equation tex="\mu_i^{\mathrm{c}}" /> and
+          the spatial distance from its centroid{" "}
+          <Equation tex="\mu_i^{\mathrm{xy}}" />; the compactness parameter{" "}
+          <Equation tex="m" /> trades them off in the per-pixel cost
+        </p>
+        <Equation
+          block
+          tex="D_i(p) = d_{\mathrm{c}}(p, \mu_i^{\mathrm{c}}) + \frac{m}{S} \, d_{\mathrm{xy}}(p, \mu_i^{\mathrm{xy}}), \quad S = \sqrt{N / K}."
+        />
+        <p>
+          Smaller compactness gives spatially tight regions; larger
+          compactness lets colour drive the boundaries. This project ships
+          two SLIC budgets — 500 and 2000 regions — both with the
+          scikit-image default <Equation tex="m = 10" /> for visual
+          reproducibility against the published Achanta et al. examples.
+        </p>
+
+        <p className="mt-3">
+          <strong>2. Felzenszwalb internal-vs-external energy</strong>{" "}
+          (Felzenszwalb &amp; Huttenlocher 2004). The graph-segmentation
+          baseline merges two adjacent regions{" "}
+          <Equation tex="C_1, C_2" /> whenever the minimum edge weight
+          crossing them is small relative to their internal differences
+          plus a size-penalised threshold{" "}
+          <Equation tex="\tau(C) = k / |C|" />:
+        </p>
+        <Equation
+          block
+          tex="\mathrm{Diff}(C_1, C_2) < \min\{\mathrm{Int}(C_1) + \tau(C_1), \, \mathrm{Int}(C_2) + \tau(C_2)\}."
+        />
+        <p>
+          The parameter <Equation tex="k" /> controls average region size
+          (larger <Equation tex="k" /> → larger regions). The builder fixes
+          <Equation tex="k = 100" /> for the SLIC-comparable budget; the
+          resulting regions are reported alongside SLIC and patch in the
+          cross-method-agreement table.
+        </p>
+
+        <p className="mt-3">
+          <strong>3. Moran's I — spatial autocorrelation of θ</strong>{" "}
+          (Moran 1950). For each topic <Equation tex="k" /> and a row-standardised
+          spatial weight matrix <Equation tex="W" /> (4-connectivity on the
+          image grid), the topic's spatial concentration is
+        </p>
+        <Equation
+          block
+          tex="I_k = \frac{N}{S_0} \cdot \frac{\sum_{i} \sum_{j} W_{ij} (\theta_{i,k} - \bar{\theta}_k)(\theta_{j,k} - \bar{\theta}_k)}{\sum_{i} (\theta_{i,k} - \bar{\theta}_k)^2}, \quad S_0 = \sum_{i,j} W_{ij}."
+        />
+        <p>
+          <Equation tex="I_k \in [-1, 1]" /> measures how strongly the
+          per-pixel topic weight is spatially clustered. A topic that
+          captures a contiguous mineral assemblage shows{" "}
+          <Equation tex="I_k \approx 0.6\text{–}0.9" /> on HIDSAG MINERAL1;
+          a noisy / over-fragmented topic falls below 0.2. The Workspace{" "}
+          <em>Spatial structure</em> tab reports the per-topic Moran's I
+          alongside its significance under a permutation null.
+        </p>
       </Section>
 
       <Section id="reproduce" title="How to reproduce the full corpus">

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -69,6 +69,26 @@ export default function MethodologyTheory() {
           Steyvers 2004) or stochastic VI (Hoffman et al. 2013); all of them are
           approximations to the same posterior.
         </p>
+        <p className="mt-3">
+          Variational inference posits a tractable family{" "}
+          <Equation tex="q(\theta, \phi, z \mid \lambda, \gamma, \nu)" /> — typically
+          a fully-factored mean-field surrogate — and maximises the
+          Evidence Lower BOund (ELBO):
+        </p>
+        <Equation
+          block
+          tex="\mathcal{L}(\lambda, \gamma, \nu) = \mathbb{E}_q[\log p(w, \theta, \phi, z \mid \alpha, \eta)] - \mathbb{E}_q[\log q(\theta, \phi, z)] \le \log p(w \mid \alpha, \eta)"
+        />
+        <p className="mt-3">
+          The gap between the ELBO and the log-evidence is exactly the
+          KL divergence <Equation tex="\mathrm{KL}\big(q(\cdot \mid \lambda,\gamma,\nu) \,\|\, p(\cdot \mid w, \alpha, \eta)\big)" />,
+          so maximising the ELBO is equivalent to minimising the
+          discrepancy between the surrogate <Equation tex="q" /> and the true
+          posterior. Online stochastic VI (Hoffman, Blei, Bach 2010) replaces
+          the full-batch ELBO with a noisy mini-batch estimator, which is
+          what <code>gensim</code>'s <code>LdaModel</code> ships and what this
+          project uses for the LDA fits.
+        </p>
       </Section>
 
       <Section
@@ -136,27 +156,150 @@ export default function MethodologyTheory() {
         </Figure>
       </Section>
 
+      <Section
+        id="topics-vs-endmembers"
+        title="Topics vs endmembers — the φ ↔ E relationship"
+        lead="Linear spectral unmixing factorises a cube into endmember signatures × per-pixel abundances. LDA factorises a tokenised cube into topic distributions × per-document mixtures. The two factorisations are different objects, but on mineral scenes they end up describing the same underlying material families — which is why the per-topic cosine vs endmember runs 0.7–0.9 on the HIDSAG mineral subsets."
+      >
+        <p>
+          Linear unmixing assumes the pixel spectrum{" "}
+          <Equation tex="x_d \in \mathbb{R}^B" /> is a non-negative combination
+          of <em>M</em> endmember signatures{" "}
+          <Equation tex="E = [e_1, \dots, e_M] \in \mathbb{R}_{\ge 0}^{B \times M}" />{" "}
+          weighted by abundance fractions{" "}
+          <Equation tex="a_d \in \Delta^{M-1}" />:
+        </p>
+        <Equation
+          block
+          tex="x_d \approx E\, a_d, \quad \sum_{m=1}^{M} a_{d,m} = 1, \quad a_{d,m} \ge 0."
+        />
+        <p className="mt-3">
+          LDA's mixed factorisation, after wordification, expresses the
+          reconstructed token distribution of a document as{" "}
+          <Equation tex="\hat{w}_d = \Phi\, \theta_d" /> where{" "}
+          <Equation tex="\Phi = [\phi_1, \dots, \phi_K] \in \Delta^{V-1, K}" /> are
+          the topic-word distributions and{" "}
+          <Equation tex="\theta_d \in \Delta^{K-1}" /> the per-document mixture.
+        </p>
+        <Equation block tex="\hat{w}_d = \Phi\, \theta_d, \quad \sum_{k=1}^{K} \theta_{d,k} = 1." />
+        <p className="mt-3">
+          The two factorisations live in different spaces:{" "}
+          <Equation tex="E" /> in continuous reflectance{" "}
+          <Equation tex="(B \text{ bands})" /> and{" "}
+          <Equation tex="\Phi" /> in discrete tokens{" "}
+          <Equation tex="(V \text{ vocabulary})" />. They are linked by the
+          wordification map <Equation tex="w: \mathbb{R}^B \to \mathbb{N}^V" />:
+          if <Equation tex="w" /> is approximately linear over the
+          mineral-relevant regime, then{" "}
+          <Equation tex="w(E\, a_d) \approx w(E)\, a_d" />, so a column of{" "}
+          <Equation tex="w(E)" /> behaves like a topic{" "}
+          <Equation tex="\phi_k" />. Empirically, on the HIDSAG MINERAL
+          subsets, the maximum cosine similarity between any topic{" "}
+          <Equation tex="\phi_k" /> and any endmember{" "}
+          <Equation tex="w(e_m)" /> is in the 0.7–0.9 range, with the matched
+          topic dominating the abundance map of the same material. The
+          Workspace USGS tab shows the same pairing against the public USGS
+          splib07 spectral library.
+        </p>
+      </Section>
+
+      <Section
+        id="coherence-metrics"
+        title="Topic coherence — c_v, NPMI, and U-Mass"
+        lead="Coherence quantifies whether the top words of a topic 'go together' in the corpus. The three metrics this project tracks (c_v, NPMI, U-Mass) measure that signal at different scales and with different statistics. Higher is better for c_v and NPMI; less-negative is better for U-Mass."
+      >
+        <p>
+          Given a topic <Equation tex="\phi_k" /> and its top-N words{" "}
+          <Equation tex="W_k = \{w_1, \dots, w_N\}" />, all three metrics
+          aggregate over pairs <Equation tex="(w_i, w_j) \in W_k" /> a
+          point-wise statistic that depends on the joint and marginal
+          probabilities of the two words in some reference corpus.
+        </p>
+
+        <p className="mt-3">
+          <strong>U-Mass</strong> (Mimno et al. 2011) uses corpus
+          co-occurrence within the documents themselves:
+        </p>
+        <Equation
+          block
+          tex="C_{\mathrm{UMass}}(\phi_k) = \sum_{i=2}^{N} \sum_{j=1}^{i-1} \log \frac{D(w_i, w_j) + \varepsilon}{D(w_j)}"
+        />
+        <p>
+          where <Equation tex="D(w)" /> is the number of documents containing{" "}
+          <em>w</em> and <Equation tex="D(w_i, w_j)" /> the number containing
+          both. U-Mass is bounded above by 0; values close to zero are best.
+        </p>
+
+        <p className="mt-3">
+          <strong>NPMI</strong> (Bouma 2009; Aletras &amp; Stevenson 2013) is
+          the normalised point-wise mutual information of the two words in a
+          sliding context window of width <Equation tex="s" />:
+        </p>
+        <Equation
+          block
+          tex="\mathrm{NPMI}(w_i, w_j) = \frac{\log \big(P(w_i, w_j) / (P(w_i) P(w_j))\big)}{-\log P(w_i, w_j)} \in [-1, 1], \quad C_{\mathrm{NPMI}}(\phi_k) = \frac{1}{\binom{N}{2}} \sum_{i < j} \mathrm{NPMI}(w_i, w_j)."
+        />
+
+        <p className="mt-3">
+          <strong>c_v</strong> (Röder, Both, Hinneburg 2015) combines an NPMI
+          sliding-window estimator with a one-vs-rest cosine of the top-N
+          NPMI vectors:
+        </p>
+        <Equation
+          block
+          tex="C_v(\phi_k) = \frac{1}{N} \sum_{i=1}^{N} \cos\!\Big(\vec{v}_{w_i},\; \tfrac{1}{N}\textstyle\sum_{j=1}^{N} \vec{v}_{w_j}\Big), \quad \vec{v}_w = \big(\mathrm{NPMI}(w, w_1), \dots, \mathrm{NPMI}(w, w_N)\big)."
+        />
+        <p>
+          In the project's WSDM-2015 systematic study, <em>c_v</em> showed
+          the highest correlation with human word-intrusion judgements
+          across 8 datasets and 6 model families. The Benchmarks{" "}
+          <em>Topics</em> tab tracks <em>c_v</em>, NPMI, and U-Mass jointly
+          so a verdict is never resting on a single metric.
+        </p>
+      </Section>
+
       <Section id="readings" title="Minimal reading list">
         <ul
           className="mt-2 space-y-2 list-disc pl-5"
           style={{ color: "var(--color-fg-subtle)" }}
         >
           <li>
-            Blei, Ng &amp; Jordan (2003) — <em>Latent Dirichlet Allocation</em>.
-            JMLR. The canonical paper.
+            Blei, Ng &amp; Jordan (2003) —{" "}
+            <em>Latent Dirichlet Allocation</em>. JMLR 3, 993–1022. The
+            canonical paper. §3 of the journal manuscript reproduces the
+            joint factorisation; §4.2 motivates the wordification recipes.
+          </li>
+          <li>
+            Hoffman, Blei &amp; Bach (2010) —{" "}
+            <em>Online learning for Latent Dirichlet Allocation</em>. NIPS.
+            Source of the stochastic VI updates that <code>gensim</code>
+            ships and that this project uses for the LDA fits (§3.3 of the
+            journal manuscript).
           </li>
           <li>
             Griffiths &amp; Steyvers (2004) —{" "}
-            <em>Finding scientific topics</em>. PNAS. Collapsed Gibbs.
+            <em>Finding scientific topics</em>. PNAS 101 (Suppl 1),
+            5228–5235. Collapsed-Gibbs alternative; cited in the
+            inference-choice rationale (§3.4).
           </li>
           <li>
             Sievert &amp; Shirley (2014) —{" "}
             <em>LDAvis: A method for visualizing and interpreting topics</em>.
-            Defines the relevance formula λ used in the Workspace page.
+            Defines the relevance formula λ (Workspace <em>Topics</em> tab)
+            and is referenced in §6.1 of the journal manuscript.
           </li>
           <li>
-            Stammbach et al. (2024) — <em>Re-visiting word intrusion</em>. TACL.
-            Modern framework for validating topics with LLM oracles.
+            Röder, Both &amp; Hinneburg (2015) —{" "}
+            <em>Exploring the Space of Topic Coherence Measures</em>. WSDM.
+            Source of the c_v / NPMI / U-Mass definitions used above and in
+            the Benchmarks <em>Topics</em> tab (§6.2 of the journal
+            manuscript).
+          </li>
+          <li>
+            Stammbach et al. (2024) —{" "}
+            <em>Re-visiting word intrusion</em>. TACL. Modern framework for
+            validating topics with LLM oracles; underpins the Workspace{" "}
+            <em>LLM tea-leaves</em> tab (§7 of the journal manuscript).
           </li>
         </ul>
       </Section>

--- a/frontend/src/pages/overview/Papers.tsx
+++ b/frontend/src/pages/overview/Papers.tsx
@@ -15,6 +15,7 @@ type PaperCard = {
   blurb: string;
   pdfHref: string;
   pdfSizeKb: number;
+  buildStamp: string;
   note: string;
 };
 
@@ -27,6 +28,7 @@ const PAPERS: PaperCard[] = [
       "Long-form treatment: 12-axis Framework, hierarchical Bayesian benchmarks, deep-encoder ablations, HIDSAG cross-preprocessing stability.",
     pdfHref: "/papers/caos-lda-hsi-journal.pdf",
     pdfSizeKb: 476,
+    buildStamp: "2026-05-22",
     note: "Preprint; target venue redacted while it circulates.",
   },
   {
@@ -37,6 +39,7 @@ const PAPERS: PaperCard[] = [
       "Short companion: theta-as-gate vs theta-as-feature, the B-3 result, and the multi-axis battery summary.",
     pdfHref: "/papers/caos-lda-hsi-conference.pdf",
     pdfSizeKb: 332,
+    buildStamp: "2026-05-22",
     note: "Preprint; target venue redacted while it circulates.",
   },
 ];
@@ -117,6 +120,12 @@ export function Papers() {
             >
               <span>{p.pdfHref.split("/").pop()}</span>
               <span>{p.pdfSizeKb} KB · PDF</span>
+            </div>
+            <div
+              className="text-[11px] font-mono"
+              style={{ color: "var(--color-fg-faint)" }}
+            >
+              build {p.buildStamp}
             </div>
           </a>
         ))}


### PR DESCRIPTION
Closes the 8-item Tier-2 list from the 2026-05-23 web-app methodology audit. Each item adds a formal block that backs a claim previously textual-only.

## Changes by page

| Page | New section / block | Backs |
|---|---|---|
| `Theory.tsx` | ELBO equation + KL-gap + SVI ref | the 'intractable in closed form / proceeds via VI/Gibbs/SVI' line |
| `Theory.tsx` | New §: 'Topics vs endmembers (phi ↔ E)' | the per-topic cosine 0.7-0.9 vs endmember claim |
| `Theory.tsx` | New §: 'Topic coherence — c_v, NPMI, U-Mass' | every 'wins coherence' claim across the surface |
| `Theory.tsx` | Reading list cross-links to paper §§ | the previously-vague 'see the paper' deferrals |
| `Application.tsx` | New §: 'Hierarchical Bayesian benchmark — model spec' | every P(μ_a > μ_b) ≥ 0.999 claim |
| `Application.tsx` | New §: 'Hungarian topic-matching — stability and cross-mask' | F-8 stability + cross-mask identity rows |
| `Pipeline.tsx` | New §: 'Spatial coherence' (SLIC compactness, Felzenszwalb, Moran's I) | the groupings stage diagnostics |
| `Papers.tsx` | Per-card `buildStamp` | replaces 'most recent deploy' informal language |

## Verification

- `npx tsc --noEmit` → exit 0
- `npx vite build` → exit 0, 10.65s, no errors

## Followup

Tier-2 items from the parallel builder audit (Demšar, Moran/Geary on builders, Kraskov, Bergstra/Akiba, Jégou PQ) land in c338.

Audit report: `_CAOS_MANAGE/wip/caos-lda-hsi/audits/2026-05-23-webapp-methodology-audit.md`.