### PR TITLE
c338: Tier-2 builder docstring citations across 12 builders

### DIFF
--- a/data-pipeline/build_cross_method_agreement.py
+++ b/data-pipeline/build_cross_method_agreement.py
@@ -9,6 +9,26 @@ eventual web app can render as a heatmap to answer the methodological
 question: which grouping methods agree and which disagree?
 
 Output: data/derived/cross_method_agreement/<scene>.json
+
+References
+----------
+- Hubert, L., Arabie, P. (1985). "Comparing Partitions". *Journal
+  of Classification* 2(1), 193-218. DOI:10.1007/BF01908075. Source
+  of the Adjusted Rand Index (ARI) used here as the
+  chance-corrected partition-agreement statistic.
+- Strehl, A., Ghosh, J. (2002). "Cluster Ensembles — A Knowledge
+  Reuse Framework for Combining Multiple Partitions". *JMLR* 3,
+  583-617. Reference for Normalised Mutual Information (NMI) as
+  the symmetric information-theoretic agreement statistic.
+- Rosenberg, A., Hirschberg, J. (2007). "V-Measure: A Conditional
+  Entropy-Based External Cluster Evaluation Measure". *EMNLP-CoNLL*,
+  410-420. Source of the V-measure (homogeneity / completeness
+  harmonic mean) that complements ARI and NMI here.
+- Vinh, N. X., Epps, J., Bailey, J. (2010). "Information Theoretic
+  Measures for Clusterings Comparison: Variants, Properties,
+  Normalization and Correction for Chance". *JMLR* 11, 2837-2854.
+  Reference for the chance-correction protocol applied to NMI in
+  scikit-learn's implementation.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_deep_anomaly.py
+++ b/data-pipeline/build_deep_anomaly.py
@@ -13,6 +13,24 @@ Output: data/derived/deep_anomaly/<scene>.json
 
 Higher Spearman => the deep representations reconstruction error
 flags hard / mis-classified documents better than chance.
+
+References
+----------
+- Masci, J., Meier, U., Cireşan, D., Schmidhuber, J. (2011). "Stacked
+  Convolutional Auto-Encoders for Hierarchical Feature Extraction".
+  *ICANN*. The canonical 1D-CAE design used here for the
+  reconstruction-loss anomaly indicator.
+- Kingma, D. P., Welling, M. (2014). "Auto-Encoding Variational
+  Bayes". *ICLR*. arXiv:1312.6114. Source of the VAE ELBO with the
+  recon-loss + KL decomposition this builder consumes.
+- Higgins, I., Matthey, L., Pal, A., et al. (2017). "β-VAE: Learning
+  Basic Visual Concepts with a Constrained Variational Framework".
+  *ICLR*. Introduces the β > 1 KL multiplier used to control the
+  disentanglement / reconstruction trade-off.
+- Hendrycks, D., Gimpel, K. (2017). "A Baseline for Detecting
+  Misclassified and Out-of-Distribution Examples in Neural
+  Networks". *ICLR*. arXiv:1610.02136. Justifies using the
+  reconstruction loss as a proxy for example-level uncertainty.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_hierarchical_super_topics.py
+++ b/data-pipeline/build_hierarchical_super_topics.py
@@ -12,6 +12,19 @@ list (scene_id, topic_k pairs), within-cluster cohesion, and the
 dendrogram in linkage-matrix form so the public web app can render it.
 
 Output: `data/derived/super_topics/super_topics.json`
+
+References
+----------
+- Murtagh, F., Contreras, P. (2012). "Algorithms for hierarchical
+  clustering: an overview". *WIREs Data Mining and Knowledge
+  Discovery* 2(1), 86-97. DOI:10.1002/widm.53. Reference for the
+  average-linkage agglomerative clustering used here on cosine
+  distances over the per-topic spectral profiles.
+- Sokal, R. R., Michener, C. D. (1958). "A Statistical Method for
+  Evaluating Systematic Relationships". *University of Kansas
+  Science Bulletin* 38, 1409-1438. The UPGMA / average-linkage
+  scheme; `scipy.cluster.hierarchy.linkage(..., method='average')`
+  implements it.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_linear_probe_panel.py
+++ b/data-pipeline/build_linear_probe_panel.py
@@ -30,6 +30,21 @@ It then:
 
 Output:
   data/derived/linear_probe_panel/<scene>.json
