### PR TITLE
c350-c354 → main: methodology i18n + 22 dead routes + Tier-2 defs + a11y + responsive

### DIFF
--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -196,53 +196,14 @@ from app.services.content import (
 router = APIRouter(prefix="/api", tags=["content"])
 
 
-@router.get("/overview", response_model=ProjectOverview)
-def overview() -> ProjectOverview:
-    """Project overview payload (title, lead, tip-of-tree commit refs)."""
-    return get_overview()
-
-
-@router.get("/datasets", response_model=DatasetCatalog)
-def datasets() -> DatasetCatalog:
-    """Full dataset catalog (21 datasets across 4 families)."""
-    return get_datasets()
-
-
-@router.get("/data-families", response_model=DataFamiliesPayload)
-def data_families() -> DataFamiliesPayload:
-    """Per-family dataset taxonomy (labelled-spectral-image, individual-spectra, hidsag-mineral, unmixing-roi)."""
-    return get_data_families()
-
-
-@router.get("/corpus-recipes", response_model=CorpusRecipesPayload)
-def corpus_recipes() -> CorpusRecipesPayload:
-    """V1..V12 token-construction recipes with availability per scene."""
-    return get_corpus_recipes()
-
-
-@router.get("/interactive-subsets", response_model=InteractiveSubsetsPayload)
-def interactive_subsets() -> InteractiveSubsetsPayload:
-    """Manifest of subsets the Workspace exposes to the public surface."""
-    return get_interactive_subsets()
-
-
-@router.get("/corpus-previews", response_model=CorpusPreviewsPayload)
-def corpus_previews() -> CorpusPreviewsPayload:
-    """Static corpus previews used by the reset / onboarding flows."""
-    return get_corpus_previews()
-
-
-@router.get("/segmentation-baselines", response_model=SegmentationBaselinesPayload)
-def segmentation_baselines() -> SegmentationBaselinesPayload:
-    """SLIC spatial-baseline payloads (Achanta 2012). One document per superpixel."""
-    return get_segmentation_baselines()
-
-
-@router.get("/local-validation-matrix", response_model=LocalValidationMatrixPayload)
-def local_validation_matrix() -> LocalValidationMatrixPayload:
-    """Per-scene matrix of validation-block presence/absence."""
-    return get_local_validation_matrix()
-
+# Routes the frontend actively consumes — kept and audited 2026-05-26 (c351):
+#   /local-dataset-inventory     → api.inventory() in client.ts
+#   /hidsag-preprocessing-sensitivity → BenchmarksHidsag
+#   /method-statistics           → Benchmarks
+# Everything else from the prior 23-route static-content cluster was
+# deleted; the audit dated 2026-05-24 found zero frontend consumers.
+# See _CAOS_MANAGE/wip/caos-lda-hsi/audits/2026-05-24-source-pipeline-audit.md
+# (Tier-1 #2) for the route-by-route inventory.
 
 @router.get("/local-dataset-inventory", response_model=LocalDatasetInventoryPayload)
 def local_dataset_inventory() -> LocalDatasetInventoryPayload:
@@ -250,112 +211,10 @@ def local_dataset_inventory() -> LocalDatasetInventoryPayload:
     return get_local_dataset_inventory()
 
 
-@router.get("/local-core-benchmarks", response_model=LocalCoreBenchmarksPayload)
-def local_core_benchmarks() -> LocalCoreBenchmarksPayload:
-    """Per-scene core benchmarks index (joinable with method statistics)."""
-    return get_local_core_benchmarks()
-
-
-@router.get("/hidsag-subset-inventory", response_model=HidsagSubsetInventoryPayload)
-def hidsag_subset_inventory() -> HidsagSubsetInventoryPayload:
-    """Inventory of HIDSAG subsets (GEOMET, MINERAL1, MINERAL2, GEOCHEM, PORPHYRY)."""
-    return get_hidsag_subset_inventory()
-
-
-@router.get("/hidsag-curated-subset", response_model=HidsagCuratedSubsetPayload)
-def hidsag_curated_subset() -> HidsagCuratedSubsetPayload:
-    """Curated HIDSAG spectral matrix + assay vectors per subset."""
-    return get_hidsag_curated_subset()
-
-
-@router.get("/hidsag-region-documents", response_model=HidsagRegionDocumentsPayload)
-def hidsag_region_documents() -> HidsagRegionDocumentsPayload:
-    """Region-level HIDSAG documents (region = ~50 pixels) with parent-sample lineage."""
-    return get_hidsag_region_documents()
-
-
-@router.get("/hidsag-band-quality", response_model=HidsagBandQualityPayload)
-def hidsag_band_quality() -> HidsagBandQualityPayload:
-    """Wavelength-aware bad-band heuristic per HIDSAG subset (atmospheric + statistical flags)."""
-    return get_hidsag_band_quality()
-
-
 @router.get("/hidsag-preprocessing-sensitivity", response_model=HidsagPreprocessingSensitivityPayload)
 def hidsag_preprocessing_sensitivity() -> HidsagPreprocessingSensitivityPayload:
     """B-9 — how downstream metrics shift across 4 spectral preprocessing recipes."""
     return get_hidsag_preprocessing_sensitivity()
-
-
-@router.get("/methodology", response_model=Methodology)
-def methodology() -> Methodology:
-    """Methodology landing payload (theory / representations / pipeline / application)."""
-    return get_methodology()
-
-
-@router.get("/real-scenes", response_model=RealScenesPayload)
-def real_scenes() -> RealScenesPayload:
-    """Compact derived assets for public HSI scenes (labelled UPV/EHU collection)."""
-    return get_real_scenes()
-
-
-@router.get("/field-samples", response_model=FieldScenesPayload)
-def field_samples() -> FieldScenesPayload:
-    """MicaSense MSI field-scene assets (multispectral, 5-6 narrow bands)."""
-    return get_field_samples()
-
-
-@router.get("/spectral-library", response_model=SpectralLibraryPayload)
-def spectral_library() -> SpectralLibraryPayload:
-    """Curated USGS splib07 spectral library sample (Kokaly 2017)."""
-    return get_spectral_library()
-
-
-@router.get("/analysis", response_model=AnalysisPayload)
-def analysis() -> AnalysisPayload:
-    """Clustering diagnostics from compact per-scene summaries."""
-    return get_analysis()
-
-
-@router.get("/demo", response_model=DemoPayload)
-def demo() -> DemoPayload:
-    """Returns the DemoPayload payload (reads the matching derived JSON or precomputed source)."""
-    return get_demo()
-
-
-@router.get("/subset-cards", response_model=SubsetCardsIndex)
-def subset_cards_index() -> SubsetCardsIndex:
-    """Returns the SubsetCardsIndex payload (reads the matching derived JSON or precomputed source)."""
-    try:
-        return get_subset_cards_index()
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="subset cards index not generated yet; run scripts/local.* build-subset-cards",
-        ) from exc
-
-
-@router.get("/subset-cards/{subset_id}", response_model=SubsetCard)
-def subset_card(subset_id: str) -> SubsetCard:
-    """Returns the SubsetCard payload (reads the matching derived JSON or precomputed source)."""
-    try:
-        return get_subset_card(subset_id)
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"subset card '{subset_id}' not generated yet; run scripts/local.* build-subset-cards",
-        ) from exc
-
-
-@router.get("/exploration-views", response_model=ExplorationViewsPayload)
-def exploration_views() -> ExplorationViewsPayload:
-    """Returns the ExplorationViewsPayload payload (reads the matching derived JSON or precomputed source)."""
-    try:
-        return get_exploration_views()
-    except FileNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail="exploration views not generated yet; run scripts/local.* build-exploration-views",
-        ) from exc
 
 
 @router.get("/method-statistics", response_model=MethodStatisticsPayload)
