### PR TITLE
c369: HIDSAG F-7 by sample_owner — V12 wins, V6 catastrophic

### DIFF
--- a/data-pipeline/build_v_sweep_hidsag_f7.py
+++ b/data-pipeline/build_v_sweep_hidsag_f7.py
@@ -1,0 +1,150 @@
+"""HIDSAG F-7 — NMI of topic-argmax against sample-owner ID.
+
+The HIDSAG region documents come from physical mineral samples; each
+document carries a `sample_owner` integer that identifies which sample
+it came from (e.g. MINERAL1 has 99 owners × 9 docs = 891 documents).
+Using sample_owner as the "label" we can compute F-7-style NMI: how
+much do the topics carry sample-membership information?
+
+This is a more interesting question for mineralogy than the labelled-
+scene F-7 because each sample is a unique mineralogical entity; topics
+that capture per-sample chemistry will score high here, while topics
+that capture generic spectral patterns will score low.
+
+Output: data/derived/v_sweep/hidsag/f7_topic_to_owner/{subset}_{V}_uniform_Q8.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from research_core.paths import DATA_DIR, DERIVED_DIR  # noqa: E402
+
+HIDSAG_NPZ = DATA_DIR / "derived" / "core" / "hidsag_region_documents.npz"
+SWEEP_LOCAL = DATA_DIR / "local" / "v_sweep" / "lda_fits_hidsag"
+F7_DERIVED = DERIVED_DIR / "v_sweep" / "hidsag" / "f7_topic_to_owner"
+
+SUBSETS = ["GEOCHEM", "GEOMET", "MINERAL1", "MINERAL2", "PORPHYRY"]
+RECIPES = [f"V{i}" for i in range(1, 13)]
+EPS = 1e-12
+
+
+def entropy(p):
+    p = np.clip(p, EPS, None)
+    p = p / p.sum()
+    return float(-np.sum(p * np.log2(p)))
+
+
+def compute_f7(theta: np.ndarray, owners: np.ndarray) -> dict:
+    z = np.argmax(theta, axis=1)
+    K = theta.shape[1]
+    classes = np.array(sorted(int(c) for c in np.unique(owners)))
+    C = classes.size
+    cls_idx = {c: i for i, c in enumerate(classes.tolist())}
+    owner_idx = np.array([cls_idx[int(c)] for c in owners])
+
+    p_owner = np.bincount(owner_idx, minlength=C).astype(np.float64)
+    p_owner /= max(p_owner.sum(), EPS)
+    H_owner = entropy(p_owner)
+
+    p_topic = np.bincount(z, minlength=K).astype(np.float64)
+    p_topic /= max(p_topic.sum(), EPS)
+
+    H_cond_terms = []
+    for k in range(K):
+        mask = z == k
+        if mask.sum() == 0:
+            continue
+        p_lk = np.bincount(owner_idx[mask], minlength=C).astype(np.float64)
+        p_lk /= p_lk.sum()
+        H_cond_terms.append(p_topic[k] * entropy(p_lk))
+    H_cond = float(np.sum(H_cond_terms))
+    mi = H_owner - H_cond
+    return {
+        "n_owners": int(C),
+        "K": int(K),
+        "H_owner_bits": round(H_owner, 6),
+        "H_owner_given_topic_bits": round(H_cond, 6),
+        "mutual_information_bits": round(mi, 6),
+        "normalised_mi": round(mi / max(H_owner, EPS), 6),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="HIDSAG F-7 by sample-owner.")
+    parser.add_argument("--recipes", nargs="+", default=RECIPES, choices=RECIPES)
+    parser.add_argument("--subsets", nargs="+", default=SUBSETS, choices=SUBSETS)
+    args = parser.parse_args()
+
+    if not HIDSAG_NPZ.exists():
+        print(f"HIDSAG npz not found: {HIDSAG_NPZ}", flush=True)
+        return 1
+    npz = np.load(HIDSAG_NPZ, allow_pickle=True)
+
+    F7_DERIVED.mkdir(parents=True, exist_ok=True)
+    n_ok = n_skip = 0
+    summary = []
+    for subset in args.subsets:
+        owners_key = f"{subset}__sample_owner"
+        if owners_key not in npz:
+            continue
+        owners = npz[owners_key]
+        for recipe in args.recipes:
+            fit_dir = SWEEP_LOCAL / f"{subset}_{recipe}_uniform_Q8"
+            theta_path = fit_dir / "theta.npy"
+            if not theta_path.exists():
+                n_skip += 1
+                continue
+            theta = np.load(theta_path)
+            if theta.shape[0] != len(owners):
+                n_skip += 1
+                continue
+            try:
+                res = compute_f7(theta, owners)
+            except Exception as exc:
+                n_skip += 1
+                print(f"[hidsag_f7] {subset} {recipe} FAILED: {exc}", flush=True)
+                continue
+            res.update({
+                "subset": subset, "recipe": recipe, "scheme": "uniform", "Q": 8,
+                "generated_at": datetime.now(timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z"),
+                "builder": "build_v_sweep_hidsag_f7 v0.1",
+            })
+            out = F7_DERIVED / f"{subset}_{recipe}_uniform_Q8.json"
+            with out.open("w", encoding="utf-8") as h:
+                json.dump(res, h, indent=2)
+            n_ok += 1
+            summary.append(res)
+            print(
+                f"[hidsag_f7] {subset:10s} {recipe:5s} K={res['K']:2d} "
+                f"n_owners={res['n_owners']:3d} NMI={res['normalised_mi']:.3f}",
+                flush=True,
+            )
+
+    if summary:
+        from collections import defaultdict
+        by_recipe = defaultdict(list)
+        for r in summary:
+            by_recipe[r["recipe"]].append(r["normalised_mi"])
+        print("\n[hidsag_f7] Per-recipe mean NMI (vs sample_owner):", flush=True)
+        for r in sorted(by_recipe, key=lambda x: int(x[1:])):
+            v = by_recipe[r]
+            print(f"    {r:5s} mean={np.mean(v):.4f} (n={len(v)})", flush=True)
+
+    print(f"\n[hidsag_f7] done. ok={n_ok} skipped={n_skip}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V10_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 3,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.654083,
+  "mutual_information_bits": 0.130441,
+  "normalised_mi": 0.027263,
+  "subset": "GEOCHEM",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V11_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 3,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.726074,
+  "mutual_information_bits": 0.05845,
+  "normalised_mi": 0.012217,
+  "subset": "GEOCHEM",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V12_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.649733,
+  "mutual_information_bits": 0.134791,
+  "normalised_mi": 0.028172,
+  "subset": "GEOCHEM",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V1_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.60208,
+  "mutual_information_bits": 0.182444,
+  "normalised_mi": 0.038132,
+  "subset": "GEOCHEM",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V2_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.538662,
+  "mutual_information_bits": 0.245862,
+  "normalised_mi": 0.051387,
+  "subset": "GEOCHEM",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V3_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.716814,
+  "mutual_information_bits": 0.06771,
+  "normalised_mi": 0.014152,
+  "subset": "GEOCHEM",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V4_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.549012,
+  "mutual_information_bits": 0.235512,
+  "normalised_mi": 0.049224,
+  "subset": "GEOCHEM",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V5_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.573934,
+  "mutual_information_bits": 0.21059,
+  "normalised_mi": 0.044015,
+  "subset": "GEOCHEM",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V6_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.760721,
+  "mutual_information_bits": 0.023804,
+  "normalised_mi": 0.004975,
+  "subset": "GEOCHEM",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOCHEM_V7_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 3,
+  "H_owner_bits": 4.784524,
+  "H_owner_given_topic_bits": 4.705178,
+  "mutual_information_bits": 0.079346,
+  "normalised_mi": 0.016584,
+  "subset": "GEOCHEM",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V10_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 3,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 7.18429,
+  "mutual_information_bits": 0.005535,
+  "normalised_mi": 0.00077,
+  "subset": "GEOMET",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V11_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 3,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 6.02414,
+  "mutual_information_bits": 1.165685,
+  "normalised_mi": 0.16213,
+  "subset": "GEOMET",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V12_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 8,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 5.473472,
+  "mutual_information_bits": 1.716353,
+  "normalised_mi": 0.23872,
+  "subset": "GEOMET",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V1_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 8,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 6.269322,
+  "mutual_information_bits": 0.920503,
+  "normalised_mi": 0.128029,
+  "subset": "GEOMET",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V2_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 8,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 5.641668,
+  "mutual_information_bits": 1.548156,
+  "normalised_mi": 0.215326,
+  "subset": "GEOMET",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V3_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 8,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 5.912708,
+  "mutual_information_bits": 1.277116,
+  "normalised_mi": 0.177628,
+  "subset": "GEOMET",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V4_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 8,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 5.98431,
+  "mutual_information_bits": 1.205515,
+  "normalised_mi": 0.16767,
+  "subset": "GEOMET",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V5_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 8,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 6.023827,
+  "mutual_information_bits": 1.165997,
+  "normalised_mi": 0.162173,
+  "subset": "GEOMET",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V6_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 8,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 6.55984,
+  "mutual_information_bits": 0.629984,
+  "normalised_mi": 0.087622,
+  "subset": "GEOMET",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/GEOMET_V7_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 146,
+  "K": 3,
+  "H_owner_bits": 7.189825,
+  "H_owner_given_topic_bits": 6.699004,
+  "mutual_information_bits": 0.49082,
+  "normalised_mi": 0.068266,
+  "subset": "GEOMET",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V10_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 3,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.383781,
+  "mutual_information_bits": 1.245575,
+  "normalised_mi": 0.187888,
+  "subset": "MINERAL1",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V11_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 3,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.824187,
+  "mutual_information_bits": 0.805169,
+  "normalised_mi": 0.121455,
+  "subset": "MINERAL1",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V12_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 8,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.032435,
+  "mutual_information_bits": 1.596921,
+  "normalised_mi": 0.240886,
+  "subset": "MINERAL1",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V1_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 8,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.308751,
+  "mutual_information_bits": 1.320606,
+  "normalised_mi": 0.199206,
+  "subset": "MINERAL1",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V2_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 8,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.204129,
+  "mutual_information_bits": 1.425227,
+  "normalised_mi": 0.214987,
+  "subset": "MINERAL1",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V3_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 8,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.112356,
+  "mutual_information_bits": 1.517001,
+  "normalised_mi": 0.228831,
+  "subset": "MINERAL1",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V4_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 8,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.853209,
+  "mutual_information_bits": 0.776148,
+  "normalised_mi": 0.117077,
+  "subset": "MINERAL1",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V5_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 8,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.535122,
+  "mutual_information_bits": 1.094235,
+  "normalised_mi": 0.165059,
+  "subset": "MINERAL1",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V6_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 8,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 6.629357,
+  "mutual_information_bits": 0.0,
+  "normalised_mi": 0.0,
+  "subset": "MINERAL1",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL1_V7_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 99,
+  "K": 3,
+  "H_owner_bits": 6.629357,
+  "H_owner_given_topic_bits": 5.724095,
+  "mutual_information_bits": 0.905262,
+  "normalised_mi": 0.136553,
+  "subset": "MINERAL1",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V10_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 3,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 3.625086,
+  "mutual_information_bits": 0.696842,
+  "normalised_mi": 0.161234,
+  "subset": "MINERAL2",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V11_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 3,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 3.272409,
+  "mutual_information_bits": 1.04952,
+  "normalised_mi": 0.242836,
+  "subset": "MINERAL2",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V12_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 8,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 3.837947,
+  "mutual_information_bits": 0.483981,
+  "normalised_mi": 0.111983,
+  "subset": "MINERAL2",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V1_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 8,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 2.859106,
+  "mutual_information_bits": 1.462822,
+  "normalised_mi": 0.338465,
+  "subset": "MINERAL2",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V2_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 8,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 3.125091,
+  "mutual_information_bits": 1.196837,
+  "normalised_mi": 0.276922,
+  "subset": "MINERAL2",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V3_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 8,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 3.978907,
+  "mutual_information_bits": 0.343021,
+  "normalised_mi": 0.079368,
+  "subset": "MINERAL2",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V4_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 8,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 4.136632,
+  "mutual_information_bits": 0.185296,
+  "normalised_mi": 0.042873,
+  "subset": "MINERAL2",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V5_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 8,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 4.321928,
+  "mutual_information_bits": 0.0,
+  "normalised_mi": 0.0,
+  "subset": "MINERAL2",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V6_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 8,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 4.321928,
+  "mutual_information_bits": 0.0,
+  "normalised_mi": 0.0,
+  "subset": "MINERAL2",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/MINERAL2_V7_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 20,
+  "K": 3,
+  "H_owner_bits": 4.321928,
+  "H_owner_given_topic_bits": 3.698434,
+  "mutual_information_bits": 0.623494,
+  "normalised_mi": 0.144263,
+  "subset": "MINERAL2",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V10_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 3,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 4.39982,
+  "mutual_information_bits": 0.407535,
+  "normalised_mi": 0.084773,
+  "subset": "PORPHYRY",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V11_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 3,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 3.619281,
+  "mutual_information_bits": 1.188074,
+  "normalised_mi": 0.247137,
+  "subset": "PORPHYRY",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V12_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 2.984233,
+  "mutual_information_bits": 1.823121,
+  "normalised_mi": 0.379236,
+  "subset": "PORPHYRY",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V1_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 3.941664,
+  "mutual_information_bits": 0.86569,
+  "normalised_mi": 0.180076,
+  "subset": "PORPHYRY",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V2_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 3.695042,
+  "mutual_information_bits": 1.112313,
+  "normalised_mi": 0.231377,
+  "subset": "PORPHYRY",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V3_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 4.497966,
+  "mutual_information_bits": 0.309389,
+  "normalised_mi": 0.064357,
+  "subset": "PORPHYRY",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V4_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 3.955731,
+  "mutual_information_bits": 0.851624,
+  "normalised_mi": 0.17715,
+  "subset": "PORPHYRY",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V5_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 3.616845,
+  "mutual_information_bits": 1.19051,
+  "normalised_mi": 0.247644,
+  "subset": "PORPHYRY",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V6_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 8,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 4.807355,
+  "mutual_information_bits": 0.0,
+  "normalised_mi": 0.0,
+  "subset": "PORPHYRY",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}

--- a/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hidsag/f7_topic_to_owner/PORPHYRY_V7_uniform_Q8.json
@@ -1,0 +1,14 @@
+{
+  "n_owners": 28,
+  "K": 3,
+  "H_owner_bits": 4.807355,
+  "H_owner_given_topic_bits": 3.951994,
+  "mutual_information_bits": 0.855361,
+  "normalised_mi": 0.177928,
+  "subset": "PORPHYRY",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "generated_at": "2026-05-27T03:40:00Z",
+  "builder": "build_v_sweep_hidsag_f7 v0.1"
+}


### PR DESCRIPTION
Quick follow-up to c368: compute F-7 NMI on HIDSAG using sample_owner ID as the label. V12 (GMM-token) wins again at 0.20 mean NMI; V6 (wavelet) catastrophic at 0.02. V7 hypothesis (absorption-triplet wins on mineralogical data) **disproved under LDA**. Tracks #606.