+
+References
+----------
+- Alain, G., Bengio, Y. (2017). "Understanding intermediate layers
+  using linear classifier probes". *ICLR Workshop*.
+  arXiv:1610.01644. The linear-probe protocol used here:
+  representation quality is diagnosed by the accuracy of a frozen
+  logistic regression on top of the candidate features, holding
+  the probe capacity fixed across methods.
+- Demšar, J. (2006). "Statistical Comparisons of Classifiers over
+  Multiple Data Sets". *JMLR* 7, 1-30. Source of the pairwise
+  Wilcoxon-Holm protocol applied across scenes here.
+- Cliff, N. (1993). "Dominance Statistics: Ordinal Analyses to
+  Answer Ordinal Questions". *Psychological Bulletin* 114(3),
+  494-509. Source of the Cliff δ effect-size measure.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_method_statistics.py
+++ b/data-pipeline/build_method_statistics.py
@@ -10,6 +10,16 @@ short natural-language verdict.
 This is the payload the interactive Workspace consumes to render
 confidence intervals, paired diff plots, and method ranking with
 statistical significance — instead of point estimates.
+
+References
+----------
+- Demšar, J. (2006). "Statistical Comparisons of Classifiers over
+  Multiple Data Sets". *Journal of Machine Learning Research* 7,
+  1-30. The canonical reference for the Friedman + Nemenyi /
+  Wilcoxon-signed-rank-with-Holm protocol applied here on paired
+  fold-seed scores across methods.
+- Wilcoxon, F. (1945). "Individual Comparisons by Ranking Methods".
+  *Biometrics* 1(6), 80-83. Underlies the paired signed-rank test.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_method_statistics_hidsag.py
+++ b/data-pipeline/build_method_statistics_hidsag.py
@@ -26,6 +26,22 @@ lacks:
 - ranking summary (mean rank, win rate)
 
 Output: data/derived/method_statistics_hidsag/<subset>.json
+
+References
+----------
+- Demšar, J. (2006). "Statistical Comparisons of Classifiers over
+  Multiple Data Sets". *Journal of Machine Learning Research* 7,
+  1-30. Canonical protocol for the Friedman χ² + Nemenyi post-hoc
+  and the Wilcoxon-signed-rank-with-Holm-Bonferroni correction
+  used here.
+- Cliff, N. (1993). "Dominance Statistics: Ordinal Analyses to
+  Answer Ordinal Questions". *Psychological Bulletin* 114(3),
+  494-509. Source of the Cliff's δ effect-size measure.
+- Wilcoxon, F. (1945). "Individual Comparisons by Ranking Methods".
+  *Biometrics* 1(6), 80-83.
+- Holm, S. (1979). "A Simple Sequentially Rejective Multiple Test
+  Procedure". *Scandinavian Journal of Statistics* 6(2), 65-70.
+  Source of the Holm step-down family-wise-error control.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_mutual_information.py
+++ b/data-pipeline/build_mutual_information.py
@@ -13,6 +13,20 @@ Output:
   data/derived/mutual_information/<scene>.json
   data/derived/mutual_information/hidsag/<subset>.json (when DMR fit
                                                        available)
+
+References
+----------
+- Kraskov, A., Stögbauer, H., Grassberger, P. (2004). "Estimating
+  Mutual Information". *Physical Review E* 69(6), 066138.
+  DOI:10.1103/PhysRevE.69.066138. The KSG k-nearest-neighbour MI
+  estimator underlying `sklearn.feature_selection.mutual_info_*`.
+- Ross, B. C. (2014). "Mutual Information between Discrete and
+  Continuous Data Sets". *PLOS ONE* 9(2), e87357. The KSG extension
+  to the mixed discrete/continuous case used in
+  `mutual_info_classif`.
+- Cover, T. M., Thomas, J. A. (2006). *Elements of Information
+  Theory* (2nd ed.). Wiley. Reference for the conditional-entropy
+  decomposition H(label | theta) = H(label) - I(theta; label).
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_optuna_hyperparam_search.py
+++ b/data-pipeline/build_optuna_hyperparam_search.py
@@ -15,6 +15,20 @@ is `c_v - 0.001 * perplexity_test`.
 
 Output: data/derived/lda_hyperparam_search/<scene>.json
         data/local/lda_hyperparam_search/<scene>/study.pkl
