### PR TITLE
c375: F-18 reliability complete — V12 wins everything except reliability

### DIFF
--- a/data/derived/v_sweep/f18_reliability/botswana_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V10_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.806667,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 0.933333,
+  "per_pair_cosine_mean_per_topic": [
+    0.8,
+    0.79,
+    0.83
+  ],
+  "generated_at": "2026-05-27T05:31:46Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V11_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.663333,
+  "frac_above_0.5": 0.733333,
+  "frac_above_0.7": 0.266667,
+  "per_pair_cosine_mean_per_topic": [
+    0.72,
+    0.68,
+    0.59
+  ],
+  "generated_at": "2026-05-27T05:32:05Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V12_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.4275,
+  "frac_above_0.5": 0.366667,
+  "frac_above_0.7": 0.108333,
+  "per_pair_cosine_mean_per_topic": [
+    0.8,
+    0.35,
+    0.44,
+    0.45,
+    0.21,
+    0.42,
+    0.42,
+    0.33,
+    0.37,
+    0.3,
+    0.49,
+    0.55
+  ],
+  "generated_at": "2026-05-27T05:34:15Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V1_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.7,
+  "frac_above_0.5": 0.816667,
+  "frac_above_0.7": 0.375,
+  "per_pair_cosine_mean_per_topic": [
+    0.71,
+    0.52,
+    0.58,
+    0.69,
+    0.59,
+    0.64,
+    0.79,
+    0.83,
+    0.65,
+    0.69,
+    0.85,
+    0.86
+  ],
+  "generated_at": "2026-05-27T05:07:52Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V2_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 1.0,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0
+  ],
+  "generated_at": "2026-05-27T05:12:04Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V3_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.329167,
+  "frac_above_0.5": 0.225,
+  "frac_above_0.7": 0.125,
+  "per_pair_cosine_mean_per_topic": [
+    0.21,
+    0.48,
+    0.46,
+    0.35,
+    0.25,
+    0.33,
+    0.23,
+    0.28,
+    0.37,
+    0.25,
+    0.38,
+    0.36
+  ],
+  "generated_at": "2026-05-27T05:14:51Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V4_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.570833,
+  "frac_above_0.5": 0.6,
+  "frac_above_0.7": 0.091667,
+  "per_pair_cosine_mean_per_topic": [
+    0.53,
+    0.57,
+    0.6,
+    0.61,
+    0.64,
+    0.51,
+    0.62,
+    0.52,
+    0.67,
+    0.51,
+    0.52,
+    0.55
+  ],
+  "generated_at": "2026-05-27T05:20:03Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V5_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.695,
+  "frac_above_0.5": 0.891667,
+  "frac_above_0.7": 0.333333,
+  "per_pair_cosine_mean_per_topic": [
+    0.59,
+    0.76,
+    0.66,
+    0.73,
+    0.73,
+    0.69,
+    0.73,
+    0.8,
+    0.69,
+    0.64,
+    0.67,
+    0.65
+  ],
+  "generated_at": "2026-05-27T05:25:19Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V6_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.993333,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    0.98,
+    1.0,
+    0.97,
+    0.98,
+    1.0,
+    1.0,
+    1.0,
+    0.99
+  ],
+  "generated_at": "2026-05-27T05:29:28Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V7_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.466667,
+  "frac_above_0.5": 0.366667,
+  "frac_above_0.7": 0.033333,
+  "per_pair_cosine_mean_per_topic": [
+    0.52,
+    0.46,
+    0.42
+  ],
+  "generated_at": "2026-05-27T05:29:42Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V8_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.9425,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.98,
+    0.97,
+    0.97,
+    0.97,
+    0.94,
+    0.95,
+    0.94,
+    0.91,
+    0.93,
+    0.93,
+    0.91,
+    0.91
+  ],
+  "generated_at": "2026-05-27T05:30:46Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/botswana_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/botswana_V9_uniform_Q8.json
@@ -1,0 +1,27 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 4,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.3375,
+  "frac_above_0.5": 0.0,
+  "frac_above_0.7": 0.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.37,
+    0.29,
+    0.34,
+    0.35
+  ],
+  "generated_at": "2026-05-27T05:30:59Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V10_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.706667,
+  "frac_above_0.5": 0.766667,
+  "frac_above_0.7": 0.466667,
+  "per_pair_cosine_mean_per_topic": [
+    0.7,
+    0.65,
+    0.77
+  ],
+  "generated_at": "2026-05-27T05:00:44Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V11_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.736667,
+  "frac_above_0.5": 0.933333,
+  "frac_above_0.7": 0.366667,
+  "per_pair_cosine_mean_per_topic": [
+    0.79,
+    0.71,
+    0.71
+  ],
+  "generated_at": "2026-05-27T05:01:05Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V12_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.31,
+  "frac_above_0.5": 0.283333,
+  "frac_above_0.7": 0.125,
+  "per_pair_cosine_mean_per_topic": [
+    0.19,
+    0.29,
+    0.12,
+    0.41,
+    0.41,
+    0.49,
+    0.11,
+    0.48,
+    0.27,
+    0.27,
+    0.3,
+    0.38
+  ],
+  "generated_at": "2026-05-27T05:03:15Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V1_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.605,
+  "frac_above_0.5": 0.55,
+  "frac_above_0.7": 0.25,
+  "per_pair_cosine_mean_per_topic": [
+    0.59,
+    0.81,
+    0.94,
+    0.5,
+    0.73,
+    0.58,
+    0.63,
+    0.54,
+    0.56,
+    0.39,
+    0.5,
+    0.49
+  ],
+  "generated_at": "2026-05-27T04:37:16Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V2_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 1.0,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0
+  ],
+  "generated_at": "2026-05-27T04:41:09Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V3_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.43,
+  "frac_above_0.5": 0.425,
+  "frac_above_0.7": 0.258333,
+  "per_pair_cosine_mean_per_topic": [
+    0.29,
+    0.36,
+    0.48,
+    0.36,
+    0.58,
+    0.47,
+    0.52,
+    0.5,
+    0.39,
+    0.34,
+    0.58,
+    0.29
+  ],
+  "generated_at": "2026-05-27T04:43:43Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V4_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.3275,
+  "frac_above_0.5": 0.083333,
+  "frac_above_0.7": 0.083333,
+  "per_pair_cosine_mean_per_topic": [
+    0.45,
+    0.33,
+    0.25,
+    0.33,
+    0.27,
+    0.31,
+    0.29,
+    0.52,
+    0.35,
+    0.21,
+    0.37,
+    0.25
+  ],
+  "generated_at": "2026-05-27T04:48:53Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V5_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.495833,
+  "frac_above_0.5": 0.316667,
+  "frac_above_0.7": 0.083333,
+  "per_pair_cosine_mean_per_topic": [
+    0.45,
+    0.43,
+    0.55,
+    0.53,
+    0.52,
+    0.54,
+    0.41,
+    0.56,
+    0.46,
+    0.49,
+    0.54,
+    0.47
+  ],
+  "generated_at": "2026-05-27T04:54:01Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V6_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.899167,
+  "frac_above_0.5": 0.916667,
+  "frac_above_0.7": 0.875,
+  "per_pair_cosine_mean_per_topic": [
+    0.96,
+    1.0,
+    0.95,
+    0.99,
+    0.79,
+    0.88,
+    0.98,
+    0.73,
+    0.88,
+    0.82,
+    0.94,
+    0.87
+  ],
+  "generated_at": "2026-05-27T04:57:40Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V7_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.63,
+  "frac_above_0.5": 0.666667,
+  "frac_above_0.7": 0.2,
+  "per_pair_cosine_mean_per_topic": [
+    0.67,
+    0.74,
+    0.48
+  ],
+  "generated_at": "2026-05-27T04:57:58Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V8_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.894167,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.93,
+    0.92,
+    0.94,
+    0.92,
+    0.89,
+    0.88,
+    0.9,
+    0.91,
+    0.87,
+    0.87,
+    0.86,
+    0.84
+  ],
+  "generated_at": "2026-05-27T04:59:58Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/kennedy-space-center_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/kennedy-space-center_V9_uniform_Q8.json
@@ -1,0 +1,27 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 4,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.34,
+  "frac_above_0.5": 0.0,
+  "frac_above_0.7": 0.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.38,
+    0.33,
+    0.33,
+    0.32
+  ],
+  "generated_at": "2026-05-27T05:00:11Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V10_uniform_Q8.json
@@ -1,0 +1,27 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 4,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.56,
+  "frac_above_0.5": 0.575,
+  "frac_above_0.7": 0.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.57,
+    0.58,
+    0.57,
+    0.52
+  ],
+  "generated_at": "2026-05-27T04:31:18Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V11_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.613333,
+  "frac_above_0.5": 0.733333,
+  "frac_above_0.7": 0.133333,
+  "per_pair_cosine_mean_per_topic": [
+    0.61,
+    0.59,
+    0.64
+  ],
+  "generated_at": "2026-05-27T04:31:33Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V12_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.46,
+  "frac_above_0.5": 0.455556,
+  "frac_above_0.7": 0.311111,
+  "per_pair_cosine_mean_per_topic": [
+    0.53,
+    0.49,
+    0.46,
+    0.61,
+    0.2,
+    0.56,
+    0.39,
+    0.42,
+    0.48
+  ],
+  "generated_at": "2026-05-27T04:32:24Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V1_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.468889,
+  "frac_above_0.5": 0.322222,
+  "frac_above_0.7": 0.144444,
+  "per_pair_cosine_mean_per_topic": [
+    0.48,
+    0.54,
+    0.38,
+    0.38,
+    0.53,
+    0.67,
+    0.52,
+    0.37,
+    0.35
+  ],
+  "generated_at": "2026-05-27T04:16:49Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V2_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 1.0,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0
+  ],
+  "generated_at": "2026-05-27T04:19:13Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V3_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.395556,
+  "frac_above_0.5": 0.444444,
+  "frac_above_0.7": 0.211111,
+  "per_pair_cosine_mean_per_topic": [
+    0.44,
+    0.17,
+    0.6,
+    0.18,
+    0.36,
+    0.22,
+    0.45,
+    0.76,
+    0.38
+  ],
+  "generated_at": "2026-05-27T04:20:14Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V4_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.51,
+  "frac_above_0.5": 0.4,
+  "frac_above_0.7": 0.233333,
+  "per_pair_cosine_mean_per_topic": [
+    0.39,
+    0.53,
+    0.47,
+    0.48,
+    0.54,
+    0.37,
+    0.57,
+    0.63,
+    0.61
+  ],
+  "generated_at": "2026-05-27T04:23:42Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V5_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.527778,
+  "frac_above_0.5": 0.433333,
+  "frac_above_0.7": 0.1,
+  "per_pair_cosine_mean_per_topic": [
+    0.49,
+    0.49,
+    0.58,
+    0.6,
+    0.53,
+    0.53,
+    0.45,
+    0.49,
+    0.59
+  ],
+  "generated_at": "2026-05-27T04:27:08Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V6_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.917778,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 0.977778,
+  "per_pair_cosine_mean_per_topic": [
+    0.91,
+    0.87,
+    0.96,
+    0.88,
+    0.9,
+    0.94,
+    0.91,
+    0.95,
+    0.94
+  ],
+  "generated_at": "2026-05-27T04:29:54Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V7_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.556667,
+  "frac_above_0.5": 0.666667,
+  "frac_above_0.7": 0.066667,
+  "per_pair_cosine_mean_per_topic": [
+    0.68,
+    0.54,
+    0.45
+  ],
+  "generated_at": "2026-05-27T04:30:07Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V8_uniform_Q8.json
@@ -1,0 +1,32 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 1.0,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0
+  ],
+  "generated_at": "2026-05-27T04:30:49Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/pavia-university_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/pavia-university_V9_uniform_Q8.json
@@ -1,0 +1,27 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 4,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.3475,
+  "frac_above_0.5": 0.05,
+  "frac_above_0.7": 0.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.31,
+    0.39,
+    0.34,
+    0.35
+  ],
+  "generated_at": "2026-05-27T04:31:00Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V10_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.81,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 0.933333,
+  "per_pair_cosine_mean_per_topic": [
+    0.79,
+    0.79,
+    0.85
+  ],
+  "generated_at": "2026-05-27T04:12:37Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V11_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.68,
+  "frac_above_0.5": 0.633333,
+  "frac_above_0.7": 0.366667,
+  "per_pair_cosine_mean_per_topic": [
+    0.58,
+    0.74,
+    0.72
+  ],
+  "generated_at": "2026-05-27T04:12:47Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V12_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.343333,
+  "frac_above_0.5": 0.283333,
+  "frac_above_0.7": 0.116667,
+  "per_pair_cosine_mean_per_topic": [
+    0.5,
+    0.28,
+    0.23,
+    0.57,
+    0.19,
+    0.29
+  ],
+  "generated_at": "2026-05-27T04:13:53Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V1_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.55,
+  "frac_above_0.5": 0.566667,
+  "frac_above_0.7": 0.283333,
+  "per_pair_cosine_mean_per_topic": [
+    0.58,
+    0.61,
+    0.68,
+    0.5,
+    0.63,
+    0.3
+  ],
+  "generated_at": "2026-05-27T03:59:58Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V2_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 1.0,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0
+  ],
+  "generated_at": "2026-05-27T04:02:26Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V3_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.508333,
+  "frac_above_0.5": 0.483333,
+  "frac_above_0.7": 0.383333,
+  "per_pair_cosine_mean_per_topic": [
+    0.62,
+    0.49,
+    0.54,
+    0.42,
+    0.49,
+    0.49
+  ],
+  "generated_at": "2026-05-27T04:03:32Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V4_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.651667,
+  "frac_above_0.5": 0.8,
+  "frac_above_0.7": 0.25,
+  "per_pair_cosine_mean_per_topic": [
+    0.67,
+    0.59,
+    0.76,
+    0.69,
+    0.61,
+    0.59
+  ],
+  "generated_at": "2026-05-27T04:06:35Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V5_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.573333,
+  "frac_above_0.5": 0.65,
+  "frac_above_0.7": 0.116667,
+  "per_pair_cosine_mean_per_topic": [
+    0.49,
+    0.59,
+    0.52,
+    0.58,
+    0.65,
+    0.61
+  ],
+  "generated_at": "2026-05-27T04:09:37Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V6_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.868333,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 0.866667,
+  "per_pair_cosine_mean_per_topic": [
+    0.91,
+    0.89,
+    0.84,
+    0.82,
+    0.89,
+    0.86
+  ],
+  "generated_at": "2026-05-27T04:10:56Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V7_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.54,
+  "frac_above_0.5": 0.5,
+  "frac_above_0.7": 0.3,
+  "per_pair_cosine_mean_per_topic": [
+    0.56,
+    0.43,
+    0.63
+  ],
+  "generated_at": "2026-05-27T04:11:05Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V8_uniform_Q8.json
@@ -1,0 +1,29 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 1.0,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+    1.0
+  ],
+  "generated_at": "2026-05-27T04:11:58Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-a-corrected_V9_uniform_Q8.json
@@ -1,0 +1,27 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 4,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.325,
+  "frac_above_0.5": 0.025,
+  "frac_above_0.7": 0.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.3,
+    0.32,
+    0.35,
+    0.33
+  ],
+  "generated_at": "2026-05-27T04:12:05Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-corrected_V10_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.756667,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 0.566667,
+  "per_pair_cosine_mean_per_topic": [
+    0.74,
+    0.75,
+    0.78
+  ],
+  "generated_at": "2026-05-27T03:53:40Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-corrected_V11_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.616667,
+  "frac_above_0.5": 0.766667,
+  "frac_above_0.7": 0.133333,
+  "per_pair_cosine_mean_per_topic": [
+    0.58,
+    0.59,
+    0.68
+  ],
+  "generated_at": "2026-05-27T03:54:07Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-corrected_V12_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.300833,
+  "frac_above_0.5": 0.208333,
+  "frac_above_0.7": 0.1,
+  "per_pair_cosine_mean_per_topic": [
+    0.26,
+    0.16,
+    0.33,
+    0.29,
+    0.32,
+    0.27,
+    0.29,
+    0.33,
+    0.26,
+    0.2,
+    0.41,
+    0.49
+  ],
+  "generated_at": "2026-05-27T03:57:23Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-corrected_V6_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.914167,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 0.991667,
+  "per_pair_cosine_mean_per_topic": [
+    0.89,
+    0.91,
+    0.91,
+    0.87,
+    0.97,
+    0.96,
+    0.91,
+    0.93,
+    0.95,
+    0.91,
+    0.88,
+    0.88
+  ],
+  "generated_at": "2026-05-27T03:49:37Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-corrected_V7_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.573333,
+  "frac_above_0.5": 0.333333,
+  "frac_above_0.7": 0.166667,
+  "per_pair_cosine_mean_per_topic": [
+    0.57,
+    0.58,
+    0.57
+  ],
+  "generated_at": "2026-05-27T03:50:02Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-corrected_V8_uniform_Q8.json
@@ -1,0 +1,35 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.9525,
+  "frac_above_0.5": 1.0,
+  "frac_above_0.7": 1.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.99,
+    0.99,
+    0.95,
+    0.96,
+    0.95,
+    0.93,
+    0.98,
+    0.93,
+    0.95,
+    0.93,
+    0.96,
+    0.91
+  ],
+  "generated_at": "2026-05-27T03:52:02Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}

--- a/data/derived/v_sweep/f18_reliability/salinas-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f18_reliability/salinas-corrected_V9_uniform_Q8.json
@@ -1,0 +1,27 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 4,
+  "n_seeds": 5,
+  "top_n": 10,
+  "seeds_used": [
+    42,
+    43,
+    44,
+    45,
+    46
+  ],
+  "mean_matched_cosine": 0.35,
+  "frac_above_0.5": 0.05,
+  "frac_above_0.7": 0.0,
+  "per_pair_cosine_mean_per_topic": [
+    0.35,
+    0.36,
+    0.32,
+    0.37
+  ],
+  "generated_at": "2026-05-27T03:52:23Z",
+  "builder": "build_v_sweep_f18_reliability v0.1"
+}


### PR DESCRIPTION
Tradeoff revealed: V12 wins F-1/F-2/F-7/F-14/F-22 + HIDSAG but loses F-18 (0.141 vs V1 0.255). V1 canonical defensible as reproducibility default. Tracks #624.