### PR TITLE
c352: Tier-2 remaining inline definitions (DMR-LDA, NFINDR/ATGP, Geary's C, word-intrusion, KSG MI)

### DIFF
--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -218,6 +218,24 @@ export default function MethodologyApplication() {
           is a distinct way of using the same apparatus.
         </p>
         <p className="mt-3">
+          <strong>What DMR-LDA is.</strong> Mimno &amp; McCallum (2008)
+          extended LDA so that the per-document topic prior is a function
+          of observed metadata <Equation tex="x_d" />:
+        </p>
+        <Equation
+          block
+          tex="\theta_d \sim \mathrm{Dirichlet}\big(\exp(W x_d)\big), \quad W \in \mathbb{R}^{K \times F},"
+        />
+        <p>
+          where <Equation tex="x_d" /> is the per-document covariate vector
+          (HIDSAG continuous assay readings) and <Equation tex="W" /> is a
+          learned weight matrix. Standard LDA recovers as the special case
+          <Equation tex="W x_d \equiv \alpha" /> for every document. DMR-LDA
+          lets topics depend on a sample's Cu / Au / mineral grade without
+          turning those numbers into the prediction target — they enter as
+          context, not as supervision.
+        </p>
+        <p className="mt-3">
           <strong>Builders:</strong>{" "}
           <code>build_dmr_lda_hidsag.py</code> +{" "}
           <code>build_method_statistics_hidsag.py</code>. The Benchmarks page

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -251,6 +251,25 @@ export default function MethodologyPipeline() {
           <em>Spatial structure</em> tab reports the per-topic Moran's I
           alongside its significance under a permutation null.
         </p>
+
+        <p className="mt-3">
+          <strong>4. Geary's C — local contiguity ratio</strong>{" "}
+          (Geary 1954). Complementary to Moran's I but built from
+          pairwise squared differences rather than centered products:
+        </p>
+        <Equation
+          block
+          tex="C_k = \frac{(N - 1) \sum_{i} \sum_{j} W_{ij} (\theta_{i,k} - \theta_{j,k})^2}{2 \, S_0 \sum_{i} (\theta_{i,k} - \bar{\theta}_k)^2}."
+        />
+        <p>
+          <Equation tex="C_k \in [0, 2]" />: values below 1 indicate
+          positive spatial autocorrelation (smoother than random), values
+          above 1 indicate negative autocorrelation. Geary's C is more
+          sensitive than Moran's I to <em>local</em> differences (it
+          downweights long-range pairs more aggressively), so the two are
+          usually reported jointly. The <code>build_topic_spatial_continuous.py</code>
+          builder ships both per topic.
+        </p>
       </Section>
 
       <Section id="reproduce" title={t("pages:methodology_pipeline.sections.reproduce.title")}>

--- a/frontend/src/pages/workspace/tabs/LlmTeaLeavesTab.tsx
+++ b/frontend/src/pages/workspace/tabs/LlmTeaLeavesTab.tsx
@@ -81,10 +81,15 @@ export function LlmTeaLeavesTab({
           className="text-[12px] mb-3"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          For each topic, top-N words by relevance λ get one intruder word
-          inserted. An LLM ({data.model}) is asked to pick the odd word out.
-          Correct picks ⇒ topic is coherent enough to make the intruder
-          obvious. Higher accuracy ⇒ more interpretable topics.
+          The <em>word-intrusion test</em> (Chang et al. 2009,
+          ‘Reading Tea Leaves’) is the gold-standard human-judgement
+          coherence probe: given a topic's top-N words, one is replaced
+          by a random word drawn from another topic; the rater (here
+          an LLM, model = {data.model}) must identify the intruder.
+          Stammbach et al. (2024, TACL) showed that capable LLMs match
+          human accuracy on this task. Correct picks ⇒ topic is
+          coherent enough to make the intruder obvious. Higher accuracy
+          ⇒ more interpretable topics; chance baseline is 1 / (top-N + 1).
         </p>
         <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
           <UnmixingStat label="model" value={data.model} />

--- a/frontend/src/pages/workspace/tabs/MetricsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/MetricsTab.tsx
@@ -87,7 +87,16 @@ export function MetricsTab({
             How much information about the label each K-dim representation
             retains (theta vs PCA-K vs NMF-K vs ICA-K vs dense-AE-K). Reported
             as joint MI clipped to label entropy and as the fraction of entropy
-            recovered.
+            recovered.{" "}
+            <em>
+              MI is estimated with the Kraskov–Stögbauer–Grassberger
+              k-NN estimator (k = 3) for continuous–discrete pairs
+              (Ross 2014 extension of Kraskov et al. 2004), the same
+              estimator scikit-learn ships behind{" "}
+              <code>mutual_info_classif</code>. Values are bias-corrected
+              and shown alongside the label-entropy upper bound so the
+              ratio MI / H(L) reflects the actual recoverable fraction.
+            </em>
           </p>
         </header>
         {miLoading && (

--- a/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
@@ -85,7 +85,7 @@ export function UnmixingTab({
 
       <UnmixingSpectraCard
         title="NFINDR endmember spectra"
-        subtitle="K vertices of the data simplex (Winter 1999). Each curve is one pure-pixel candidate."
+        subtitle="N-FINDR (Winter 1999) seeds K random pixels, then iteratively swaps each in turn for any pixel that increases the volume of the K-simplex they span; convergence picks K pure-pixel candidates that maximise simplex volume. Each curve below is one of those K vertices."
         spectra={data.nfindr_endmembers ?? []}
         wavelengths={wavelengths}
         accent="rgba(56,189,248,1)"
@@ -94,7 +94,7 @@ export function UnmixingTab({
       {data.atgp_endmembers && data.atgp_endmembers.length > 0 ? (
         <UnmixingSpectraCard
           title="ATGP endmember spectra"
-          subtitle="Automatic Target Generation Process (Ren & Chang 2003). Alternative extractor — pixel-wise orthogonal subspace projection."
+          subtitle="Automatic Target Generation Process (Ren & Chang 2003): pick the pixel with maximum L2 norm as endmember 1; iteratively project the residual orthogonal to the current set and pick the pixel with the largest projection norm as the next endmember. Greedy alternative to N-FINDR; usually produces a similar set."
           spectra={data.atgp_endmembers}
           wavelengths={wavelengths}
           accent="rgba(170,60,200,1)"


### PR DESCRIPTION
Closes the remaining Tier-2 content-depth items from #569 follow-up. Each named-but-undefined term now carries math + canonical citation.