### PR TITLE
c353: a11y SVG role+aria-label + theme-token white fills

### DIFF
--- a/frontend/src/components/plots/ClassDistributionBar.tsx
+++ b/frontend/src/components/plots/ClassDistributionBar.tsx
@@ -44,7 +44,7 @@ export function ClassDistributionBar({ classes }: Props) {
                   x={x + segW / 2}
                   y={h - 16}
                   textAnchor="middle"
-                  fill="#fff"
+                  fill="var(--color-on-accent, #ffffff)"
                   fontSize="10.5"
                   fontFamily="ui-sans-serif, system-ui, sans-serif"
                   style={{ textShadow: "0 1px 2px rgba(0,0,0,0.4)" }}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2148,7 +2148,12 @@ function HidsagModalitySpectraCard({ eda }: { eda: import("@/api/client").Hidsag
         Average spectral signature per HIDSAG measurement modality (typical VNIR low/high, SWIR low). Used to validate stratification + bad-band heuristics.
       </p>
       {entries.length ? (
-        <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-auto">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="w-full h-auto"
+          role="img"
+          aria-label="Mean spectra per HIDSAG measurement type (modality)"
+        >
           {[0, 0.25, 0.5, 0.75, 1].map((g) => (
             <line key={g} x1={padL} y1={padT + g * innerH} x2={padL + innerW} y2={padT + g * innerH} stroke="currentColor" strokeOpacity={g === 0 || g === 1 ? 0.25 : 0.07} strokeWidth="0.6" />
           ))}
@@ -2294,7 +2299,13 @@ function HidsagCorrelationCard({ eda }: { eda: import("@/api/client").HidsagEda 
         Blue = positive correlation, red = negative. First {N} targets shown. Strong off-diagonal pairs (|ρ| ≥ 0.5) indicate redundancy / co-located mineralisation.
       </p>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 720 }}>
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="max-w-full h-auto"
+          style={{ maxWidth: 720 }}
+          role="img"
+          aria-label="Pearson correlation matrix of HIDSAG geochemistry targets"
+        >
           {names.map((n, j) => (
             <text key={`col-${n}`} x={labelW + j * cell + cell / 2} y={labelW - 4} fontSize="9.5" textAnchor="end" transform={`rotate(-50 ${labelW + j * cell + cell / 2} ${labelW - 4})`} fill="currentColor" opacity={0.7} fontFamily="ui-monospace, monospace">
               {n}

--- a/frontend/src/pages/benchmarks/BenchmarksAxes.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksAxes.tsx
@@ -585,7 +585,7 @@ function CrossSceneTransferSection() {
                     y={headerH + i * cell + (cell - 2) / 2 + 4}
                     fontSize="13"
                     textAnchor="middle"
-                    fill="white"
+                    fill="var(--color-on-accent, #ffffff)"
                     fontWeight={isDiag ? "700" : "500"}
                     fontFamily="ui-monospace, monospace"
                   >

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -642,13 +642,13 @@ function MixedMembershipSVG() {
           <rect x="160" y="80" width="200" height="20" fill="#0ea5e9" />
           <rect x="360" y="80" width="120" height="20" fill="#f97316" />
           <rect x="480" y="80" width="50" height="20" fill="#22c55e" />
-          <text x="260" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+          <text x="260" y="95" textAnchor="middle" fill="var(--color-on-accent, #ffffff)" fontSize="11">
             topic 1 — 0.59
           </text>
-          <text x="420" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+          <text x="420" y="95" textAnchor="middle" fill="var(--color-on-accent, #ffffff)" fontSize="11">
             topic 2 — 0.27
           </text>
-          <text x="505" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+          <text x="505" y="95" textAnchor="middle" fill="var(--color-on-accent, #ffffff)" fontSize="11">
             t3
           </text>
         </g>

--- a/frontend/src/pages/workspace/tabs/CrossMethodAgreementTab.tsx
+++ b/frontend/src/pages/workspace/tabs/CrossMethodAgreementTab.tsx
@@ -154,6 +154,8 @@ function AgreementMatrixCard({
           viewBox={`0 0 ${W} ${H}`}
           className="max-w-full h-auto"
           style={{ maxWidth: 1080 }}
+          role="img"
+          aria-label="Cross-method agreement matrix (ARI between each pair of partition methods)"
         >
           {agreement.method_names.map((m, j) => (
             <text

--- a/frontend/src/pages/workspace/tabs/RobustnessTab.tsx
+++ b/frontend/src/pages/workspace/tabs/RobustnessTab.tsx
@@ -239,6 +239,8 @@ function CrossSceneTransferCard({
           viewBox={`0 0 ${W} ${H}`}
           className="max-w-full h-auto"
           style={{ maxWidth: 1080 }}
+          role="img"
+          aria-label="Cross-scene transfer ARI matrix"
         >
           {transfer.scene_order.map((sc, j) => (
             <text

--- a/frontend/src/pages/workspace/tabs/SpatialStructureTab.tsx
+++ b/frontend/src/pages/workspace/tabs/SpatialStructureTab.tsx
@@ -456,6 +456,8 @@ function FelzenszwalbCard({
           viewBox={`0 0 ${W} ${H}`}
           className="max-w-full h-auto"
           style={{ maxWidth: 900 }}
+          role="img"
+          aria-label="Spatial structure per-method comparison plot"
         >
           <line
             x1={pad.l}

--- a/frontend/src/pages/workspace/tabs/SpectralBrowserTab.tsx
+++ b/frontend/src/pages/workspace/tabs/SpectralBrowserTab.tsx
@@ -416,6 +416,8 @@ function FalseColorBandPicker({
             className="block"
             style={{ width: Math.min(420, W * cellSize), height: Math.min(480, H * cellSize), backgroundColor: "var(--color-bg)" }}
             shapeRendering="crispEdges"
+            role="img"
+            aria-label="Spectral browser pixel-grid (click to pin a pixel and inspect its spectrum)"
           >
             {samples.map((s, i) => (
               <rect

--- a/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
@@ -186,7 +186,7 @@ function UnmixingSpectraCard({
       </div>
       <p className="text-[12px] mb-2" style={{ color: "var(--color-fg-faint)" }}>{subtitle}</p>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 900 }}>
+        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 900 }} role="img" aria-label="Per-topic endmember-cosine matrix">
           {/* axes */}
           <line x1={pad.l} y1={pad.t + innerH} x2={pad.l + innerW} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
           <line x1={pad.l} y1={pad.t} x2={pad.l} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
@@ -288,7 +288,7 @@ function UnmixingTopicHeatmap({
         Rows = LDA topic profiles φ<sub>k</sub>; columns = NFINDR endmember spectra. Cell ≈ cosine. Best matches are starred.
       </p>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 720 }}>
+        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 720 }} role="img" aria-label="Per-topic abundance map heatmap">
           {Array.from({ length: N }).map((_, j) => (
             <text key={`c-${j}`} x={labelW + j * cell + cell / 2} y={labelW - 6} fontSize="9.5" textAnchor="middle" fill="currentColor" opacity={0.65} fontFamily="ui-monospace, monospace">
               em{j}


### PR DESCRIPTION
Closes #568 a11y follow-up.