+
+References
+----------
+- Bergstra, J., Bardenet, R., Bengio, Y., Kégl, B. (2011).
+  "Algorithms for Hyper-Parameter Optimization". *NIPS*.
+  Source of the Tree-structured Parzen Estimator (TPE) sampler used
+  here via Optuna's default sampler.
+- Akiba, T., Sano, S., Yanase, T., Ohta, T., Koyama, M. (2019).
+  "Optuna: A Next-generation Hyperparameter Optimization Framework".
+  *KDD*. DOI:10.1145/3292500.3330701. The Optuna framework whose
+  `optuna.create_study(direction="maximize")` powers this builder.
+- Bergstra, J., Bengio, Y. (2012). "Random Search for Hyper-Parameter
+  Optimization". *JMLR* 13, 281-305. Reference for the random-search
+  baseline that TPE is expected to beat on a same-budget comparison.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_spatial_validation.py
+++ b/data-pipeline/build_spatial_validation.py
@@ -10,6 +10,19 @@ requires:
   ground-truth class regions
 
 Output: data/derived/spatial/<scene>.json
+
+References
+----------
+- Moran, P. A. P. (1950). "Notes on Continuous Stochastic Phenomena".
+  *Biometrika* 37(1/2), 17-23. Canonical definition of Moran's I for
+  continuous spatial fields; applied here on θ_dominant under
+  4-connectivity row-standardised weights.
+- Geary, R. C. (1954). "The Contiguity Ratio and Statistical Mapping".
+  *The Incorporated Statistician* 5(3), 115-145. Provides Geary's C
+  as a complementary local-contiguity statistic used alongside Moran's I.
+- Anselin, L. (1995). "Local Indicators of Spatial Association — LISA".
+  *Geographical Analysis* 27(2), 93-115. Foundation for the optional
+  LISA decomposition that breaks Moran's I into per-pixel contributions.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_topic_spatial_continuous.py
+++ b/data-pipeline/build_topic_spatial_continuous.py
@@ -24,6 +24,18 @@ proper BDE requires recomputing per-pixel theta over the full
 labelled mask via a fresh LDA transform, deferred to a follow-up.
 
 Output: data/derived/topic_spatial_continuous/<scene>.json
+
+References
+----------
+- Moran, P. A. P. (1950). "Notes on Continuous Stochastic Phenomena".
+  *Biometrika* 37(1/2), 17-23. Source of Moran's I for the continuous
+  theta_k abundance map under 4-neighbour row-standardised weights.
+- Geary, R. C. (1954). "The Contiguity Ratio and Statistical Mapping".
+  *The Incorporated Statistician* 5(3), 115-145. Source of Geary's C
+  as a complementary local-contiguity statistic.
+- Cliff, A. D., Ord, J. K. (1981). *Spatial Processes: Models &
+  Applications*. Pion. Reference for the permutation null used to
+  derive p-values for both I and C in the per-topic significance test.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_topic_to_library.py
+++ b/data-pipeline/build_topic_to_library.py
@@ -17,6 +17,25 @@ For every labelled scene with a topic-views fit, this builder:
    distance matrix per scene
 
 Output: `data/derived/topic_to_library/<scene>.json`
