### PR TITLE
c358: ORCID URL fix on Header (was bogus 3614-2087)

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -16,7 +16,7 @@ const NAV_ITEMS = [
 ];
 
 const EXTERNAL = {
-  orcid: "https://orcid.org/0000-0002-3614-2087",
+  orcid: "https://orcid.org/0000-0002-0150-3246",
   github: "https://github.com/fsantibanezleal/CAOS_LDA_HSI",
   paper: "https://github.com/fsantibanezleal/CAOS_LDA_HSI_Paper",
   site: "https://fasl-work.com",


### PR DESCRIPTION
Felipe caught this. Wrong ID lived in Header.tsx:19 since 2026-05-04 commit 173cf18. Correct ID 0000-0002-0150-3246 already in docs/sources.md + paper + legacy/.