### PR TITLE
c357: HOTFIX deploy-blocker (Section duplicate title attr)

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -565,6 +565,10 @@
       },
       "see-also": {
         "title": "How to continue"
+      },
+      "what-topics-capture": {
+        "title": "What does a topic \"capture\", in task terms?",
+        "lead": "It is not text: the question is answered visually with distributions."
       }
     }
   },

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -565,6 +565,10 @@
       },
       "see-also": {
         "title": "Cómo continuar"
+      },
+      "what-topics-capture": {
+        "title": "¿Qué \"captura\" un tópico, en términos de tarea?",
+        "lead": "No es texto: la pregunta se responde visualmente con distribuciones."
       }
     }
   },

--- a/frontend/src/pages/methodology/Application.tsx
+++ b/frontend/src/pages/methodology/Application.tsx
@@ -409,7 +409,11 @@ export default function MethodologyApplication() {
         </p>
       </Section>
 
-      <Section id="what-topics-capture" title='What does a topic "capture", in task terms?' title={t("pages:methodology_application.sections.what-topics-capture.title")}>
+      <Section
+        id="what-topics-capture"
+        title={t("pages:methodology_application.sections.what-topics-capture.title")}
+        lead={t("pages:methodology_application.sections.what-topics-capture.lead")}
+      >
         <p>
           For each topic <Equation tex="k" />, the Workspace shows:
         </p>


### PR DESCRIPTION
tsc -b on the server caught a duplicate JSX title= attr at Application.tsx:412 that local tsc --noEmit missed. Adds the i18n key + removes the literal title.