### PR TITLE
c344: close #565 i18n holes Tier-1 (LandingCTA, FindingsCarousel, Papers, EXPLORE_PHASES, TabStates)

### DIFF
--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -7,6 +7,9 @@
   },
   "states": {
     "loading": "Loading…",
+    "empty": "No data available for this scene / representation.",
+    "error_generic": "Could not load this tab's data.",
+    "retry": "Retry",
     "endpoint_unavailable": "Endpoint not available yet"
   },
   "external": {

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -2,8 +2,12 @@
   "overview": {
     "title": "Overview",
     "lead": "CAOS LDA HSI explores what probabilistic topic models can capture when documents are pixels, regions, or measurements drawn from hyperspectral imagery.",
-    "cta_workspace": "Open the Workspace",
-    "cta_methodology": "Read the Methodology",
+    "landing_cta": {
+      "lead": "Probabilistic topic models on hyperspectral imagery — a multi-axis evaluation framework that asks whether LDA basis spectra add interpretable value over deep encoders for HSI scene classification.",
+      "open_workspace": "Open the Workspace →",
+      "read_methodology": "Read the methodology",
+      "primary_actions": "primary actions"
+    },
     "hero": {
       "spectral_signature": "Live spectral signature",
       "indian_pines_caption": "Indian Pines · 16 classes · {{bands}} bands · 400–2500 nm",
@@ -27,8 +31,74 @@
       "variants_label": "Topic-model variants",
       "variants_sub": "LDA · ProdLDA · ETM · …"
     },
+    "papers": {
+      "section_kicker": "Papers",
+      "section_title": "Manuscripts in preparation",
+      "section_lead": "Both PDFs below are <strong>preprints</strong> — current build of the manuscripts as of the most recent deploy. They have not been submitted to a peer-reviewed venue yet; treat them as work-in-progress.",
+      "build_prefix": "build",
+      "size_suffix": "KB · PDF",
+      "cards": {
+        "journal": {
+          "badge": "Journal preprint",
+          "title": "Probabilistic topic models on hyperspectral imagery",
+          "blurb": "Long-form treatment: 12-axis Framework, hierarchical Bayesian benchmarks, deep-encoder ablations, HIDSAG cross-preprocessing stability.",
+          "note": "Preprint; target venue redacted while it circulates."
+        },
+        "conference": {
+          "badge": "Conference preprint",
+          "title": "Topic-routed classifiers for hyperspectral scene labelling",
+          "blurb": "Short companion: theta-as-gate vs theta-as-feature, the B-3 result, and the multi-axis battery summary.",
+          "note": "Preprint; target venue redacted while it circulates."
+        }
+      },
+      "links": {
+        "app_source": "App source (GitHub)",
+        "paper_source": "Paper source (GitHub)",
+        "wiki": "Project wiki"
+      }
+    },
     "findings": {
-      "section_badge": "Featured finding · {{idx}} / {{total}}"
+      "section_badge": "Featured finding · {{idx}} / {{total}}",
+      "see_pipeline": "See the pipeline page →",
+      "see_benchmark": "See the supporting Benchmarks panel →",
+      "show_finding_aria": "Show finding {{n}}",
+      "cards": {
+        "b3": {
+          "badge": "B-3",
+          "title": "θ as a gate beats θ as a feature; small lift over raw",
+          "body": "topic_routed_soft ties or narrowly beats raw_logistic on 4 of 6 labelled scenes (mean lift ≈ +0.5–1.5 pp; Pavia U is the largest at +1.4 pp). The bigger story is theta_logistic (θ as a flat feature), which loses to raw by 14 pp (Pavia U) up to 47 pp (Indian Pines). The 'θ is a gate, not a feature' framing is empirically validated."
+        },
+        "b3_followup": {
+          "badge": "B-3 follow-up",
+          "title": "No deep encoder can replace θ as the gate",
+          "body": "Hierarchical Bayesian: raw > θ > {pca_8, cae_1d_8, beta_vae_8} at P(μ_a > μ_b) ≥ 0.999. Softmaxed deep latents satisfy the simplex constraint geometrically but not structurally — the gating mechanism does not transfer."
+        },
+        "topic_family": {
+          "badge": "Topic family",
+          "title": "LDA wins ARI · ProdLDA wins coherence · ETM is the safe middle",
+          "body": "Head-to-head on 220-per-class stratified samples: LDA wins KMeans-vs-label ARI on 4/6 scenes (loses to ProdLDA/ETM on Pavia U and KSC); ProdLDA wins c_v topic coherence 6/6; ETM beats ProdLDA on ARI 5/6 (KSC is a tie at 0.222 vs 0.223; ETM wins the other five)."
+        },
+        "decoder_design": {
+          "badge": "Decoder design",
+          "title": "Decoder reconstruction target is itself a hyperparameter",
+          "body": "CAE-3D anchor-only vs full-patch gives net mean ΔARI ≈ +0.003 (K=8) and +0.011 (K=4) — neutral on average, scene-dependent direction. Pavia U inverts with capacity."
+        },
+        "gpu_stack": {
+          "badge": "GPU stack · operational",
+          "title": "50–120× speedup on the deep / neural family",
+          "body": "RTX 4070 Laptop CUDA 12.6: cae_3d_full K=32 single scene goes from ~60 min CPU to ~30 s GPU. Full K-curve {4, 8, 16, 32} × 6 scenes from 9–12 h CPU to ~10 min GPU. Determinism drift ±0.010 ARI is below per-seed σ ≈ 0.05. Engineering claim — runtime / determinism only, not a methodological result."
+        },
+        "stability": {
+          "badge": "Stability",
+          "title": "9-method × 6-scene seed stability ladder",
+          "body": "PCA = ICA (1.000 deterministic) > LDA > NMF > CAE-2D > CAE-1D > CAE-3D > dense-AE > β-VAE. KSC β-VAE off-diag ≈ 0.18 — KL stochasticity overwhelms the inter-seed signal."
+        },
+        "posterior_collapse": {
+          "badge": "Posterior collapse",
+          "title": "β-VAE Salinas at β ≥ 8 — textbook failure mode",
+          "body": "Salinas β-VAE at β=8 and β=16 collapses to ARI = 0.000: the encoder converges to q(z|x) ≈ p(z) regardless of input; the latent is uninformative. Salinas-A's compact 6-class structure resists the same regulariser."
+        }
+      }
     },
     "pipeline_anatomy": {
       "tag": "Pipeline anatomy",
@@ -381,6 +451,17 @@
   "workspace": {
     "title": "Workspace",
     "lead": "Guided flow in four steps: family → subset → representation → explore. Each step depends on the previous; you can go back at any time.",
+    "explore_phases": {
+      "tab_count_aria": "{{label}} ({{count}} tabs)",
+      "contains_active_suffix": " — contains the active tab",
+      "panels_aria": "{{label}} panels",
+      "data": { "label": "Data", "description": "What does the spectra look like?" },
+      "topics": { "label": "Topics", "description": "What does the topic model say?" },
+      "geometry": { "label": "Geometry", "description": "Where do topics live? 3D + spatial views." },
+      "drilldown": { "label": "Drilldown", "description": "Inspect specific docs, pixels, regions." },
+      "manipulate": { "label": "Manipulate", "description": "Step 8: tweak Q, K, band-mask." },
+      "stability": { "label": "Stability", "description": "How trustworthy is the fit?" }
+    },
     "spectral_envelopes_help": "The shaded band is the p25–p75 range; the line is the median. Click on a class to isolate it; click again to bring all classes back.",
     "raster_isolate_topic": "Isolate a topic",
     "embed3d_color_by_topic": "Dominant topic",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -7,6 +7,9 @@
   },
   "states": {
     "loading": "Cargando…",
+    "empty": "Sin datos disponibles para esta escena / representación.",
+    "error_generic": "No se pudieron cargar los datos de esta pestaña.",
+    "retry": "Reintentar",
     "endpoint_unavailable": "Endpoint no disponible todavía"
   },
   "external": {

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -2,8 +2,12 @@
   "overview": {
     "title": "Visión general",
     "lead": "CAOS LDA HSI explora qué pueden capturar los modelos probabilísticos de tópicos cuando los documentos son píxeles, regiones o mediciones extraídas de imágenes hiperespectrales.",
-    "cta_workspace": "Abrir el Laboratorio",
-    "cta_methodology": "Leer la metodología",
+    "landing_cta": {
+      "lead": "Modelos probabilísticos de tópicos sobre imágenes hiperespectrales — un framework de evaluación multi-eje que pregunta si los espectros base de LDA añaden valor interpretable sobre los codificadores profundos en la clasificación de escenas HSI.",
+      "open_workspace": "Abrir el Laboratorio →",
+      "read_methodology": "Leer la metodología",
+      "primary_actions": "acciones principales"
+    },
     "hero": {
       "spectral_signature": "Firma espectral en vivo",
       "indian_pines_caption": "Indian Pines · 16 clases · {{bands}} bandas · 400–2500 nm",
@@ -27,8 +31,74 @@
       "variants_label": "Variantes de tópicos",
       "variants_sub": "LDA · ProdLDA · ETM · …"
     },
+    "papers": {
+      "section_kicker": "Papers",
+      "section_title": "Manuscritos en preparación",
+      "section_lead": "Ambos PDFs a continuación son <strong>preprints</strong> — la compilación actual de los manuscritos al último deploy. Aún no se han enviado a una revista revisada por pares; tratar como work-in-progress.",
+      "build_prefix": "build",
+      "size_suffix": "KB · PDF",
+      "cards": {
+        "journal": {
+          "badge": "Preprint para revista",
+          "title": "Modelos probabilísticos de tópicos sobre imágenes hiperespectrales",
+          "blurb": "Tratamiento extenso: Framework de 12 ejes, benchmarks bayesianos jerárquicos, ablaciones de codificadores profundos, estabilidad cross-preprocessing en HIDSAG.",
+          "note": "Preprint; revista de destino redactada mientras circula."
+        },
+        "conference": {
+          "badge": "Preprint para conferencia",
+          "title": "Clasificadores topic-routed para etiquetado de escenas hiperespectrales",
+          "blurb": "Compañero corto: θ-como-compuerta vs θ-como-feature, el resultado B-3, y el resumen de la batería multi-eje.",
+          "note": "Preprint; conferencia de destino redactada mientras circula."
+        }
+      },
+      "links": {
+        "app_source": "Código de la app (GitHub)",
+        "paper_source": "Código del paper (GitHub)",
+        "wiki": "Wiki del proyecto"
+      }
+    },
     "findings": {
-      "section_badge": "Hallazgo destacado · {{idx}} / {{total}}"
+      "section_badge": "Hallazgo destacado · {{idx}} / {{total}}",
+      "see_pipeline": "Ver la página de pipeline →",
+      "see_benchmark": "Ver el panel de Benchmarks que lo respalda →",
+      "show_finding_aria": "Mostrar hallazgo {{n}}",
+      "cards": {
+        "b3": {
+          "badge": "B-3",
+          "title": "θ como compuerta supera a θ como feature; ganancia pequeña sobre raw",
+          "body": "topic_routed_soft iguala o supera marginalmente a raw_logistic en 4 de 6 escenas etiquetadas (ganancia media ≈ +0.5–1.5 pp; Pavia U es la mayor con +1.4 pp). La historia mayor es theta_logistic (θ como feature plano), que pierde frente a raw entre 14 pp (Pavia U) y 47 pp (Indian Pines). La idea 'θ es una compuerta, no un feature' queda empíricamente validada."
+        },
+        "b3_followup": {
+          "badge": "B-3 follow-up",
+          "title": "Ningún codificador profundo puede reemplazar a θ como compuerta",
+          "body": "Bayesiano jerárquico: raw > θ > {pca_8, cae_1d_8, beta_vae_8} con P(μ_a > μ_b) ≥ 0.999. Los latentes profundos softmaxeados satisfacen la restricción del símplex geométricamente pero no estructuralmente — el mecanismo de gating no se transfiere."
+        },
+        "topic_family": {
+          "badge": "Familia de tópicos",
+          "title": "LDA gana ARI · ProdLDA gana coherencia · ETM es el punto medio seguro",
+          "body": "Comparación cabeza-a-cabeza sobre muestras estratificadas de 220 por clase: LDA gana KMeans-vs-label ARI en 4/6 escenas (pierde frente a ProdLDA/ETM en Pavia U y KSC); ProdLDA gana coherencia c_v 6/6; ETM supera a ProdLDA en ARI 5/6 (KSC es un empate 0.222 vs 0.223; ETM gana las otras cinco)."
+        },
+        "decoder_design": {
+          "badge": "Diseño del decodificador",
+          "title": "El objetivo de reconstrucción es en sí mismo un hiperparámetro",
+          "body": "CAE-3D anchor-only vs full-patch da una ΔARI media neta ≈ +0.003 (K=8) y +0.011 (K=4) — neutra en promedio, con dirección dependiente de la escena. Pavia U se invierte con la capacidad."
+        },
+        "gpu_stack": {
+          "badge": "Stack GPU · operacional",
+          "title": "Aceleración 50–120× en la familia deep / neuronal",
+          "body": "RTX 4070 Laptop CUDA 12.6: cae_3d_full K=32 escena individual baja de ~60 min CPU a ~30 s GPU. Curva K completa {4, 8, 16, 32} × 6 escenas de 9–12 h CPU a ~10 min GPU. Deriva de determinismo ±0.010 ARI por debajo del σ por-seed ≈ 0.05. Afirmación de ingeniería — sólo runtime/determinismo, no resultado metodológico."
+        },
+        "stability": {
+          "badge": "Estabilidad",
+          "title": "Escalera de estabilidad por semillas — 9 métodos × 6 escenas",
+          "body": "PCA = ICA (1.000 determinista) > LDA > NMF > CAE-2D > CAE-1D > CAE-3D > dense-AE > β-VAE. β-VAE en KSC con off-diag ≈ 0.18 — la estocasticidad del KL ahoga la señal entre semillas."
+        },
+        "posterior_collapse": {
+          "badge": "Colapso de posterior",
+          "title": "β-VAE Salinas con β ≥ 8 — caso de manual",
+          "body": "β-VAE en Salinas con β=8 y β=16 colapsa a ARI = 0.000: el codificador converge a q(z|x) ≈ p(z) independientemente del input; el latente no aporta información. La estructura compacta de 6 clases de Salinas-A resiste el mismo regularizador."
+        }
+      }
     },
     "pipeline_anatomy": {
       "tag": "Pipeline anatómico",
@@ -381,6 +451,17 @@
   "workspace": {
     "title": "Laboratorio",
     "lead": "Flujo guiado en cuatro pasos: familia → conjunto → representación → explorar. Cada paso depende de los anteriores; puedes retroceder en cualquier momento.",
+    "explore_phases": {
+      "tab_count_aria": "{{label}} ({{count}} pestañas)",
+      "contains_active_suffix": " — contiene la pestaña activa",
+      "panels_aria": "Paneles de {{label}}",
+      "data": { "label": "Datos", "description": "¿Cómo se ven los espectros?" },
+      "topics": { "label": "Tópicos", "description": "¿Qué dice el modelo de tópicos?" },
+      "geometry": { "label": "Geometría", "description": "¿Dónde viven los tópicos? Vistas 3D + espaciales." },
+      "drilldown": { "label": "Detalle", "description": "Inspeccionar documentos, píxeles y regiones específicas." },
+      "manipulate": { "label": "Manipular", "description": "Paso 8: ajustar Q, K, band-mask." },
+      "stability": { "label": "Estabilidad", "description": "¿Qué tan confiable es el ajuste?" }
+    },
     "spectral_envelopes_help": "La banda sombreada es el rango p25–p75; la línea es la mediana. Haz click sobre una clase para aislarla; click nuevamente para ver todas.",
     "raster_isolate_topic": "Aislar un tópico",
     "embed3d_color_by_topic": "Tópico dominante",

--- a/frontend/src/pages/overview/FindingsCarousel.tsx
+++ b/frontend/src/pages/overview/FindingsCarousel.tsx
@@ -7,63 +7,23 @@ import { useTranslation } from "react-i18next";
 //   `kind`     "benchmark" → has a tab anchor, click reveals the supporting plot.
 //              "operational" → engineering / runtime claim with no benchmark
 //              tab. Marked exploratory on-card.
-const FINDINGS = [
-  {
-    badge: "B-3",
-    title: "θ as a gate beats θ as a feature; small lift over raw",
-    body: "topic_routed_soft ties or narrowly beats raw_logistic on 4 of 6 labelled scenes (mean lift ≈ +0.5–1.5 pp; Pavia U is the largest at +1.4 pp). The bigger story is theta_logistic (θ as a flat feature), which loses to raw by 14 pp (Pavia U) up to 47 pp (Indian Pines). The 'θ is a gate, not a feature' framing is empirically validated.",
-    accent: "rgba(40, 160, 80, 1)",
-    href: "/benchmarks#gating",
-    kind: "benchmark" as const,
-  },
-  {
-    badge: "B-3 follow-up",
-    title: "No deep encoder can replace θ as the gate",
-    body: "Hierarchical Bayesian: raw > θ > {pca_8, cae_1d_8, beta_vae_8} at P(μ_a > μ_b) ≥ 0.999. Softmaxed deep latents satisfy the simplex constraint geometrically but not structurally — the gating mechanism does not transfer.",
-    accent: "rgba(214, 39, 40, 1)",
-    href: "/benchmarks#gating",
-    kind: "benchmark" as const,
-  },
-  {
-    badge: "Topic family",
-    title: "LDA wins ARI · ProdLDA wins coherence · ETM is the safe middle",
-    body: "Head-to-head on 220-per-class stratified samples: LDA wins KMeans-vs-label ARI on 4/6 scenes (loses to ProdLDA/ETM on Pavia U and KSC); ProdLDA wins c_v topic coherence 6/6; ETM beats ProdLDA on ARI 5/6 (KSC is a tie at 0.222 vs 0.223; ETM wins the other five).",
-    accent: "rgba(31, 119, 180, 1)",
-    href: "/benchmarks#gating",
-    kind: "benchmark" as const,
-  },
-  {
-    badge: "Decoder design",
-    title: "Decoder reconstruction target is itself a hyperparameter",
-    body: "CAE-3D anchor-only vs full-patch gives net mean ΔARI ≈ +0.003 (K=8) and +0.011 (K=4) — neutral on average, scene-dependent direction. Pavia U inverts with capacity.",
-    accent: "rgba(170, 60, 200, 1)",
-    href: "/benchmarks#deep",
-    kind: "benchmark" as const,
-  },
-  {
-    badge: "GPU stack · operational",
-    title: "50–120× speedup on the deep / neural family",
-    body: "RTX 4070 Laptop CUDA 12.6: cae_3d_full K=32 single scene goes from ~60 min CPU to ~30 s GPU. Full K-curve {4, 8, 16, 32} × 6 scenes from 9–12 h CPU to ~10 min GPU. Determinism drift ±0.010 ARI is below per-seed σ ≈ 0.05. Engineering claim — runtime / determinism only, not a methodological result.",
-    accent: "rgba(214, 140, 40, 1)",
-    href: "/methodology/pipeline",
-    kind: "operational" as const,
-  },
-  {
-    badge: "Stability",
-    title: "9-method × 6-scene seed stability ladder",
-    body: "PCA = ICA (1.000 deterministic) > LDA > NMF > CAE-2D > CAE-1D > CAE-3D > dense-AE > β-VAE. KSC β-VAE off-diag ≈ 0.18 — KL stochasticity overwhelms the inter-seed signal.",
-    accent: "rgba(140, 86, 75, 1)",
-    href: "/benchmarks#axes",
-    kind: "benchmark" as const,
-  },
-  {
-    badge: "Posterior collapse",
-    title: "β-VAE Salinas at β ≥ 8 — textbook failure mode",
-    body: "Salinas β-VAE at β=8 and β=16 collapses to ARI = 0.000: the encoder converges to q(z|x) ≈ p(z) regardless of input; the latent is uninformative. Salinas-A's compact 6-class structure resists the same regulariser.",
-    accent: "rgba(120, 50, 50, 1)",
-    href: "/benchmarks#deep",
-    kind: "benchmark" as const,
-  },
+// Card copy (badge/title/body) lives in i18n under
+// `pages:overview.findings.cards.<key>` so both locales stay in sync.
+type FindingMeta = {
+  key: string;
+  accent: string;
+  href: string;
+  kind: "benchmark" | "operational";
+};
+
+const FINDINGS: FindingMeta[] = [
+  { key: "b3", accent: "rgba(40, 160, 80, 1)", href: "/benchmarks#gating", kind: "benchmark" },
+  { key: "b3_followup", accent: "rgba(214, 39, 40, 1)", href: "/benchmarks#gating", kind: "benchmark" },
+  { key: "topic_family", accent: "rgba(31, 119, 180, 1)", href: "/benchmarks#gating", kind: "benchmark" },
+  { key: "decoder_design", accent: "rgba(170, 60, 200, 1)", href: "/benchmarks#deep", kind: "benchmark" },
+  { key: "gpu_stack", accent: "rgba(214, 140, 40, 1)", href: "/methodology/pipeline", kind: "operational" },
+  { key: "stability", accent: "rgba(140, 86, 75, 1)", href: "/benchmarks#axes", kind: "benchmark" },
+  { key: "posterior_collapse", accent: "rgba(120, 50, 50, 1)", href: "/benchmarks#deep", kind: "benchmark" },
 ];
 
 export function FindingsCarousel() {
@@ -76,6 +36,7 @@ export function FindingsCarousel() {
     return () => clearInterval(timer);
   }, [paused]);
   const cur = FINDINGS[idx]!;
+  const k = (suffix: string) => `pages:overview.findings.cards.${cur.key}.${suffix}`;
 
   return (
     <section className="mt-10">
@@ -101,9 +62,9 @@ export function FindingsCarousel() {
         <div className="flex flex-wrap items-center gap-3 mb-3 pl-3">
           <span
             className="rounded-md px-2 py-0.5 text-[10.5px] font-semibold tracking-widest uppercase"
-            style={{ backgroundColor: cur.accent, color: "white" }}
+            style={{ backgroundColor: cur.accent, color: "var(--color-on-accent, white)" }}
           >
-            {cur.badge}
+            {t(k("badge"))}
           </span>
           <span
             className="text-[11px] uppercase tracking-widest"
@@ -116,13 +77,13 @@ export function FindingsCarousel() {
           className="text-lg md:text-xl font-semibold tracking-tight mb-2 pl-3"
           style={{ color: "var(--color-fg)" }}
         >
-          {cur.title}
+          {t(k("title"))}
         </h2>
         <p
           className="text-[14px] leading-relaxed max-w-4xl pl-3"
           style={{ color: "var(--color-fg-subtle)" }}
         >
-          {cur.body}
+          {t(k("body"))}
         </p>
         <div className="mt-4 pl-3">
           <Link
@@ -130,17 +91,19 @@ export function FindingsCarousel() {
             className="inline-flex items-center gap-1.5 text-[13px] font-medium underline-offset-4 hover:underline"
             style={{ color: cur.accent }}
           >
-            {cur.kind === "operational"
-              ? "See the pipeline page →"
-              : "See the supporting Benchmarks panel →"}
+            {t(
+              cur.kind === "operational"
+                ? "pages:overview.findings.see_pipeline"
+                : "pages:overview.findings.see_benchmark",
+            )}
           </Link>
         </div>
         <div className="mt-4 flex gap-1.5 pl-3">
           {FINDINGS.map((f, i) => (
             <button
-              key={f.title}
+              key={f.key}
               onClick={() => setIdx(i)}
-              aria-label={`Show finding ${i + 1}`}
+              aria-label={t("pages:overview.findings.show_finding_aria", { n: i + 1 })}
               className="h-1.5 rounded-full transition-all"
               style={{
                 width: i === idx ? 32 : 10,

--- a/frontend/src/pages/overview/LandingCTA.tsx
+++ b/frontend/src/pages/overview/LandingCTA.tsx
@@ -16,12 +16,13 @@ export function LandingCTA() {
         className="text-base lg:text-lg leading-snug max-w-3xl"
         style={{ color: "var(--color-fg)" }}
       >
-        {t("pages:overview.landing_cta.lead", {
-          defaultValue:
-            "Probabilistic topic models on hyperspectral imagery — a multi-axis evaluation framework that asks whether LDA basis spectra add interpretable value over deep encoders for HSI scene classification.",
-        })}
+        {t("pages:overview.landing_cta.lead")}
       </p>
-      <div className="flex gap-2 flex-wrap" role="group" aria-label="primary actions">
+      <div
+        className="flex gap-2 flex-wrap"
+        role="group"
+        aria-label={t("pages:overview.landing_cta.primary_actions")}
+      >
         <Link
           to="/workspace"
           className="rounded-md px-4 py-2 text-sm font-semibold transition-opacity"
@@ -30,9 +31,7 @@ export function LandingCTA() {
             color: "var(--color-on-accent, white)",
           }}
         >
-          {t("pages:overview.landing_cta.open_workspace", {
-            defaultValue: "Open the Workspace →",
-          })}
+          {t("pages:overview.landing_cta.open_workspace")}
         </Link>
         <Link
           to="/methodology"
@@ -43,9 +42,7 @@ export function LandingCTA() {
             backgroundColor: "transparent",
           }}
         >
-          {t("pages:overview.landing_cta.read_methodology", {
-            defaultValue: "Read the methodology",
-          })}
+          {t("pages:overview.landing_cta.read_methodology")}
         </Link>
       </div>
     </div>

--- a/frontend/src/pages/overview/Papers.tsx
+++ b/frontend/src/pages/overview/Papers.tsx
@@ -6,45 +6,40 @@
  * Both manuscripts are **preprints** — not yet submitted to a
  * peer-reviewed venue. Don't add venue/journal claims here until
  * acceptance.
+ *
+ * All card copy + section headings + link labels live under
+ * `pages:overview.papers.*`. Only file paths and numeric facts
+ * (size, build stamp) stay here.
  */
 
+import { Trans, useTranslation } from "react-i18next";
+
+type PaperVariant = "journal" | "conference";
+
 type PaperCard = {
-  variant: "journal" | "conference";
-  badge: string;
-  title: string;
-  blurb: string;
+  variant: PaperVariant;
   pdfHref: string;
   pdfSizeKb: number;
   buildStamp: string;
-  note: string;
 };
 
 const PAPERS: PaperCard[] = [
   {
     variant: "journal",
-    badge: "Journal preprint",
-    title: "Probabilistic topic models on hyperspectral imagery",
-    blurb:
-      "Long-form treatment: 12-axis Framework, hierarchical Bayesian benchmarks, deep-encoder ablations, HIDSAG cross-preprocessing stability.",
     pdfHref: "/papers/caos-lda-hsi-journal.pdf",
     pdfSizeKb: 510,
     buildStamp: "2026-05-24",
-    note: "Preprint; target venue redacted while it circulates.",
   },
   {
     variant: "conference",
-    badge: "Conference preprint",
-    title: "Topic-routed classifiers for hyperspectral scene labelling",
-    blurb:
-      "Short companion: theta-as-gate vs theta-as-feature, the B-3 result, and the multi-axis battery summary.",
     pdfHref: "/papers/caos-lda-hsi-conference.pdf",
     pdfSizeKb: 333,
     buildStamp: "2026-05-24",
-    note: "Preprint; target venue redacted while it circulates.",
   },
 ];
 
 export function Papers() {
+  const { t } = useTranslation(["pages"]);
   return (
     <section
       className="rounded-xl border p-6 mt-6"
@@ -59,21 +54,22 @@ export function Papers() {
           className="text-[10.5px] uppercase tracking-widest font-semibold mb-1"
           style={{ color: "var(--color-accent)" }}
         >
-          Papers
+          {t("pages:overview.papers.section_kicker")}
         </div>
         <h3
           className="text-lg font-semibold tracking-tight"
           style={{ color: "var(--color-fg)" }}
         >
-          Manuscripts in preparation
+          {t("pages:overview.papers.section_title")}
         </h3>
         <p
           className="text-sm mt-1"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          Both PDFs below are <strong>preprints</strong> — current build of the
-          manuscripts as of the most recent deploy. They have not been submitted
-          to a peer-reviewed venue yet; treat them as work-in-progress.
+          <Trans
+            i18nKey="pages:overview.papers.section_lead"
+            components={{ strong: <strong /> }}
+          />
         </p>
       </header>
 
@@ -94,38 +90,40 @@ export function Papers() {
               className="text-[10.5px] uppercase tracking-widest font-semibold"
               style={{ color: "var(--color-accent)" }}
             >
-              {p.badge}
+              {t(`pages:overview.papers.cards.${p.variant}.badge`)}
             </div>
             <div
               className="text-base font-semibold leading-snug"
               style={{ color: "var(--color-fg)" }}
             >
-              {p.title}
+              {t(`pages:overview.papers.cards.${p.variant}.title`)}
             </div>
             <div
               className="text-[13px] leading-relaxed"
               style={{ color: "var(--color-fg-subtle)" }}
             >
-              {p.blurb}
+              {t(`pages:overview.papers.cards.${p.variant}.blurb`)}
             </div>
             <div
               className="text-[11.5px] italic"
               style={{ color: "var(--color-fg-faint)" }}
             >
-              {p.note}
+              {t(`pages:overview.papers.cards.${p.variant}.note`)}
             </div>
             <div
               className="mt-2 flex items-baseline justify-between text-[12px] font-mono"
               style={{ color: "var(--color-fg-faint)" }}
             >
               <span>{p.pdfHref.split("/").pop()}</span>
-              <span>{p.pdfSizeKb} KB · PDF</span>
+              <span>
+                {p.pdfSizeKb} {t("pages:overview.papers.size_suffix")}
+              </span>
             </div>
             <div
               className="text-[11px] font-mono"
               style={{ color: "var(--color-fg-faint)" }}
             >
-              build {p.buildStamp}
+              {t("pages:overview.papers.build_prefix")} {p.buildStamp}
             </div>
           </a>
         ))}
@@ -141,7 +139,7 @@ export function Papers() {
           rel="noreferrer"
           className="underline hover:no-underline"
         >
-          App source (GitHub)
+          {t("pages:overview.papers.links.app_source")}
         </a>
         <a
           href="https://github.com/fsantibanezleal/CAOS_LDA_HSI_Paper"
@@ -149,7 +147,7 @@ export function Papers() {
           rel="noreferrer"
           className="underline hover:no-underline"
         >
-          Paper source (GitHub)
+          {t("pages:overview.papers.links.paper_source")}
         </a>
         <a
           href="https://github.com/fsantibanezleal/CAOS_LDA_HSI/wiki"
@@ -157,7 +155,7 @@ export function Papers() {
           rel="noreferrer"
           className="underline hover:no-underline"
         >
-          Project wiki
+          {t("pages:overview.papers.links.wiki")}
         </a>
       </div>
     </section>

--- a/frontend/src/pages/workspace/components/ExploreNav.tsx
+++ b/frontend/src/pages/workspace/components/ExploreNav.tsx
@@ -48,7 +48,16 @@ export function ExploreNav({
         {EXPLORE_PHASES.map((phase) => {
           const isActive = phase.id === activePhaseId;
           const isContainingCurrent = phase.id === currentPhase.id;
-          const containsActiveSuffix = isContainingCurrent && !isActive ? " — contains active tab" : "";
+          const phaseLabel = t(
+            `pages:workspace.explore_phases.${phase.id}.label` as never,
+          ) as string;
+          const phaseDescription = t(
+            `pages:workspace.explore_phases.${phase.id}.description` as never,
+          ) as string;
+          const containsActiveSuffix =
+            isContainingCurrent && !isActive
+              ? (t("pages:workspace.explore_phases.contains_active_suffix") as string)
+              : "";
           return (
             <button
               key={phase.id}
@@ -57,9 +66,14 @@ export function ExploreNav({
               id={`phase-tab-${phase.id}`}
               aria-controls={`phase-panel-${phase.id}`}
               aria-selected={isActive}
-              aria-label={`${phase.label} (${phase.tabs.length} tabs)${containsActiveSuffix}`}
+              aria-label={
+                (t("pages:workspace.explore_phases.tab_count_aria", {
+                  label: phaseLabel,
+                  count: phase.tabs.length,
+                }) as string) + containsActiveSuffix
+              }
               onClick={() => setActivePhaseId(phase.id)}
-              title={phase.description + (isContainingCurrent && !isActive ? " (contains the active tab)" : "")}
+              title={phaseDescription + containsActiveSuffix}
               className={cn(
                 "rounded-md border-l-4 border-y border-r px-3.5 py-2 text-[13px] font-semibold transition-all inline-flex items-center gap-2",
                 isActive ? "shadow-sm" : "opacity-70 hover:opacity-100",
@@ -81,7 +95,7 @@ export function ExploreNav({
                 color: isActive ? phase.color : "var(--color-fg)",
               }}
             >
-              <span>{phase.label}</span>
+              <span>{phaseLabel}</span>
               <span
                 className="font-mono text-[10.5px] rounded-full px-1.5 py-0.5"
                 style={{
@@ -115,11 +129,19 @@ export function ExploreNav({
           className="text-[11.5px] italic mb-2.5"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          {activePhase.description}
+          {t(
+            `pages:workspace.explore_phases.${activePhase.id}.description` as never,
+          ) as string}
         </p>
         <div
           role="tablist"
-          aria-label={`${activePhase.label} panels`}
+          aria-label={
+            t("pages:workspace.explore_phases.panels_aria", {
+              label: t(
+                `pages:workspace.explore_phases.${activePhase.id}.label` as never,
+              ) as string,
+            }) as string
+          }
           className="flex flex-wrap gap-1.5"
         >
           {activePhase.tabs.map((opt) => {

--- a/frontend/src/pages/workspace/components/TabStates.tsx
+++ b/frontend/src/pages/workspace/components/TabStates.tsx
@@ -12,6 +12,7 @@
  */
 
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
 const CARD_STYLE = {
   borderColor: "var(--color-border)",
@@ -28,7 +29,8 @@ type CommonProps = {
   children?: ReactNode;
 };
 
-export function TabLoading({ message = "Loading…" }: { message?: string }) {
+export function TabLoading({ message }: { message?: string }) {
+  const { t } = useTranslation(["common"]);
   return (
     <div
       className="rounded-lg border p-8 flex items-center justify-center"
@@ -40,23 +42,21 @@ export function TabLoading({ message = "Loading…" }: { message?: string }) {
         className="text-sm"
         style={{ color: "var(--color-fg-faint)" }}
       >
-        {message}
+        {message ?? t("common:states.loading")}
       </p>
     </div>
   );
 }
 
-export function TabEmpty({
-  message = "No data available for this scene / representation.",
-  detail,
-}: CommonProps) {
+export function TabEmpty({ message, detail }: CommonProps) {
+  const { t } = useTranslation(["common"]);
   return (
     <div
       className="rounded-lg border p-8 flex flex-col items-center justify-center gap-2"
       style={CARD_STYLE}
     >
       <p className="text-sm" style={{ color: "var(--color-fg-subtle)" }}>
-        {message}
+        {message ?? t("common:states.empty")}
       </p>
       {detail && (
         <p
@@ -71,11 +71,12 @@ export function TabEmpty({
 }
 
 export function TabError({
-  message = "Could not load this tab's data.",
+  message,
   detail,
   onRetry,
   children,
 }: CommonProps & { onRetry?: () => void }) {
+  const { t } = useTranslation(["common"]);
   return (
     <div
       className="rounded-lg border p-6 flex flex-col items-start gap-3"
@@ -86,7 +87,7 @@ export function TabError({
       role="alert"
     >
       <p className="text-sm" style={{ color: "var(--color-fg)" }}>
-        {message}
+        {message ?? t("common:states.error_generic")}
       </p>
       {detail && (
         <p
@@ -107,7 +108,7 @@ export function TabError({
             color: "var(--color-fg)",
           }}
         >
-          Retry
+          {t("common:states.retry")}
         </button>
       )}
       {children}

--- a/frontend/src/pages/workspace/state/tabs.ts
+++ b/frontend/src/pages/workspace/state/tabs.ts
@@ -71,10 +71,11 @@ export const EXPLORE_TAB_ORDER: ExploreTab[] = [
   "metrics",
 ];
 
+// Phase label + description are read from i18n by ExploreNav at
+// `pages:workspace.explore_phases.<phase.id>.{label,description}` so
+// only id + color + tabs live here.
 export type ExplorePhase = {
   id: "data" | "topics" | "geometry" | "drilldown" | "manipulate" | "stability";
-  label: string;
-  description: string;
   color: string;
   tabs: { id: ExploreTab; labelKey: string }[];
 };
@@ -89,8 +90,6 @@ export type ExplorePhase = {
 export const EXPLORE_PHASES: ExplorePhase[] = [
   {
     id: "data",
-    label: "Data",
-    description: "What does the spectra look like?",
     color: "rgba(56, 189, 248, 1)",
     tabs: [
       { id: "raw", labelKey: "raw" },
@@ -99,8 +98,6 @@ export const EXPLORE_PHASES: ExplorePhase[] = [
   },
   {
     id: "topics",
-    label: "Topics",
-    description: "What does the topic model say?",
     color: "rgba(40, 160, 80, 1)",
     tabs: [
       { id: "topics", labelKey: "topics" },
@@ -112,8 +109,6 @@ export const EXPLORE_PHASES: ExplorePhase[] = [
   },
   {
     id: "geometry",
-    label: "Geometry",
-    description: "Where do topics live? 3D + spatial views.",
     color: "rgba(170, 60, 200, 1)",
     tabs: [
       { id: "raster", labelKey: "raster" },
@@ -126,8 +121,6 @@ export const EXPLORE_PHASES: ExplorePhase[] = [
   },
   {
     id: "drilldown",
-    label: "Drilldown",
-    description: "Inspect specific docs, pixels, regions.",
     color: "rgba(214, 100, 60, 1)",
     tabs: [
       { id: "applydoc", labelKey: "applydoc" },
@@ -138,8 +131,6 @@ export const EXPLORE_PHASES: ExplorePhase[] = [
   },
   {
     id: "manipulate",
-    label: "Manipulate",
-    description: "Step 8: tweak Q, K, band-mask.",
     color: "rgba(234, 179, 8, 1)",
     tabs: [
       { id: "recipes", labelKey: "recipes" },
@@ -149,8 +140,6 @@ export const EXPLORE_PHASES: ExplorePhase[] = [
   },
   {
     id: "stability",
-    label: "Stability",
-    description: "How trustworthy is the fit?",
     color: "rgba(244, 63, 94, 1)",
     tabs: [
       { id: "stability", labelKey: "stability" },


### PR DESCRIPTION
Closes [#565](https://github.com/fsantibanezleal/cAOS_LDA_HSI/issues/565) Tier-1.

## Wired into i18n

- LandingCTA — three broken keys now resolve in both locales
- FindingsCarousel — 7 cards + CTAs + aria-labels
- Papers — both cards + section + links + size/build labels
- EXPLORE_PHASES — 6 phase labels + descriptions + shared aria templates
- TabStates — loading/empty/error/retry defaults via `common:states`

## Out-of-scope (follow-up)

Methodology Section title/lead translations (~15 calls across Theory/Application/Pipeline/Representations) — separate commit since each section needs its own key.

## Verification

- `tsc --noEmit` exit 0
- `vite build` exit 0, 13.90s