### PR TITLE
c350: methodology Section title+lead i18n (24 sections)

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -237,7 +237,40 @@
     }
   },
   "methodology_theory": {
-    "title": "Theory — PTM, LDA, HSI"
+    "title": "Theory — PTM, LDA, HSI",
+    "sections": {
+      "why-ptm": {
+        "title": "What is a probabilistic topic model?",
+        "lead": "A probabilistic topic model (PTM) describes every document as a latent mixture over a handful of word distributions called topics. The key point is that this latent structure is learned without supervision from word co-occurrences alone."
+      },
+      "lda-plate": {
+        "title": "LDA — plate notation and generative process",
+        "lead": "The outer plates repeat over documents and words; the latent distributions (theta and phi) are the objects the model learns."
+      },
+      "hsi-as-document": {
+        "title": "HSI as a corpus — why a pixel can be a document",
+        "lead": "Each pixel of a hyperspectral image is a reflectance vector. For LDA to consume it, the spectrum must be quantised and turned into a discrete sequence of tokens."
+      },
+      "why-mixed-membership": {
+        "title": "Mixed membership — why not hard classification?",
+        "lead": "The spectrum of a mineral pixel does not come from a single species. Mixtures, intermixed vegetation, shadow and atmospheric scattering yield measurements that reflect several signatures at once."
+      },
+      "topics-vs-endmembers": {
+        "title": "Topics vs endmembers — the φ ↔ E relationship",
+        "lead": "Linear spectral unmixing factorises a cube into endmember signatures × per-pixel abundances. LDA factorises a tokenised cube into topic distributions × per-document mixtures. The two factorisations are different objects, but on mineral scenes they end up describing the same underlying material families — which is why the per-topic cosine vs endmember runs 0.7–0.9 on the HIDSAG mineral subsets."
+      },
+      "coherence-metrics": {
+        "title": "Topic coherence — c_v, NPMI, and U-Mass",
+        "lead": "Coherence quantifies whether the top words of a topic 'go together' in the corpus. The three metrics this project tracks (c_v, NPMI, U-Mass) measure that signal at different scales and with different statistics. Higher is better for c_v and NPMI; less-negative is better for U-Mass."
+      },
+      "metric-glossary": {
+        "title": "Metric glossary — partition agreement, spectral angle, β",
+        "lead": "Three definitions referenced throughout the site that the prior surfaces named but never gave on-page. Each is a one-line formula plus the role it plays in the framework."
+      },
+      "readings": {
+        "title": "Minimal reading list"
+      }
+    }
   },
   "methodology_representations": {
     "title": "Representations · method-by-method",
@@ -465,10 +498,75 @@
     }
   },
   "methodology_pipeline": {
-    "title": "Local data-creation pipeline"
+    "title": "Local data-creation pipeline",
+    "sections": {
+      "overview": {
+        "title": "Overview",
+        "lead": "Twelve chained stages. Each is a single-command script. Each stage's output is the input for the next."
+      },
+      "stages": {
+        "title": "The stages, command by command",
+        "lead": "The commands assume you are at the repo root and have the two venvs created (scripts/local setup-all)."
+      },
+      "spatial-coherence": {
+        "title": "Spatial coherence — what the groupings stage measures",
+        "lead": "The four document constructions (SLIC-500, SLIC-2000, patch-7/15, Felzenszwalb) carve the cube in geometrically different ways. The cross-method agreement panel summarises how often they place two pixels in the same document; the per-method spatial-coherence diagnostics summarise how compact each construction's regions are."
+      },
+      "reproduce": {
+        "title": "How to reproduce the full corpus"
+      },
+      "boundary": {
+        "title": "What the web app does NOT do"
+      }
+    }
   },
   "methodology_application": {
-    "title": "Application to classification and regression via topics"
+    "title": "Application to classification and regression via topics",
+    "sections": {
+      "why": {
+        "title": "Why not classify directly?",
+        "lead": "Reducing an HSI cube to hard classes throws away all the mixture information. If a pixel is 60% soil and 40% scrub, a hard label picks one and lies. Topics preserve the mixture."
+      },
+      "three-families": {
+        "title": "Three families of topic-based models",
+        "lead": "Each family uses theta in a different way. The difference is methodological, not cosmetic."
+      },
+      "direct": {
+        "title": "1. Direct — theta as feature",
+        "lead": "The simplest, also the least informative."
+      },
+      "routed": {
+        "title": "2. Routed — one specialist per topic",
+        "lead": "Each topic trains its own classifier on the raw spectrum, weighted by membership."
+      },
+      "embedded": {
+        "title": "3. Embedded — theta concatenated with baseline",
+        "lead": "Concat is the least elegant but sometimes the healthiest: let the classifier decide how much theta weighs."
+      },
+      "regression": {
+        "title": "Regression over measurements (HIDSAG)",
+        "lead": "When the target is not a class but a continuous measurement (Cu %, Au g/t, mineral grade), the logic is the same with linear regressors."
+      },
+      "bayesian-spec": {
+        "title": "Hierarchical Bayesian benchmark — model spec",
+        "lead": "The pairwise posterior probabilities P(μ_a > μ_b) above come from a flat one-way ANOVA-style model with additive scene and fold offsets, fit with PyMC NUTS. The spec below mirrors the actual code in build_bayesian_classification_labelled.py exactly — no hidden hyperpriors."
+      },
+      "hungarian-stability": {
+        "title": "Hungarian topic-matching — stability and cross-mask identity",
+        "lead": "Topic indices are not stable across re-fits — both LDA seeds and water-mask choices can permute the K topics. The seed-stability and cross-mask validation blocks pair topics by the assignment that maximises the average matched cosine. That is the Hungarian (linear-assignment) algorithm applied to a topic-cosine cost matrix."
+      },
+      "paired-statistics": {
+        "title": "Paired statistics — Cliff δ, Wilcoxon-Holm, Friedman-Nemenyi",
+        "lead": "The Benchmarks page reports method-vs-method comparisons that use three non-parametric tools. Each is one paragraph here so the headline numbers (Cliff δ = +0.28 on the embedded baseline, P(routed_soft > raw) = 0.641, Wilcoxon-Holm < 0.05) are self-contained."
+      },
+      "axis-crosswalk": {
+        "title": "F-axes (paper) ↔ B-axes (wiki / web app)",
+        "lead": "The companion paper introduces a twelve-axis Framework (F-1..F-12). This site and the wiki use a different B-1..B-12 taxonomy that predates the paper. The two share three concepts under different ordinals; the crosswalk below makes the mapping explicit."
+      },
+      "see-also": {
+        "title": "How to continue"
+      }
+    }
   },
   "databases": {
     "title": "Databases",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -237,7 +237,40 @@
     }
   },
   "methodology_theory": {
-    "title": "Teoría — PTM, LDA, HSI"
+    "title": "Teoría — PTM, LDA, HSI",
+    "sections": {
+      "why-ptm": {
+        "title": "¿Qué es un modelo probabilístico de tópicos?",
+        "lead": "Un modelo probabilístico de tópicos (PTM) describe cada documento como una mezcla latente sobre un puñado de distribuciones de palabras llamadas tópicos. La idea clave es que esa estructura latente se aprende sin supervisión, sólo a partir de las co-ocurrencias de palabras."
+      },
+      "lda-plate": {
+        "title": "LDA — notación plate y proceso generativo",
+        "lead": "Las plates externas se repiten sobre documentos y palabras; las distribuciones latentes (theta y phi) son los objetos que aprende el modelo."
+      },
+      "hsi-as-document": {
+        "title": "HSI como corpus — por qué un píxel puede ser un documento",
+        "lead": "Cada píxel de una imagen hiperespectral es un vector de reflectancia. Para que LDA lo consuma, el espectro debe cuantizarse y convertirse en una secuencia discreta de tokens."
+      },
+      "why-mixed-membership": {
+        "title": "Pertenencia mezclada — ¿por qué no clasificación dura?",
+        "lead": "El espectro de un píxel mineral no proviene de una sola especie. Mezclas, vegetación entrelazada, sombras y dispersión atmosférica producen medidas que reflejan varias firmas a la vez."
+      },
+      "topics-vs-endmembers": {
+        "title": "Tópicos vs endmembers — la relación φ ↔ E",
+        "lead": "El unmixing espectral lineal factoriza un cubo en firmas endmember × abundancias por píxel. LDA factoriza un cubo tokenizado en distribuciones de tópicos × mezclas por documento. Las dos factorizaciones son objetos distintos, pero en escenas minerales acaban describiendo las mismas familias de material — por eso el mejor coseno por tópico vs endmember se sitúa en 0.94–1.00 en las escenas etiquetadas."
+      },
+      "coherence-metrics": {
+        "title": "Coherencia de tópicos — c_v, NPMI y U-Mass",
+        "lead": "La coherencia cuantifica si las palabras superiores de un tópico 'van juntas' en el corpus. Las tres métricas que sigue este proyecto (c_v, NPMI, U-Mass) miden esa señal a distintas escalas y con distintas estadísticas. Más alto es mejor para c_v y NPMI; menos negativo es mejor para U-Mass."
+      },
+      "metric-glossary": {
+        "title": "Glosario de métricas — concordancia de particiones, ángulo espectral, β",
+        "lead": "Tres definiciones referenciadas a lo largo del sitio que las superficies previas nombraban sin definir on-page. Cada una es una fórmula de una línea más el rol que juega en el framework."
+      },
+      "readings": {
+        "title": "Lista mínima de lectura"
+      }
+    }
   },
   "methodology_representations": {
     "title": "Representaciones · método por método",
@@ -465,10 +498,75 @@
     }
   },
   "methodology_pipeline": {
-    "title": "Pipeline local de creación de datos"
+    "title": "Pipeline local de creación de datos",
+    "sections": {
+      "overview": {
+        "title": "Visión general",
+        "lead": "Doce etapas encadenadas. Cada una es un script de un solo comando. La salida de una etapa es la entrada de la siguiente."
+      },
+      "stages": {
+        "title": "Las etapas, comando por comando",
+        "lead": "Los comandos asumen que estás en la raíz del repo y tienes los dos venvs creados (scripts/local setup-all)."
+      },
+      "spatial-coherence": {
+        "title": "Coherencia espacial — qué mide la etapa de groupings",
+        "lead": "Las cuatro construcciones de documento (SLIC-500, SLIC-2000, patch-7/15, Felzenszwalb) recortan el cubo de maneras geométricamente distintas. El panel de cross-method agreement resume con qué frecuencia colocan dos píxeles en el mismo documento; los diagnósticos por método de coherencia espacial resumen qué tan compactas son las regiones de cada construcción."
+      },
+      "reproduce": {
+        "title": "Cómo reproducir el corpus completo"
+      },
+      "boundary": {
+        "title": "Lo que la web app NO hace"
+      }
+    }
   },
   "methodology_application": {
-    "title": "Aplicación a clasificación y regresión vía tópicos"
+    "title": "Aplicación a clasificación y regresión vía tópicos",
+    "sections": {
+      "why": {
+        "title": "¿Por qué no clasificar directamente?",
+        "lead": "Reducir un cubo HSI a clases duras descarta toda la información de mezcla. Si un píxel es 60% suelo y 40% matorral, una etiqueta dura elige uno y miente. Los tópicos preservan la mezcla."
+      },
+      "three-families": {
+        "title": "Tres familias de modelos basados en tópicos",
+        "lead": "Cada familia usa theta de manera distinta. La diferencia es metodológica, no cosmética."
+      },
+      "direct": {
+        "title": "1. Directo — theta como feature",
+        "lead": "El más simple, también el menos informativo."
+      },
+      "routed": {
+        "title": "2. Routed — un especialista por tópico",
+        "lead": "Cada tópico entrena su propio clasificador sobre el espectro crudo, ponderado por la pertenencia."
+      },
+      "embedded": {
+        "title": "3. Embedded — theta concatenado con baseline",
+        "lead": "Concat es el menos elegante pero a veces el más sano: dejar que el clasificador decida cuánto pesa theta."
+      },
+      "regression": {
+        "title": "Regresión sobre mediciones (HIDSAG)",
+        "lead": "Cuando el objetivo no es una clase sino una medición continua (Cu %, Au g/t, ley mineral), la lógica es la misma con regresores lineales."
+      },
+      "bayesian-spec": {
+        "title": "Benchmark bayesiano jerárquico — spec del modelo",
+        "lead": "Las probabilidades posteriores pareadas P(μ_a > μ_b) provienen de un modelo aditivo estilo ANOVA con offsets de escena y fold, ajustado con NUTS de PyMC. El spec abajo replica el código de build_bayesian_classification_labelled.py exactamente — sin hyperpriors ocultos."
+      },
+      "hungarian-stability": {
+        "title": "Topic-matching húngaro — estabilidad e identidad cross-mask",
+        "lead": "Los índices de tópicos no son estables entre re-ajustes — tanto las semillas LDA como las máscaras de agua pueden permutar los K tópicos. Los bloques de seed-stability y cross-mask emparejan tópicos con la asignación que maximiza el coseno emparejado medio. Eso es el algoritmo Húngaro (asignación lineal) aplicado a una matriz de costo coseno-tópico."
+      },
+      "paired-statistics": {
+        "title": "Estadísticas pareadas — Cliff δ, Wilcoxon-Holm, Friedman-Nemenyi",
+        "lead": "La página Benchmarks reporta comparaciones método-vs-método que usan tres herramientas no paramétricas. Cada una es un párrafo aquí para que los números headline (Cliff δ = +0.28 en el embedded baseline, P(routed_soft > raw) = 0.641, Wilcoxon-Holm < 0.05) sean autocontenidos."
+      },
+      "axis-crosswalk": {
+        "title": "Ejes F (paper) ↔ ejes B (wiki / web app)",
+        "lead": "El paper compañero introduce un framework de doce ejes (F-1..F-12). Este sitio y la wiki usan una taxonomía B-1..B-12 distinta que precede al paper. Las dos comparten tres conceptos bajo distintos ordinales; el crosswalk abajo hace explícito el mapeo."
+      },
+      "see-also": {
+        "title": "Cómo continuar"
+      }
+    }
   },
   "databases": {
     "title": "Bases de datos",

--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -54,11 +54,7 @@ export default function MethodologyApplication() {
       title={t("pages:methodology_application.title")}
       lead="How topics are applied to classification and regression problems on HSI. Three families of models: direct (theta as feature), routed (one specialist per topic) and embedded (theta concatenated with baselines)."
     >
-      <Section
-        id="why"
-        title="Why not classify directly?"
-        lead="Reducing an HSI cube to hard classes throws away all the mixture information. If a pixel is 60% soil and 40% scrub, a hard label picks one and lies. Topics preserve the mixture."
-      >
+      <Section id="why" title={t("pages:methodology_application.sections.why.title")} lead={t("pages:methodology_application.sections.why.lead")}>
         <p>
           The classical HSI strategy — fit a random forest or an SVM on the raw
           spectrum — works on balanced, well-labelled scenes. It fails where it
@@ -80,21 +76,13 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="three-families"
-        title="Three families of topic-based models"
-        lead="Each family uses theta in a different way. The difference is methodological, not cosmetic."
-      >
+      <Section id="three-families" title={t("pages:methodology_application.sections.three-families.title")} lead={t("pages:methodology_application.sections.three-families.lead")}>
         <Figure caption="Left to right: direct (theta as feature vector), routed (one specialist per topic, mixed by theta), embedded (theta concatenated with a linear baseline). All three are implemented as separate builders in data-pipeline/ and compared head-to-head on the Benchmarks page.">
           <ThreeFamiliesSVG />
         </Figure>
       </Section>
 
-      <Section
-        id="direct"
-        title="1. Direct — theta as feature"
-        lead="The simplest, also the least informative."
-      >
+      <Section id="direct" title={t("pages:methodology_application.sections.direct.title")} lead={t("pages:methodology_application.sections.direct.lead")}>
         <p>The predictor takes theta and produces the label:</p>
         <Equation block tex="\hat{y}_d = \arg\max_y \, p_\beta(y \mid \theta_d) = \arg\max_y \, \beta_y^\top \theta_d" />
         <p>
@@ -112,11 +100,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="routed"
-        title="2. Routed — one specialist per topic"
-        lead="Each topic trains its own classifier on the raw spectrum, weighted by membership."
-      >
+      <Section id="routed" title={t("pages:methodology_application.sections.routed.title")} lead={t("pages:methodology_application.sections.routed.lead")}>
         <p>
           The idea: for each topic <Equation tex="k" />, train a classifier{" "}
           <Equation tex="P_k(y \mid x)" /> on the raw spectrum{" "}
@@ -203,11 +187,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="embedded"
-        title="3. Embedded — theta concatenated with baseline"
-        lead="Concat is the least elegant but sometimes the healthiest: let the classifier decide how much theta weighs."
-      >
+      <Section id="embedded" title={t("pages:methodology_application.sections.embedded.title")} lead={t("pages:methodology_application.sections.embedded.lead")}>
         <p>
           The input feature is the concatenation{" "}
           <Equation tex="[\theta_d \; \| \; z_d]" /> where{" "}
@@ -229,11 +209,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="regression"
-        title="Regression over measurements (HIDSAG)"
-        lead="When the target is not a class but a continuous measurement (Cu %, Au g/t, mineral grade), the logic is the same with linear regressors."
-      >
+      <Section id="regression" title={t("pages:methodology_application.sections.regression.title")} lead={t("pages:methodology_application.sections.regression.lead")}>
         <p>
           For the HIDSAG subsets (GEOMET, MINERAL1, MINERAL2, GEOCHEM, PORPHYRY)
           the Benchmarks page reports R² and bootstrap CI95 over each numeric
@@ -251,8 +227,8 @@ export default function MethodologyApplication() {
 
       <Section
         id="bayesian-spec"
-        title="Hierarchical Bayesian benchmark — model spec"
-        lead="The pairwise posterior probabilities P(μ_a > μ_b) above come from a flat one-way ANOVA-style model with additive scene and fold offsets, fit with PyMC NUTS. The spec below mirrors the actual code in build_bayesian_classification_labelled.py exactly — no hidden hyperpriors."
+        title={t("pages:methodology_application.sections.bayesian-spec.title")}
+        lead={t("pages:methodology_application.sections.bayesian-spec.lead")}
       >
         <p>
           For each method <Equation tex="m \in \{\mathrm{pca\_K}, \mathrm{raw}, \mathrm{theta}, \mathrm{routed\_hard}, \mathrm{routed\_soft}\}" />,
@@ -322,11 +298,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="hungarian-stability"
-        title="Hungarian topic-matching — stability and cross-mask identity"
-        lead="Topic indices are not stable across re-fits — both LDA seeds and water-mask choices can permute the K topics. The seed-stability and cross-mask validation blocks pair topics by the assignment that maximises the average matched cosine. That is the Hungarian (linear-assignment) algorithm applied to a topic-cosine cost matrix."
-      >
+      <Section id="hungarian-stability" title={t("pages:methodology_application.sections.hungarian-stability.title")} lead={t("pages:methodology_application.sections.hungarian-stability.lead")}>
         <p>
           Given two fits with topic-word matrices{" "}
           <Equation tex="\Phi^{(a)} = [\phi_1^{(a)}, \dots, \phi_K^{(a)}]" />{" "}
@@ -364,8 +336,8 @@ export default function MethodologyApplication() {
 
       <Section
         id="paired-statistics"
-        title="Paired statistics — Cliff δ, Wilcoxon-Holm, Friedman-Nemenyi"
-        lead="The Benchmarks page reports method-vs-method comparisons that use three non-parametric tools. Each is one paragraph here so the headline numbers (Cliff δ = +0.28 on the embedded baseline, P(routed_soft > raw) = 0.641, Wilcoxon-Holm < 0.05) are self-contained."
+        title={t("pages:methodology_application.sections.paired-statistics.title")}
+        lead={t("pages:methodology_application.sections.paired-statistics.lead")}
       >
         <p>
           <strong>Cliff δ</strong> (Cliff 1993) is a non-parametric
@@ -419,11 +391,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="what-topics-capture"
-        title='What does a topic "capture", in task terms?'
-        lead="It is not text: the question is answered visually with distributions."
-      >
+      <Section id="what-topics-capture" title='What does a topic "capture", in task terms?' title={t("pages:methodology_application.sections.what-topics-capture.title")}>
         <p>
           For each topic <Equation tex="k" />, the Workspace shows:
         </p>
@@ -463,11 +431,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="axis-crosswalk"
-        title="F-axes (paper) ↔ B-axes (wiki / web app)"
-        lead="The companion paper introduces a twelve-axis Framework (F-1..F-12). This site and the wiki use a different B-1..B-12 taxonomy that predates the paper. The two share three concepts under different ordinals; the crosswalk below makes the mapping explicit."
-      >
+      <Section id="axis-crosswalk" title={t("pages:methodology_application.sections.axis-crosswalk.title")} lead={t("pages:methodology_application.sections.axis-crosswalk.lead")}>
         <p>
           <strong>F-framework in one paragraph.</strong> Topic models are
           rarely evaluated on a single axis, yet the literature defaults to
@@ -534,7 +498,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section id="see-also" title="How to continue">
+      <Section id="see-also" title={t("pages:methodology_application.sections.see-also.title")}>
         <p>
           The Workspace lets you <em>apply</em> a model to a specific document
           and see the five panels live (all precomputed, no re-fitting). The

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -123,21 +123,13 @@ export default function MethodologyPipeline() {
       title={t("pages:methodology_pipeline.title")}
       lead="The web app serves pre-computed material. Generation runs locally — fetches, preprocesses, fits LDA, computes downstream readouts, packs the manifest. Source code lives in the project repo; here we show only how to run it and what it produces."
     >
-      <Section
-        id="overview"
-        title="Overview"
-        lead="Twelve chained stages. Each is a single-command script. Each stage's output is the input for the next."
-      >
+      <Section id="overview" title={t("pages:methodology_pipeline.sections.overview.title")} lead={t("pages:methodology_pipeline.sections.overview.lead")}>
         <Figure caption="The twelve stages of the local pipeline. Arrows indicate data dependencies between stages. Acquisition is one-time; wordifications, validation-blocks and super-topics are re-run when an upstream parameter changes.">
           <PipelineDagSVG />
         </Figure>
       </Section>
 
-      <Section
-        id="stages"
-        title="The stages, command by command"
-        lead="The commands assume you are at the repo root and have the two venvs created (scripts/local setup-all)."
-      >
+      <Section id="stages" title={t("pages:methodology_pipeline.sections.stages.title")} lead={t("pages:methodology_pipeline.sections.stages.lead")}>
         <div className="space-y-4 mt-2">
           {STAGES.map((s, idx) => (
             <div
@@ -191,11 +183,7 @@ export default function MethodologyPipeline() {
         </div>
       </Section>
 
-      <Section
-        id="spatial-coherence"
-        title="Spatial coherence — what the groupings stage measures"
-        lead="The four document constructions (SLIC-500, SLIC-2000, patch-7/15, Felzenszwalb) carve the cube in geometrically different ways. The cross-method agreement panel summarises how often they place two pixels in the same document; the per-method spatial-coherence diagnostics summarise how compact each construction's regions are."
-      >
+      <Section id="spatial-coherence" title={t("pages:methodology_pipeline.sections.spatial-coherence.title")} lead={t("pages:methodology_pipeline.sections.spatial-coherence.lead")}>
         <p>
           Three diagnostics are computed by the groupings + spatial-validation
           builders and surfaced in the Workspace <em>Spatial structure</em>{" "}
@@ -265,7 +253,7 @@ export default function MethodologyPipeline() {
         </p>
       </Section>
 
-      <Section id="reproduce" title="How to reproduce the full corpus">
+      <Section id="reproduce" title={t("pages:methodology_pipeline.sections.reproduce.title")}>
         <p>
           The short form — run everything in order, single session:
         </p>
@@ -309,7 +297,7 @@ $ scripts/local audit-manifest     # must end with 0; legacy orphans are reporte
         </p>
       </Section>
 
-      <Section id="boundary" title="What the web app does NOT do">
+      <Section id="boundary" title={t("pages:methodology_pipeline.sections.boundary.title")}>
         <ul
           className="mt-2 space-y-2 list-disc pl-5"
           style={{ color: "var(--color-fg-subtle)" }}

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -12,11 +12,7 @@ export default function MethodologyTheory() {
       title={t("pages:methodology_theory.title")}
       lead="Probabilistic topic models over hyperspectral imagery — what they are, how they work, and why a pixel can be treated as a document."
     >
-      <Section
-        id="why-ptm"
-        title="What is a probabilistic topic model?"
-        lead="A probabilistic topic model (PTM) describes every document as a latent mixture over a handful of word distributions called topics. The key point is that this latent structure is learned without supervision from word co-occurrences alone."
-      >
+      <Section id="why-ptm" title={t("pages:methodology_theory.sections.why-ptm.title")} lead={t("pages:methodology_theory.sections.why-ptm.lead")}>
         <p>
           Under the most popular model — Latent Dirichlet Allocation (Blei, Ng &amp;
           Jordan, 2003) — a corpus of <em>D</em> documents over a vocabulary of
@@ -36,11 +32,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="lda-plate"
-        title="LDA — plate notation and generative process"
-        lead="The outer plates repeat over documents and words; the latent distributions (theta and phi) are the objects the model learns."
-      >
+      <Section id="lda-plate" title={t("pages:methodology_theory.sections.lda-plate.title")} lead={t("pages:methodology_theory.sections.lda-plate.lead")}>
         <Figure caption="LDA in plate notation. The outer plate iterates over the D documents; the inner plate, over the N_d words of each document. Theta_d is the per-document mixture over K topics; phi_k is the distribution of topic k over the V vocabulary words.">
           <PlateNotationSVG />
         </Figure>
@@ -91,11 +83,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="hsi-as-document"
-        title="HSI as a corpus — why a pixel can be a document"
-        lead="Each pixel of a hyperspectral image is a reflectance vector. For LDA to consume it, the spectrum must be quantised and turned into a discrete sequence of tokens."
-      >
+      <Section id="hsi-as-document" title={t("pages:methodology_theory.sections.hsi-as-document.title")} lead={t("pages:methodology_theory.sections.hsi-as-document.lead")}>
         <p>
           A hyperspectral image (HSI) is a cube{" "}
           <Equation tex="X \in \mathbb{R}^{H \times W \times B}" />, where each
@@ -129,11 +117,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="why-mixed-membership"
-        title="Mixed membership — why not hard classification?"
-        lead="The spectrum of a mineral pixel does not come from a single species. Mixtures, intermixed vegetation, shadow and atmospheric scattering yield measurements that reflect several signatures at once."
-      >
+      <Section id="why-mixed-membership" title={t("pages:methodology_theory.sections.why-mixed-membership.title")} lead={t("pages:methodology_theory.sections.why-mixed-membership.lead")}>
         <p>
           The hard-membership assumption — a pixel belongs to exactly one
           class — fails in HSI because every spectrum is by construction a
@@ -156,11 +140,7 @@ export default function MethodologyTheory() {
         </Figure>
       </Section>
 
-      <Section
-        id="topics-vs-endmembers"
-        title="Topics vs endmembers — the φ ↔ E relationship"
-        lead="Linear spectral unmixing factorises a cube into endmember signatures × per-pixel abundances. LDA factorises a tokenised cube into topic distributions × per-document mixtures. The two factorisations are different objects, but on mineral scenes they end up describing the same underlying material families — which is why the per-topic cosine vs endmember runs 0.7–0.9 on the HIDSAG mineral subsets."
-      >
+      <Section id="topics-vs-endmembers" title={t("pages:methodology_theory.sections.topics-vs-endmembers.title")} lead={t("pages:methodology_theory.sections.topics-vs-endmembers.lead")}>
         <p>
           Linear unmixing assumes the pixel spectrum{" "}
           <Equation tex="x_d \in \mathbb{R}^B" /> is a non-negative combination
@@ -207,11 +187,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="coherence-metrics"
-        title="Topic coherence — c_v, NPMI, and U-Mass"
-        lead="Coherence quantifies whether the top words of a topic 'go together' in the corpus. The three metrics this project tracks (c_v, NPMI, U-Mass) measure that signal at different scales and with different statistics. Higher is better for c_v and NPMI; less-negative is better for U-Mass."
-      >
+      <Section id="coherence-metrics" title={t("pages:methodology_theory.sections.coherence-metrics.title")} lead={t("pages:methodology_theory.sections.coherence-metrics.lead")}>
         <p>
           Given a topic <Equation tex="\phi_k" /> and its top-N words{" "}
           <Equation tex="W_k = \{w_1, \dots, w_N\}" />, all three metrics
@@ -262,11 +238,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="metric-glossary"
-        title="Metric glossary — partition agreement, spectral angle, β"
-        lead="Three definitions referenced throughout the site that the prior surfaces named but never gave on-page. Each is a one-line formula plus the role it plays in the framework."
-      >
+      <Section id="metric-glossary" title={t("pages:methodology_theory.sections.metric-glossary.title")} lead={t("pages:methodology_theory.sections.metric-glossary.lead")}>
         <p className="mt-2">
           <strong>Adjusted Rand Index (ARI)</strong>{" "}
           (Hubert &amp; Arabie 1985) is the chance-corrected pairwise
@@ -329,7 +301,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section id="readings" title="Minimal reading list">
+      <Section id="readings" title={t("pages:methodology_theory.sections.readings.title")}>
         <ul
           className="mt-2 space-y-2 list-disc pl-5"
           style={{ color: "var(--color-fg-subtle)" }}


### PR DESCRIPTION
Closes the methodology Section translation gap left from c344 (#565 follow-up). 24 sections wired to i18n with full ES translations.