### PR TITLE
c354: responsive md: breakpoints (8 grid containers)

### DIFF
--- a/frontend/src/pages/methodology/Representations.tsx
+++ b/frontend/src/pages/methodology/Representations.tsx
@@ -515,7 +515,7 @@ function MethodDetail({ entry, t }: { entry: MethodEntry; t: TFunction<["pages"]
         </p>
       </header>
 
-      <div className="grid lg:grid-cols-2 gap-6">
+      <div className="grid md:grid-cols-2 gap-6">
         <MethodSubsection title={t("pages:methodology_representations.section_theory")} accent={FAMILY_COLOR[entry.family]}>
           {entry.equations.map((eq, i) => (
             <Equation key={i} tex={eq} block />

--- a/frontend/src/pages/workspace/tabs/BandMaskTab.tsx
+++ b/frontend/src/pages/workspace/tabs/BandMaskTab.tsx
@@ -115,7 +115,7 @@ export function BandMaskTab({
           the band-selection axis differs. The summary below ships
           precomputed; click any mask to drill into the per-topic detail.
         </p>
-        <ul className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <ul className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
           {Object.entries(maskDefs).map(([id, def]) => {
             const entry = sceneEntries.find((e) => e.mask_id === id);
             const skipped = entry?.skipped ?? false;
@@ -330,7 +330,7 @@ function BandMaskDetailCard({
         </span>
         {summary.kept_band_indices.length > 10 ? ", …" : ""}
       </div>
-      <div className="grid lg:grid-cols-2 gap-5">
+      <div className="grid md:grid-cols-2 gap-5">
         <div>
           <h5
             className="text-[12px] uppercase tracking-widest font-semibold mb-2"

--- a/frontend/src/pages/workspace/tabs/HidsagBandMaskTab.tsx
+++ b/frontend/src/pages/workspace/tabs/HidsagBandMaskTab.tsx
@@ -116,7 +116,7 @@ export function HidsagBandMaskTab({
           discriminant on labels (HIDSAG has no per-pixel label —{" "}
           covariates are sample-level tags like lithology / mineralogy).
         </p>
-        <ul className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <ul className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
           {Object.entries(maskDefs).map(([id, def]) => {
             const entry = subsetEntries.find((e) => e.mask_id === id);
             const skipped = entry?.skipped ?? false;
@@ -308,7 +308,7 @@ function HidsagBandMaskDetailCard({
         {summary.kept_band_indices.length > 10 ? ", …" : ""}
       </div>
 
-      <div className="grid lg:grid-cols-2 gap-5 mb-5">
+      <div className="grid md:grid-cols-2 gap-5 mb-5">
         <div>
           <h5
             className="text-[12px] uppercase tracking-widest font-semibold mb-2"

--- a/frontend/src/pages/workspace/tabs/NeuralTopicComparisonTab.tsx
+++ b/frontend/src/pages/workspace/tabs/NeuralTopicComparisonTab.tsx
@@ -133,7 +133,7 @@ function NeuralComparisonGrid({
 }) {
   const methods = Object.entries(comparison.methods);
   return (
-    <div className="grid lg:grid-cols-3 gap-4">
+    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
       {methods.map(([name, m]) => {
         const colour = NEURAL_METHOD_COLOR[name] ?? "var(--color-accent)";
         return (

--- a/frontend/src/pages/workspace/tabs/QKExploreTab.tsx
+++ b/frontend/src/pages/workspace/tabs/QKExploreTab.tsx
@@ -121,7 +121,7 @@ export function QKExploreTab({
             {canonicalK} canonical fit.
           </p>
         )}
-        <div className="grid lg:grid-cols-3 gap-4">
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
           <SweepCurveCard
             title="Perplexity (test)"
             subtitle="lower is better; ↓ shows the model captures the held-out word distribution"

--- a/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
+++ b/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
@@ -198,7 +198,7 @@ export function TopicLabelTab({
       </div>
 
       <div
-        className="grid lg:grid-cols-2 gap-5"
+        className="grid md:grid-cols-2 gap-5"
         style={{ color: "var(--color-fg-subtle)" }}
       >
         <div

--- a/frontend/src/pages/workspace/tabs/UsgsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UsgsTab.tsx
@@ -122,7 +122,7 @@ export function UsgsTab({
         </div>
 
         {top && (
-          <div className="grid lg:grid-cols-2 gap-5">
+          <div className="grid md:grid-cols-2 gap-5">
             <div>
               <h5
                 className="text-sm font-semibold mb-2"


### PR DESCRIPTION
Tablet-portrait (768-1023px) viewports now get 2-3 columns instead of collapsing to 1.