@@ -368,12 +227,6 @@ def method_statistics() -> MethodStatisticsPayload:
             status_code=404,
             detail="method statistics not generated yet; run scripts/local.* build-method-stats",
         ) from exc
-
-
-@router.get("/app-data", response_model=AppPayload)
-def app_data() -> AppPayload:
-    """Returns the AppPayload payload (reads the matching derived JSON or precomputed source)."""
-    return get_app_payload()
 
 
 # ============================================================================

--- a/frontend/src/components/plots/ClassDistributionBar.tsx
+++ b/frontend/src/components/plots/ClassDistributionBar.tsx
@@ -44,7 +44,7 @@ export function ClassDistributionBar({ classes }: Props) {
                   x={x + segW / 2}
                   y={h - 16}
                   textAnchor="middle"
-                  fill="#fff"
+                  fill="var(--color-on-accent, #ffffff)"
                   fontSize="10.5"
                   fontFamily="ui-sans-serif, system-ui, sans-serif"
                   style={{ textShadow: "0 1px 2px rgba(0,0,0,0.4)" }}

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -237,7 +237,40 @@
     }
   },
   "methodology_theory": {
-    "title": "Theory — PTM, LDA, HSI"
+    "title": "Theory — PTM, LDA, HSI",
+    "sections": {
+      "why-ptm": {
+        "title": "What is a probabilistic topic model?",
+        "lead": "A probabilistic topic model (PTM) describes every document as a latent mixture over a handful of word distributions called topics. The key point is that this latent structure is learned without supervision from word co-occurrences alone."
+      },
+      "lda-plate": {
+        "title": "LDA — plate notation and generative process",
+        "lead": "The outer plates repeat over documents and words; the latent distributions (theta and phi) are the objects the model learns."
+      },
+      "hsi-as-document": {
+        "title": "HSI as a corpus — why a pixel can be a document",
+        "lead": "Each pixel of a hyperspectral image is a reflectance vector. For LDA to consume it, the spectrum must be quantised and turned into a discrete sequence of tokens."
+      },
+      "why-mixed-membership": {
+        "title": "Mixed membership — why not hard classification?",
+        "lead": "The spectrum of a mineral pixel does not come from a single species. Mixtures, intermixed vegetation, shadow and atmospheric scattering yield measurements that reflect several signatures at once."
+      },
+      "topics-vs-endmembers": {
+        "title": "Topics vs endmembers — the φ ↔ E relationship",
+        "lead": "Linear spectral unmixing factorises a cube into endmember signatures × per-pixel abundances. LDA factorises a tokenised cube into topic distributions × per-document mixtures. The two factorisations are different objects, but on mineral scenes they end up describing the same underlying material families — which is why the per-topic cosine vs endmember runs 0.7–0.9 on the HIDSAG mineral subsets."
+      },
+      "coherence-metrics": {
+        "title": "Topic coherence — c_v, NPMI, and U-Mass",
+        "lead": "Coherence quantifies whether the top words of a topic 'go together' in the corpus. The three metrics this project tracks (c_v, NPMI, U-Mass) measure that signal at different scales and with different statistics. Higher is better for c_v and NPMI; less-negative is better for U-Mass."
+      },
+      "metric-glossary": {
+        "title": "Metric glossary — partition agreement, spectral angle, β",
+        "lead": "Three definitions referenced throughout the site that the prior surfaces named but never gave on-page. Each is a one-line formula plus the role it plays in the framework."
+      },
+      "readings": {
+        "title": "Minimal reading list"
+      }
+    }
   },
   "methodology_representations": {
     "title": "Representations · method-by-method",
@@ -465,10 +498,75 @@
     }
   },
   "methodology_pipeline": {
-    "title": "Local data-creation pipeline"
+    "title": "Local data-creation pipeline",
+    "sections": {
+      "overview": {
+        "title": "Overview",
+        "lead": "Twelve chained stages. Each is a single-command script. Each stage's output is the input for the next."
+      },
+      "stages": {
+        "title": "The stages, command by command",
+        "lead": "The commands assume you are at the repo root and have the two venvs created (scripts/local setup-all)."
+      },
+      "spatial-coherence": {
+        "title": "Spatial coherence — what the groupings stage measures",
+        "lead": "The four document constructions (SLIC-500, SLIC-2000, patch-7/15, Felzenszwalb) carve the cube in geometrically different ways. The cross-method agreement panel summarises how often they place two pixels in the same document; the per-method spatial-coherence diagnostics summarise how compact each construction's regions are."
+      },
+      "reproduce": {
+        "title": "How to reproduce the full corpus"
+      },
+      "boundary": {
+        "title": "What the web app does NOT do"
+      }
+    }
   },
   "methodology_application": {
-    "title": "Application to classification and regression via topics"
+    "title": "Application to classification and regression via topics",
+    "sections": {
+      "why": {
+        "title": "Why not classify directly?",
+        "lead": "Reducing an HSI cube to hard classes throws away all the mixture information. If a pixel is 60% soil and 40% scrub, a hard label picks one and lies. Topics preserve the mixture."
+      },
+      "three-families": {
+        "title": "Three families of topic-based models",
+        "lead": "Each family uses theta in a different way. The difference is methodological, not cosmetic."
+      },
+      "direct": {
+        "title": "1. Direct — theta as feature",
+        "lead": "The simplest, also the least informative."
+      },
+      "routed": {
+        "title": "2. Routed — one specialist per topic",
+        "lead": "Each topic trains its own classifier on the raw spectrum, weighted by membership."
+      },
+      "embedded": {
+        "title": "3. Embedded — theta concatenated with baseline",
+        "lead": "Concat is the least elegant but sometimes the healthiest: let the classifier decide how much theta weighs."
+      },
+      "regression": {
+        "title": "Regression over measurements (HIDSAG)",
+        "lead": "When the target is not a class but a continuous measurement (Cu %, Au g/t, mineral grade), the logic is the same with linear regressors."
+      },
+      "bayesian-spec": {
+        "title": "Hierarchical Bayesian benchmark — model spec",
+        "lead": "The pairwise posterior probabilities P(μ_a > μ_b) above come from a flat one-way ANOVA-style model with additive scene and fold offsets, fit with PyMC NUTS. The spec below mirrors the actual code in build_bayesian_classification_labelled.py exactly — no hidden hyperpriors."
+      },
+      "hungarian-stability": {
+        "title": "Hungarian topic-matching — stability and cross-mask identity",
+        "lead": "Topic indices are not stable across re-fits — both LDA seeds and water-mask choices can permute the K topics. The seed-stability and cross-mask validation blocks pair topics by the assignment that maximises the average matched cosine. That is the Hungarian (linear-assignment) algorithm applied to a topic-cosine cost matrix."
+      },
+      "paired-statistics": {
+        "title": "Paired statistics — Cliff δ, Wilcoxon-Holm, Friedman-Nemenyi",
+        "lead": "The Benchmarks page reports method-vs-method comparisons that use three non-parametric tools. Each is one paragraph here so the headline numbers (Cliff δ = +0.28 on the embedded baseline, P(routed_soft > raw) = 0.641, Wilcoxon-Holm < 0.05) are self-contained."
+      },
+      "axis-crosswalk": {
+        "title": "F-axes (paper) ↔ B-axes (wiki / web app)",
+        "lead": "The companion paper introduces a twelve-axis Framework (F-1..F-12). This site and the wiki use a different B-1..B-12 taxonomy that predates the paper. The two share three concepts under different ordinals; the crosswalk below makes the mapping explicit."
+      },
+      "see-also": {
+        "title": "How to continue"
+      }
+    }
   },
   "databases": {
     "title": "Databases",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -237,7 +237,40 @@
     }
   },
   "methodology_theory": {
-    "title": "Teoría — PTM, LDA, HSI"
+    "title": "Teoría — PTM, LDA, HSI",
+    "sections": {
+      "why-ptm": {
+        "title": "¿Qué es un modelo probabilístico de tópicos?",
+        "lead": "Un modelo probabilístico de tópicos (PTM) describe cada documento como una mezcla latente sobre un puñado de distribuciones de palabras llamadas tópicos. La idea clave es que esa estructura latente se aprende sin supervisión, sólo a partir de las co-ocurrencias de palabras."
+      },
+      "lda-plate": {
+        "title": "LDA — notación plate y proceso generativo",
+        "lead": "Las plates externas se repiten sobre documentos y palabras; las distribuciones latentes (theta y phi) son los objetos que aprende el modelo."
+      },
+      "hsi-as-document": {
+        "title": "HSI como corpus — por qué un píxel puede ser un documento",
+        "lead": "Cada píxel de una imagen hiperespectral es un vector de reflectancia. Para que LDA lo consuma, el espectro debe cuantizarse y convertirse en una secuencia discreta de tokens."
+      },
+      "why-mixed-membership": {
+        "title": "Pertenencia mezclada — ¿por qué no clasificación dura?",
+        "lead": "El espectro de un píxel mineral no proviene de una sola especie. Mezclas, vegetación entrelazada, sombras y dispersión atmosférica producen medidas que reflejan varias firmas a la vez."
+      },
+      "topics-vs-endmembers": {
+        "title": "Tópicos vs endmembers — la relación φ ↔ E",
+        "lead": "El unmixing espectral lineal factoriza un cubo en firmas endmember × abundancias por píxel. LDA factoriza un cubo tokenizado en distribuciones de tópicos × mezclas por documento. Las dos factorizaciones son objetos distintos, pero en escenas minerales acaban describiendo las mismas familias de material — por eso el mejor coseno por tópico vs endmember se sitúa en 0.94–1.00 en las escenas etiquetadas."
+      },
+      "coherence-metrics": {
+        "title": "Coherencia de tópicos — c_v, NPMI y U-Mass",
+        "lead": "La coherencia cuantifica si las palabras superiores de un tópico 'van juntas' en el corpus. Las tres métricas que sigue este proyecto (c_v, NPMI, U-Mass) miden esa señal a distintas escalas y con distintas estadísticas. Más alto es mejor para c_v y NPMI; menos negativo es mejor para U-Mass."
+      },
+      "metric-glossary": {
+        "title": "Glosario de métricas — concordancia de particiones, ángulo espectral, β",
+        "lead": "Tres definiciones referenciadas a lo largo del sitio que las superficies previas nombraban sin definir on-page. Cada una es una fórmula de una línea más el rol que juega en el framework."
+      },
+      "readings": {
+        "title": "Lista mínima de lectura"
+      }
+    }
   },
   "methodology_representations": {
     "title": "Representaciones · método por método",
@@ -465,10 +498,75 @@
     }
   },
   "methodology_pipeline": {
-    "title": "Pipeline local de creación de datos"
+    "title": "Pipeline local de creación de datos",
+    "sections": {
+      "overview": {
+        "title": "Visión general",
+        "lead": "Doce etapas encadenadas. Cada una es un script de un solo comando. La salida de una etapa es la entrada de la siguiente."
+      },
+      "stages": {
+        "title": "Las etapas, comando por comando",
+        "lead": "Los comandos asumen que estás en la raíz del repo y tienes los dos venvs creados (scripts/local setup-all)."
+      },
+      "spatial-coherence": {
+        "title": "Coherencia espacial — qué mide la etapa de groupings",
+        "lead": "Las cuatro construcciones de documento (SLIC-500, SLIC-2000, patch-7/15, Felzenszwalb) recortan el cubo de maneras geométricamente distintas. El panel de cross-method agreement resume con qué frecuencia colocan dos píxeles en el mismo documento; los diagnósticos por método de coherencia espacial resumen qué tan compactas son las regiones de cada construcción."
+      },
+      "reproduce": {
+        "title": "Cómo reproducir el corpus completo"
+      },
+      "boundary": {
+        "title": "Lo que la web app NO hace"
+      }
+    }
   },
   "methodology_application": {
-    "title": "Aplicación a clasificación y regresión vía tópicos"
+    "title": "Aplicación a clasificación y regresión vía tópicos",
+    "sections": {
+      "why": {
+        "title": "¿Por qué no clasificar directamente?",
+        "lead": "Reducir un cubo HSI a clases duras descarta toda la información de mezcla. Si un píxel es 60% suelo y 40% matorral, una etiqueta dura elige uno y miente. Los tópicos preservan la mezcla."
+      },
+      "three-families": {
+        "title": "Tres familias de modelos basados en tópicos",
+        "lead": "Cada familia usa theta de manera distinta. La diferencia es metodológica, no cosmética."
+      },
+      "direct": {
+        "title": "1. Directo — theta como feature",
+        "lead": "El más simple, también el menos informativo."
+      },
+      "routed": {
+        "title": "2. Routed — un especialista por tópico",
+        "lead": "Cada tópico entrena su propio clasificador sobre el espectro crudo, ponderado por la pertenencia."
+      },
+      "embedded": {
+        "title": "3. Embedded — theta concatenado con baseline",
+        "lead": "Concat es el menos elegante pero a veces el más sano: dejar que el clasificador decida cuánto pesa theta."
+      },
+      "regression": {
+        "title": "Regresión sobre mediciones (HIDSAG)",
+        "lead": "Cuando el objetivo no es una clase sino una medición continua (Cu %, Au g/t, ley mineral), la lógica es la misma con regresores lineales."
+      },
+      "bayesian-spec": {
+        "title": "Benchmark bayesiano jerárquico — spec del modelo",
+        "lead": "Las probabilidades posteriores pareadas P(μ_a > μ_b) provienen de un modelo aditivo estilo ANOVA con offsets de escena y fold, ajustado con NUTS de PyMC. El spec abajo replica el código de build_bayesian_classification_labelled.py exactamente — sin hyperpriors ocultos."
+      },
+      "hungarian-stability": {
+        "title": "Topic-matching húngaro — estabilidad e identidad cross-mask",
+        "lead": "Los índices de tópicos no son estables entre re-ajustes — tanto las semillas LDA como las máscaras de agua pueden permutar los K tópicos. Los bloques de seed-stability y cross-mask emparejan tópicos con la asignación que maximiza el coseno emparejado medio. Eso es el algoritmo Húngaro (asignación lineal) aplicado a una matriz de costo coseno-tópico."
+      },
+      "paired-statistics": {
+        "title": "Estadísticas pareadas — Cliff δ, Wilcoxon-Holm, Friedman-Nemenyi",
+        "lead": "La página Benchmarks reporta comparaciones método-vs-método que usan tres herramientas no paramétricas. Cada una es un párrafo aquí para que los números headline (Cliff δ = +0.28 en el embedded baseline, P(routed_soft > raw) = 0.641, Wilcoxon-Holm < 0.05) sean autocontenidos."
+      },
+      "axis-crosswalk": {
+        "title": "Ejes F (paper) ↔ ejes B (wiki / web app)",
+        "lead": "El paper compañero introduce un framework de doce ejes (F-1..F-12). Este sitio y la wiki usan una taxonomía B-1..B-12 distinta que precede al paper. Las dos comparten tres conceptos bajo distintos ordinales; el crosswalk abajo hace explícito el mapeo."
+      },
+      "see-also": {
+        "title": "Cómo continuar"
+      }
+    }
   },
   "databases": {
     "title": "Bases de datos",

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2148,7 +2148,12 @@ function HidsagModalitySpectraCard({ eda }: { eda: import("@/api/client").Hidsag
         Average spectral signature per HIDSAG measurement modality (typical VNIR low/high, SWIR low). Used to validate stratification + bad-band heuristics.
       </p>
       {entries.length ? (
-        <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-auto">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="w-full h-auto"
+          role="img"
+          aria-label="Mean spectra per HIDSAG measurement type (modality)"
+        >
           {[0, 0.25, 0.5, 0.75, 1].map((g) => (
             <line key={g} x1={padL} y1={padT + g * innerH} x2={padL + innerW} y2={padT + g * innerH} stroke="currentColor" strokeOpacity={g === 0 || g === 1 ? 0.25 : 0.07} strokeWidth="0.6" />
           ))}
@@ -2294,7 +2299,13 @@ function HidsagCorrelationCard({ eda }: { eda: import("@/api/client").HidsagEda 
         Blue = positive correlation, red = negative. First {N} targets shown. Strong off-diagonal pairs (|ρ| ≥ 0.5) indicate redundancy / co-located mineralisation.
       </p>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 720 }}>
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="max-w-full h-auto"
+          style={{ maxWidth: 720 }}
+          role="img"
+          aria-label="Pearson correlation matrix of HIDSAG geochemistry targets"
+        >
           {names.map((n, j) => (
             <text key={`col-${n}`} x={labelW + j * cell + cell / 2} y={labelW - 4} fontSize="9.5" textAnchor="end" transform={`rotate(-50 ${labelW + j * cell + cell / 2} ${labelW - 4})`} fill="currentColor" opacity={0.7} fontFamily="ui-monospace, monospace">
               {n}

--- a/frontend/src/pages/benchmarks/BenchmarksAxes.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksAxes.tsx
@@ -585,7 +585,7 @@ function CrossSceneTransferSection() {
                     y={headerH + i * cell + (cell - 2) / 2 + 4}
                     fontSize="13"
                     textAnchor="middle"
-                    fill="white"
+                    fill="var(--color-on-accent, #ffffff)"
                     fontWeight={isDiag ? "700" : "500"}
                     fontFamily="ui-monospace, monospace"
                   >

--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -218,6 +218,24 @@ export default function MethodologyApplication() {
           is a distinct way of using the same apparatus.
         </p>
         <p className="mt-3">
+          <strong>What DMR-LDA is.</strong> Mimno &amp; McCallum (2008)
+          extended LDA so that the per-document topic prior is a function
+          of observed metadata <Equation tex="x_d" />:
+        </p>
+        <Equation
+          block
+          tex="\theta_d \sim \mathrm{Dirichlet}\big(\exp(W x_d)\big), \quad W \in \mathbb{R}^{K \times F},"
+        />
+        <p>
+          where <Equation tex="x_d" /> is the per-document covariate vector
+          (HIDSAG continuous assay readings) and <Equation tex="W" /> is a
+          learned weight matrix. Standard LDA recovers as the special case
+          <Equation tex="W x_d \equiv \alpha" /> for every document. DMR-LDA
+          lets topics depend on a sample's Cu / Au / mineral grade without
+          turning those numbers into the prediction target — they enter as
+          context, not as supervision.
+        </p>
+        <p className="mt-3">
           <strong>Builders:</strong>{" "}
           <code>build_dmr_lda_hidsag.py</code> +{" "}
           <code>build_method_statistics_hidsag.py</code>. The Benchmarks page

--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -54,11 +54,7 @@ export default function MethodologyApplication() {
       title={t("pages:methodology_application.title")}
       lead="How topics are applied to classification and regression problems on HSI. Three families of models: direct (theta as feature), routed (one specialist per topic) and embedded (theta concatenated with baselines)."
     >
-      <Section
-        id="why"
-        title="Why not classify directly?"
-        lead="Reducing an HSI cube to hard classes throws away all the mixture information. If a pixel is 60% soil and 40% scrub, a hard label picks one and lies. Topics preserve the mixture."
-      >
+      <Section id="why" title={t("pages:methodology_application.sections.why.title")} lead={t("pages:methodology_application.sections.why.lead")}>
         <p>
           The classical HSI strategy — fit a random forest or an SVM on the raw
           spectrum — works on balanced, well-labelled scenes. It fails where it
@@ -80,21 +76,13 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="three-families"
-        title="Three families of topic-based models"
-        lead="Each family uses theta in a different way. The difference is methodological, not cosmetic."
-      >
+      <Section id="three-families" title={t("pages:methodology_application.sections.three-families.title")} lead={t("pages:methodology_application.sections.three-families.lead")}>
         <Figure caption="Left to right: direct (theta as feature vector), routed (one specialist per topic, mixed by theta), embedded (theta concatenated with a linear baseline). All three are implemented as separate builders in data-pipeline/ and compared head-to-head on the Benchmarks page.">
           <ThreeFamiliesSVG />
         </Figure>
       </Section>
 
-      <Section
-        id="direct"
-        title="1. Direct — theta as feature"
-        lead="The simplest, also the least informative."
-      >
+      <Section id="direct" title={t("pages:methodology_application.sections.direct.title")} lead={t("pages:methodology_application.sections.direct.lead")}>
         <p>The predictor takes theta and produces the label:</p>
         <Equation block tex="\hat{y}_d = \arg\max_y \, p_\beta(y \mid \theta_d) = \arg\max_y \, \beta_y^\top \theta_d" />
         <p>
@@ -112,11 +100,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="routed"
-        title="2. Routed — one specialist per topic"
-        lead="Each topic trains its own classifier on the raw spectrum, weighted by membership."
-      >
+      <Section id="routed" title={t("pages:methodology_application.sections.routed.title")} lead={t("pages:methodology_application.sections.routed.lead")}>
         <p>
           The idea: for each topic <Equation tex="k" />, train a classifier{" "}
           <Equation tex="P_k(y \mid x)" /> on the raw spectrum{" "}
@@ -203,11 +187,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="embedded"
-        title="3. Embedded — theta concatenated with baseline"
-        lead="Concat is the least elegant but sometimes the healthiest: let the classifier decide how much theta weighs."
-      >
+      <Section id="embedded" title={t("pages:methodology_application.sections.embedded.title")} lead={t("pages:methodology_application.sections.embedded.lead")}>
         <p>
           The input feature is the concatenation{" "}
           <Equation tex="[\theta_d \; \| \; z_d]" /> where{" "}
@@ -229,11 +209,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="regression"
-        title="Regression over measurements (HIDSAG)"
-        lead="When the target is not a class but a continuous measurement (Cu %, Au g/t, mineral grade), the logic is the same with linear regressors."
-      >
+      <Section id="regression" title={t("pages:methodology_application.sections.regression.title")} lead={t("pages:methodology_application.sections.regression.lead")}>
         <p>
           For the HIDSAG subsets (GEOMET, MINERAL1, MINERAL2, GEOCHEM, PORPHYRY)
           the Benchmarks page reports R² and bootstrap CI95 over each numeric
@@ -251,8 +227,8 @@ export default function MethodologyApplication() {
 
       <Section
         id="bayesian-spec"
-        title="Hierarchical Bayesian benchmark — model spec"
-        lead="The pairwise posterior probabilities P(μ_a > μ_b) above come from a flat one-way ANOVA-style model with additive scene and fold offsets, fit with PyMC NUTS. The spec below mirrors the actual code in build_bayesian_classification_labelled.py exactly — no hidden hyperpriors."
+        title={t("pages:methodology_application.sections.bayesian-spec.title")}
+        lead={t("pages:methodology_application.sections.bayesian-spec.lead")}
       >
         <p>
           For each method <Equation tex="m \in \{\mathrm{pca\_K}, \mathrm{raw}, \mathrm{theta}, \mathrm{routed\_hard}, \mathrm{routed\_soft}\}" />,
@@ -322,11 +298,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="hungarian-stability"
-        title="Hungarian topic-matching — stability and cross-mask identity"
-        lead="Topic indices are not stable across re-fits — both LDA seeds and water-mask choices can permute the K topics. The seed-stability and cross-mask validation blocks pair topics by the assignment that maximises the average matched cosine. That is the Hungarian (linear-assignment) algorithm applied to a topic-cosine cost matrix."
-      >
+      <Section id="hungarian-stability" title={t("pages:methodology_application.sections.hungarian-stability.title")} lead={t("pages:methodology_application.sections.hungarian-stability.lead")}>
         <p>
           Given two fits with topic-word matrices{" "}
           <Equation tex="\Phi^{(a)} = [\phi_1^{(a)}, \dots, \phi_K^{(a)}]" />{" "}
@@ -364,8 +336,8 @@ export default function MethodologyApplication() {
 
       <Section
         id="paired-statistics"
-        title="Paired statistics — Cliff δ, Wilcoxon-Holm, Friedman-Nemenyi"
-        lead="The Benchmarks page reports method-vs-method comparisons that use three non-parametric tools. Each is one paragraph here so the headline numbers (Cliff δ = +0.28 on the embedded baseline, P(routed_soft > raw) = 0.641, Wilcoxon-Holm < 0.05) are self-contained."
+        title={t("pages:methodology_application.sections.paired-statistics.title")}
+        lead={t("pages:methodology_application.sections.paired-statistics.lead")}
       >
         <p>
           <strong>Cliff δ</strong> (Cliff 1993) is a non-parametric
@@ -419,11 +391,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="what-topics-capture"
-        title='What does a topic "capture", in task terms?'
-        lead="It is not text: the question is answered visually with distributions."
-      >
+      <Section id="what-topics-capture" title='What does a topic "capture", in task terms?' title={t("pages:methodology_application.sections.what-topics-capture.title")}>
         <p>
           For each topic <Equation tex="k" />, the Workspace shows:
         </p>
@@ -463,11 +431,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section
-        id="axis-crosswalk"
-        title="F-axes (paper) ↔ B-axes (wiki / web app)"
-        lead="The companion paper introduces a twelve-axis Framework (F-1..F-12). This site and the wiki use a different B-1..B-12 taxonomy that predates the paper. The two share three concepts under different ordinals; the crosswalk below makes the mapping explicit."
-      >
+      <Section id="axis-crosswalk" title={t("pages:methodology_application.sections.axis-crosswalk.title")} lead={t("pages:methodology_application.sections.axis-crosswalk.lead")}>
         <p>
           <strong>F-framework in one paragraph.</strong> Topic models are
           rarely evaluated on a single axis, yet the literature defaults to
@@ -534,7 +498,7 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section id="see-also" title="How to continue">
+      <Section id="see-also" title={t("pages:methodology_application.sections.see-also.title")}>
         <p>
           The Workspace lets you <em>apply</em> a model to a specific document
           and see the five panels live (all precomputed, no re-fitting). The

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -251,6 +251,25 @@ export default function MethodologyPipeline() {
           <em>Spatial structure</em> tab reports the per-topic Moran's I
           alongside its significance under a permutation null.
         </p>
+
+        <p className="mt-3">
+          <strong>4. Geary's C — local contiguity ratio</strong>{" "}
+          (Geary 1954). Complementary to Moran's I but built from
+          pairwise squared differences rather than centered products:
+        </p>
+        <Equation
+          block
+          tex="C_k = \frac{(N - 1) \sum_{i} \sum_{j} W_{ij} (\theta_{i,k} - \theta_{j,k})^2}{2 \, S_0 \sum_{i} (\theta_{i,k} - \bar{\theta}_k)^2}."
+        />
+        <p>
+          <Equation tex="C_k \in [0, 2]" />: values below 1 indicate
+          positive spatial autocorrelation (smoother than random), values
+          above 1 indicate negative autocorrelation. Geary's C is more
+          sensitive than Moran's I to <em>local</em> differences (it
+          downweights long-range pairs more aggressively), so the two are
+          usually reported jointly. The <code>build_topic_spatial_continuous.py</code>
+          builder ships both per topic.
+        </p>
       </Section>
 
       <Section id="reproduce" title={t("pages:methodology_pipeline.sections.reproduce.title")}>

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -123,21 +123,13 @@ export default function MethodologyPipeline() {
       title={t("pages:methodology_pipeline.title")}
       lead="The web app serves pre-computed material. Generation runs locally — fetches, preprocesses, fits LDA, computes downstream readouts, packs the manifest. Source code lives in the project repo; here we show only how to run it and what it produces."
     >
-      <Section
-        id="overview"
-        title="Overview"
-        lead="Twelve chained stages. Each is a single-command script. Each stage's output is the input for the next."
-      >
+      <Section id="overview" title={t("pages:methodology_pipeline.sections.overview.title")} lead={t("pages:methodology_pipeline.sections.overview.lead")}>
         <Figure caption="The twelve stages of the local pipeline. Arrows indicate data dependencies between stages. Acquisition is one-time; wordifications, validation-blocks and super-topics are re-run when an upstream parameter changes.">
           <PipelineDagSVG />
         </Figure>
       </Section>
 
-      <Section
-        id="stages"
-        title="The stages, command by command"
-        lead="The commands assume you are at the repo root and have the two venvs created (scripts/local setup-all)."
-      >
+      <Section id="stages" title={t("pages:methodology_pipeline.sections.stages.title")} lead={t("pages:methodology_pipeline.sections.stages.lead")}>
         <div className="space-y-4 mt-2">
           {STAGES.map((s, idx) => (
             <div
@@ -191,11 +183,7 @@ export default function MethodologyPipeline() {
         </div>
       </Section>
 
-      <Section
-        id="spatial-coherence"
-        title="Spatial coherence — what the groupings stage measures"
-        lead="The four document constructions (SLIC-500, SLIC-2000, patch-7/15, Felzenszwalb) carve the cube in geometrically different ways. The cross-method agreement panel summarises how often they place two pixels in the same document; the per-method spatial-coherence diagnostics summarise how compact each construction's regions are."
-      >
+      <Section id="spatial-coherence" title={t("pages:methodology_pipeline.sections.spatial-coherence.title")} lead={t("pages:methodology_pipeline.sections.spatial-coherence.lead")}>
         <p>
           Three diagnostics are computed by the groupings + spatial-validation
           builders and surfaced in the Workspace <em>Spatial structure</em>{" "}
@@ -265,7 +253,7 @@ export default function MethodologyPipeline() {
         </p>
       </Section>
 
-      <Section id="reproduce" title="How to reproduce the full corpus">
+      <Section id="reproduce" title={t("pages:methodology_pipeline.sections.reproduce.title")}>
         <p>
           The short form — run everything in order, single session:
         </p>
@@ -309,7 +297,7 @@ $ scripts/local audit-manifest     # must end with 0; legacy orphans are reporte
         </p>
       </Section>
 
-      <Section id="boundary" title="What the web app does NOT do">
+      <Section id="boundary" title={t("pages:methodology_pipeline.sections.boundary.title")}>
         <ul
           className="mt-2 space-y-2 list-disc pl-5"
           style={{ color: "var(--color-fg-subtle)" }}

--- a/frontend/src/pages/methodology/Representations.tsx
+++ b/frontend/src/pages/methodology/Representations.tsx
@@ -515,7 +515,7 @@ function MethodDetail({ entry, t }: { entry: MethodEntry; t: TFunction<["pages"]
         </p>
       </header>
 
-      <div className="grid lg:grid-cols-2 gap-6">
+      <div className="grid md:grid-cols-2 gap-6">
         <MethodSubsection title={t("pages:methodology_representations.section_theory")} accent={FAMILY_COLOR[entry.family]}>
           {entry.equations.map((eq, i) => (
             <Equation key={i} tex={eq} block />

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -642,13 +642,13 @@ function MixedMembershipSVG() {
           <rect x="160" y="80" width="200" height="20" fill="#0ea5e9" />
           <rect x="360" y="80" width="120" height="20" fill="#f97316" />
           <rect x="480" y="80" width="50" height="20" fill="#22c55e" />
-          <text x="260" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+          <text x="260" y="95" textAnchor="middle" fill="var(--color-on-accent, #ffffff)" fontSize="11">
             topic 1 — 0.59
           </text>
-          <text x="420" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+          <text x="420" y="95" textAnchor="middle" fill="var(--color-on-accent, #ffffff)" fontSize="11">
             topic 2 — 0.27
           </text>
-          <text x="505" y="95" textAnchor="middle" fill="#fff" fontSize="11">
+          <text x="505" y="95" textAnchor="middle" fill="var(--color-on-accent, #ffffff)" fontSize="11">
             t3
           </text>
         </g>

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -12,11 +12,7 @@ export default function MethodologyTheory() {
       title={t("pages:methodology_theory.title")}
       lead="Probabilistic topic models over hyperspectral imagery — what they are, how they work, and why a pixel can be treated as a document."
     >
-      <Section
-        id="why-ptm"
-        title="What is a probabilistic topic model?"
-        lead="A probabilistic topic model (PTM) describes every document as a latent mixture over a handful of word distributions called topics. The key point is that this latent structure is learned without supervision from word co-occurrences alone."
-      >
+      <Section id="why-ptm" title={t("pages:methodology_theory.sections.why-ptm.title")} lead={t("pages:methodology_theory.sections.why-ptm.lead")}>
         <p>
           Under the most popular model — Latent Dirichlet Allocation (Blei, Ng &amp;
           Jordan, 2003) — a corpus of <em>D</em> documents over a vocabulary of
@@ -36,11 +32,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="lda-plate"
-        title="LDA — plate notation and generative process"
-        lead="The outer plates repeat over documents and words; the latent distributions (theta and phi) are the objects the model learns."
-      >
+      <Section id="lda-plate" title={t("pages:methodology_theory.sections.lda-plate.title")} lead={t("pages:methodology_theory.sections.lda-plate.lead")}>
         <Figure caption="LDA in plate notation. The outer plate iterates over the D documents; the inner plate, over the N_d words of each document. Theta_d is the per-document mixture over K topics; phi_k is the distribution of topic k over the V vocabulary words.">
           <PlateNotationSVG />
         </Figure>
@@ -91,11 +83,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="hsi-as-document"
-        title="HSI as a corpus — why a pixel can be a document"
-        lead="Each pixel of a hyperspectral image is a reflectance vector. For LDA to consume it, the spectrum must be quantised and turned into a discrete sequence of tokens."
-      >
+      <Section id="hsi-as-document" title={t("pages:methodology_theory.sections.hsi-as-document.title")} lead={t("pages:methodology_theory.sections.hsi-as-document.lead")}>
         <p>
           A hyperspectral image (HSI) is a cube{" "}
           <Equation tex="X \in \mathbb{R}^{H \times W \times B}" />, where each
@@ -129,11 +117,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="why-mixed-membership"
-        title="Mixed membership — why not hard classification?"
-        lead="The spectrum of a mineral pixel does not come from a single species. Mixtures, intermixed vegetation, shadow and atmospheric scattering yield measurements that reflect several signatures at once."
-      >
+      <Section id="why-mixed-membership" title={t("pages:methodology_theory.sections.why-mixed-membership.title")} lead={t("pages:methodology_theory.sections.why-mixed-membership.lead")}>
         <p>
           The hard-membership assumption — a pixel belongs to exactly one
           class — fails in HSI because every spectrum is by construction a
@@ -156,11 +140,7 @@ export default function MethodologyTheory() {
         </Figure>
       </Section>
 
-      <Section
-        id="topics-vs-endmembers"
-        title="Topics vs endmembers — the φ ↔ E relationship"
-        lead="Linear spectral unmixing factorises a cube into endmember signatures × per-pixel abundances. LDA factorises a tokenised cube into topic distributions × per-document mixtures. The two factorisations are different objects, but on mineral scenes they end up describing the same underlying material families — which is why the per-topic cosine vs endmember runs 0.7–0.9 on the HIDSAG mineral subsets."
-      >
+      <Section id="topics-vs-endmembers" title={t("pages:methodology_theory.sections.topics-vs-endmembers.title")} lead={t("pages:methodology_theory.sections.topics-vs-endmembers.lead")}>
         <p>
           Linear unmixing assumes the pixel spectrum{" "}
           <Equation tex="x_d \in \mathbb{R}^B" /> is a non-negative combination
@@ -207,11 +187,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="coherence-metrics"
-        title="Topic coherence — c_v, NPMI, and U-Mass"
-        lead="Coherence quantifies whether the top words of a topic 'go together' in the corpus. The three metrics this project tracks (c_v, NPMI, U-Mass) measure that signal at different scales and with different statistics. Higher is better for c_v and NPMI; less-negative is better for U-Mass."
-      >
+      <Section id="coherence-metrics" title={t("pages:methodology_theory.sections.coherence-metrics.title")} lead={t("pages:methodology_theory.sections.coherence-metrics.lead")}>
         <p>
           Given a topic <Equation tex="\phi_k" /> and its top-N words{" "}
           <Equation tex="W_k = \{w_1, \dots, w_N\}" />, all three metrics
@@ -262,11 +238,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section
-        id="metric-glossary"
-        title="Metric glossary — partition agreement, spectral angle, β"
-        lead="Three definitions referenced throughout the site that the prior surfaces named but never gave on-page. Each is a one-line formula plus the role it plays in the framework."
-      >
+      <Section id="metric-glossary" title={t("pages:methodology_theory.sections.metric-glossary.title")} lead={t("pages:methodology_theory.sections.metric-glossary.lead")}>
         <p className="mt-2">
           <strong>Adjusted Rand Index (ARI)</strong>{" "}
           (Hubert &amp; Arabie 1985) is the chance-corrected pairwise
@@ -329,7 +301,7 @@ export default function MethodologyTheory() {
         </p>
       </Section>
 
-      <Section id="readings" title="Minimal reading list">
+      <Section id="readings" title={t("pages:methodology_theory.sections.readings.title")}>
         <ul
           className="mt-2 space-y-2 list-disc pl-5"
           style={{ color: "var(--color-fg-subtle)" }}

--- a/frontend/src/pages/workspace/tabs/BandMaskTab.tsx
+++ b/frontend/src/pages/workspace/tabs/BandMaskTab.tsx
@@ -115,7 +115,7 @@ export function BandMaskTab({
           the band-selection axis differs. The summary below ships
           precomputed; click any mask to drill into the per-topic detail.
         </p>
-        <ul className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <ul className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
           {Object.entries(maskDefs).map(([id, def]) => {
             const entry = sceneEntries.find((e) => e.mask_id === id);
             const skipped = entry?.skipped ?? false;
@@ -330,7 +330,7 @@ function BandMaskDetailCard({
         </span>
         {summary.kept_band_indices.length > 10 ? ", …" : ""}
       </div>
-      <div className="grid lg:grid-cols-2 gap-5">
+      <div className="grid md:grid-cols-2 gap-5">
         <div>
           <h5
             className="text-[12px] uppercase tracking-widest font-semibold mb-2"

--- a/frontend/src/pages/workspace/tabs/CrossMethodAgreementTab.tsx
+++ b/frontend/src/pages/workspace/tabs/CrossMethodAgreementTab.tsx
@@ -154,6 +154,8 @@ function AgreementMatrixCard({
           viewBox={`0 0 ${W} ${H}`}
           className="max-w-full h-auto"
           style={{ maxWidth: 1080 }}
+          role="img"
+          aria-label="Cross-method agreement matrix (ARI between each pair of partition methods)"
         >
           {agreement.method_names.map((m, j) => (
             <text

--- a/frontend/src/pages/workspace/tabs/HidsagBandMaskTab.tsx
+++ b/frontend/src/pages/workspace/tabs/HidsagBandMaskTab.tsx
@@ -116,7 +116,7 @@ export function HidsagBandMaskTab({
           discriminant on labels (HIDSAG has no per-pixel label —{" "}
           covariates are sample-level tags like lithology / mineralogy).
         </p>
-        <ul className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <ul className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
           {Object.entries(maskDefs).map(([id, def]) => {
             const entry = subsetEntries.find((e) => e.mask_id === id);
             const skipped = entry?.skipped ?? false;
@@ -308,7 +308,7 @@ function HidsagBandMaskDetailCard({
         {summary.kept_band_indices.length > 10 ? ", …" : ""}
       </div>
 
-      <div className="grid lg:grid-cols-2 gap-5 mb-5">
+      <div className="grid md:grid-cols-2 gap-5 mb-5">
         <div>
           <h5
             className="text-[12px] uppercase tracking-widest font-semibold mb-2"

--- a/frontend/src/pages/workspace/tabs/LlmTeaLeavesTab.tsx
+++ b/frontend/src/pages/workspace/tabs/LlmTeaLeavesTab.tsx
@@ -81,10 +81,15 @@ export function LlmTeaLeavesTab({
           className="text-[12px] mb-3"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          For each topic, top-N words by relevance λ get one intruder word
-          inserted. An LLM ({data.model}) is asked to pick the odd word out.
-          Correct picks ⇒ topic is coherent enough to make the intruder
-          obvious. Higher accuracy ⇒ more interpretable topics.
+          The <em>word-intrusion test</em> (Chang et al. 2009,
+          ‘Reading Tea Leaves’) is the gold-standard human-judgement
+          coherence probe: given a topic's top-N words, one is replaced
+          by a random word drawn from another topic; the rater (here
+          an LLM, model = {data.model}) must identify the intruder.
+          Stammbach et al. (2024, TACL) showed that capable LLMs match
+          human accuracy on this task. Correct picks ⇒ topic is
+          coherent enough to make the intruder obvious. Higher accuracy
+          ⇒ more interpretable topics; chance baseline is 1 / (top-N + 1).
         </p>
         <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
           <UnmixingStat label="model" value={data.model} />

--- a/frontend/src/pages/workspace/tabs/MetricsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/MetricsTab.tsx
@@ -87,7 +87,16 @@ export function MetricsTab({
             How much information about the label each K-dim representation
             retains (theta vs PCA-K vs NMF-K vs ICA-K vs dense-AE-K). Reported
             as joint MI clipped to label entropy and as the fraction of entropy
-            recovered.
+            recovered.{" "}
+            <em>
+              MI is estimated with the Kraskov–Stögbauer–Grassberger
+              k-NN estimator (k = 3) for continuous–discrete pairs
+              (Ross 2014 extension of Kraskov et al. 2004), the same
+              estimator scikit-learn ships behind{" "}
+              <code>mutual_info_classif</code>. Values are bias-corrected
+              and shown alongside the label-entropy upper bound so the
+              ratio MI / H(L) reflects the actual recoverable fraction.
+            </em>
           </p>
         </header>
         {miLoading && (

--- a/frontend/src/pages/workspace/tabs/NeuralTopicComparisonTab.tsx
+++ b/frontend/src/pages/workspace/tabs/NeuralTopicComparisonTab.tsx
@@ -133,7 +133,7 @@ function NeuralComparisonGrid({
 }) {
   const methods = Object.entries(comparison.methods);
   return (
-    <div className="grid lg:grid-cols-3 gap-4">
+    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
       {methods.map(([name, m]) => {
         const colour = NEURAL_METHOD_COLOR[name] ?? "var(--color-accent)";
         return (

--- a/frontend/src/pages/workspace/tabs/QKExploreTab.tsx
+++ b/frontend/src/pages/workspace/tabs/QKExploreTab.tsx
@@ -121,7 +121,7 @@ export function QKExploreTab({
             {canonicalK} canonical fit.
           </p>
         )}
-        <div className="grid lg:grid-cols-3 gap-4">
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
           <SweepCurveCard
             title="Perplexity (test)"
             subtitle="lower is better; ↓ shows the model captures the held-out word distribution"

--- a/frontend/src/pages/workspace/tabs/RobustnessTab.tsx
+++ b/frontend/src/pages/workspace/tabs/RobustnessTab.tsx
@@ -239,6 +239,8 @@ function CrossSceneTransferCard({
           viewBox={`0 0 ${W} ${H}`}
           className="max-w-full h-auto"
           style={{ maxWidth: 1080 }}
+          role="img"
+          aria-label="Cross-scene transfer ARI matrix"
         >
           {transfer.scene_order.map((sc, j) => (
             <text

--- a/frontend/src/pages/workspace/tabs/SpatialStructureTab.tsx
+++ b/frontend/src/pages/workspace/tabs/SpatialStructureTab.tsx
@@ -456,6 +456,8 @@ function FelzenszwalbCard({
           viewBox={`0 0 ${W} ${H}`}
           className="max-w-full h-auto"
           style={{ maxWidth: 900 }}
+          role="img"
+          aria-label="Spatial structure per-method comparison plot"
         >
           <line
             x1={pad.l}

--- a/frontend/src/pages/workspace/tabs/SpectralBrowserTab.tsx
+++ b/frontend/src/pages/workspace/tabs/SpectralBrowserTab.tsx
@@ -416,6 +416,8 @@ function FalseColorBandPicker({
             className="block"
             style={{ width: Math.min(420, W * cellSize), height: Math.min(480, H * cellSize), backgroundColor: "var(--color-bg)" }}
             shapeRendering="crispEdges"
+            role="img"
+            aria-label="Spectral browser pixel-grid (click to pin a pixel and inspect its spectrum)"
           >
             {samples.map((s, i) => (
               <rect

--- a/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
+++ b/frontend/src/pages/workspace/tabs/TopicLabelTab.tsx
@@ -198,7 +198,7 @@ export function TopicLabelTab({
       </div>
 
       <div
-        className="grid lg:grid-cols-2 gap-5"
+        className="grid md:grid-cols-2 gap-5"
         style={{ color: "var(--color-fg-subtle)" }}
       >
         <div

--- a/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
@@ -85,7 +85,7 @@ export function UnmixingTab({
 
       <UnmixingSpectraCard
         title="NFINDR endmember spectra"
-        subtitle="K vertices of the data simplex (Winter 1999). Each curve is one pure-pixel candidate."
+        subtitle="N-FINDR (Winter 1999) seeds K random pixels, then iteratively swaps each in turn for any pixel that increases the volume of the K-simplex they span; convergence picks K pure-pixel candidates that maximise simplex volume. Each curve below is one of those K vertices."
         spectra={data.nfindr_endmembers ?? []}
         wavelengths={wavelengths}
         accent="rgba(56,189,248,1)"
@@ -94,7 +94,7 @@ export function UnmixingTab({
       {data.atgp_endmembers && data.atgp_endmembers.length > 0 ? (
         <UnmixingSpectraCard
           title="ATGP endmember spectra"
-          subtitle="Automatic Target Generation Process (Ren & Chang 2003). Alternative extractor — pixel-wise orthogonal subspace projection."
+          subtitle="Automatic Target Generation Process (Ren & Chang 2003): pick the pixel with maximum L2 norm as endmember 1; iteratively project the residual orthogonal to the current set and pick the pixel with the largest projection norm as the next endmember. Greedy alternative to N-FINDR; usually produces a similar set."
           spectra={data.atgp_endmembers}
           wavelengths={wavelengths}
           accent="rgba(170,60,200,1)"

--- a/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UnmixingTab.tsx
@@ -186,7 +186,7 @@ function UnmixingSpectraCard({
       </div>
       <p className="text-[12px] mb-2" style={{ color: "var(--color-fg-faint)" }}>{subtitle}</p>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 900 }}>
+        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 900 }} role="img" aria-label="Per-topic endmember-cosine matrix">
           {/* axes */}
           <line x1={pad.l} y1={pad.t + innerH} x2={pad.l + innerW} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
           <line x1={pad.l} y1={pad.t} x2={pad.l} y2={pad.t + innerH} stroke="currentColor" opacity={0.3} />
@@ -288,7 +288,7 @@ function UnmixingTopicHeatmap({
         Rows = LDA topic profiles φ<sub>k</sub>; columns = NFINDR endmember spectra. Cell ≈ cosine. Best matches are starred.
       </p>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 720 }}>
+        <svg viewBox={`0 0 ${W} ${H}`} className="max-w-full h-auto" style={{ maxWidth: 720 }} role="img" aria-label="Per-topic abundance map heatmap">
           {Array.from({ length: N }).map((_, j) => (
             <text key={`c-${j}`} x={labelW + j * cell + cell / 2} y={labelW - 6} fontSize="9.5" textAnchor="middle" fill="currentColor" opacity={0.65} fontFamily="ui-monospace, monospace">
               em{j}

--- a/frontend/src/pages/workspace/tabs/UsgsTab.tsx
+++ b/frontend/src/pages/workspace/tabs/UsgsTab.tsx
@@ -122,7 +122,7 @@ export function UsgsTab({
         </div>
 
         {top && (
-          <div className="grid lg:grid-cols-2 gap-5">
+          <div className="grid md:grid-cols-2 gap-5">
             <div>
               <h5
                 className="text-sm font-semibold mb-2"


### PR DESCRIPTION
5 cycles closing the post-audit deepening pass:

- c350 (PR #581): methodology Section title+lead i18n (24 sections)
- c351 (PR #582): 22 dead static-content routes removed (82 → 60 /api routes)
- c352 (PR #583): Tier-2 inline defs (DMR-LDA, NFINDR/ATGP, Geary's C, word-intrusion, KSG MI estimator)
- c353 (PR #584): a11y SVG role+aria-label (7 plots) + 5 theme-token white fills
- c354 (PR #585): responsive md: breakpoints on 8 grid containers