+
+References
+----------
+- Kruse, F. A., Lefkoff, A. B., Boardman, J. W., Heidebrecht, K. B.,
+  Shapiro, A. T., Barloon, P. J., Goetz, A. F. H. (1993). "The
+  Spectral Image Processing System (SIPS) — Interactive Visualization
+  and Analysis of Imaging Spectrometer Data". *Remote Sensing of
+  Environment* 44(2-3), 145-163.
+  DOI:10.1016/0034-4257(93)90013-N. Source of the Spectral Angle
+  Mapper (SAM) distance used here alongside cosine similarity.
+- Clark, R. N., Roush, T. L. (1984). "Reflectance Spectroscopy:
+  Quantitative Analysis Techniques for Remote Sensing
+  Applications". *Journal of Geophysical Research: Solid Earth*
+  89(B7), 6329-6340. Foundation of the reflectance-spectrum
+  matching approach.
+- Kokaly, R. F., Clark, R. N., Swayze, G. A., et al. (2017). "USGS
+  Spectral Library Version 7". *USGS Data Series* 1035.
+  DOI:10.3133/ds1035. Provides the splib07a reference spectra used
+  on the AVIRIS-Classic side of the matching.
 """
 from __future__ import annotations
 

--- a/data-pipeline/build_wordifications_v7v11.py
+++ b/data-pipeline/build_wordifications_v7v11.py
@@ -37,6 +37,20 @@ into the existing API plumbing.
 Output:
   data/local/wordifications/<recipe>/<scheme>_Q<q>/<scene>/{doc_term.npz, vocab.json}
   data/derived/wordifications/<scene>_<recipe>_<scheme>_Q<q>.json
+
+References
+----------
+- Clark, R. N., Roush, T. L. (1984). "Reflectance Spectroscopy:
+  Quantitative Analysis Techniques for Remote Sensing
+  Applications". *Journal of Geophysical Research: Solid Earth*
+  89(B7), 6329-6340. DOI:10.1029/JB089iB07p06329. Foundation of
+  the continuum-removed / convex-hull-quotient transform used in
+  V7 to isolate absorption features.
+- Jégou, H., Douze, M., Schmid, C. (2011). "Product Quantization
+  for Nearest Neighbor Search". *IEEE TPAMI* 33(1), 117-128.
+  DOI:10.1109/TPAMI.2010.57. The Product Quantisation method that
+  underlies V11; implemented here via the `nanopq.PQ` Python
+  wrapper.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Closes the Tier-2 builder-citation list from the 2026-05-23 audit. Each builder's docstring now carries a References block linking to the protocol/algorithm/theorem actually applied inside it.

| Builder | Cited |
|---|---|
| `build_method_statistics.py` | Demšar 2006, Wilcoxon 1945 |
| `build_method_statistics_hidsag.py` | Demšar 2006, Cliff 1993, Holm 1979, Wilcoxon 1945 |
| `build_spatial_validation.py` | Moran 1950, Geary 1954, Anselin 1995 |
| `build_topic_spatial_continuous.py` | Moran 1950, Geary 1954, Cliff-Ord 1981 |
| `build_mutual_information.py` | Kraskov-Stögbauer-Grassberger 2004, Ross 2014, Cover-Thomas 2006 |
| `build_optuna_hyperparam_search.py` | Bergstra 2011 TPE, Akiba 2019 Optuna, Bergstra-Bengio 2012 |
| `build_wordifications_v7v11.py` | Clark-Roush 1984 (V7), Jégou-Douze-Schmid 2011 (V11 PQ) |
| `build_topic_to_library.py` | Kruse 1993 SAM, Clark-Roush 1984, Kokaly 2017 splib07 |
| `build_deep_anomaly.py` | Masci 2011 CAE, Kingma-Welling 2014 VAE, Higgins 2017 β-VAE, Hendrycks-Gimpel 2017 |
| `build_hierarchical_super_topics.py` | Murtagh-Contreras 2012, Sokal-Michener 1958 UPGMA |
| `build_cross_method_agreement.py` | Hubert-Arabie 1985 ARI, Strehl-Ghosh 2002 NMI, Rosenberg-Hirschberg 2007 V-measure, Vinh 2010 |
| `build_linear_probe_panel.py` | Alain-Bengio 2017 linear probe, Demšar 2006, Cliff 1993 |

Docstring-only change; no functional code touched. 12/12 files pass `ast.parse`.

Audit report: `_CAOS_MANAGE/wip/caos-lda-hsi/audits/2026-05-23-builders-docstrings-audit.md`.