### PR TITLE
c379: ETM backbone — V12 wins; 4-backbone factorial summary

### DIFF
--- a/data-pipeline/build_v_sweep_etm_backbone.py
+++ b/data-pipeline/build_v_sweep_etm_backbone.py
@@ -1,0 +1,109 @@
+"""V-sweep ETM backbone — factorial backbone row (#617 third row).
+
+Embedded Topic Model (Dieng-Ruiz-Blei 2020). Reuses the ETM impl from
+build_neural_topic_models.py and runs it on each (V, scene).
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import scipy.sparse as sp
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from research_core.paths import DATA_DIR, DERIVED_DIR  # noqa: E402
+
+_PIPE = ROOT / "data-pipeline"
+_spec = importlib.util.spec_from_file_location("neural_models", _PIPE / "build_neural_topic_models.py")
+_neural = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_neural)
+
+# Reuse the helper from the ProdLDA builder via import
+_pl_spec = importlib.util.spec_from_file_location("prodlda_v", _PIPE / "build_v_sweep_prodlda_backbone.py")
+_pl = importlib.util.module_from_spec(_pl_spec)
+_pl_spec.loader.exec_module(_pl)
+
+WORDIFICATION_LOCAL = DATA_DIR / "local" / "wordifications"
+ETM_DERIVED = DERIVED_DIR / "v_sweep" / "etm_backbone"
+
+LABELLED_SCENES = _pl.LABELLED_SCENES
+RECIPES = _pl.RECIPES
+
+
+def for_cell(recipe: str, scene_id: str) -> dict | None:
+    doc_term = _pl.load_doc_term(recipe, scene_id)
+    if doc_term is None:
+        return None
+    D, V = doc_term.shape
+    mean_doc = float(np.asarray(doc_term.sum(axis=1)).reshape(-1).mean())
+    K = _pl.k_for(scene_id, mean_doc)
+    dense = doc_term.toarray().astype(np.float32)
+    t0 = time.perf_counter()
+    try:
+        fit = _neural.fit_etm(dense, K, seed=42)
+    except Exception as exc:
+        return {
+            "scene_id": scene_id, "recipe": recipe, "scheme": "uniform", "Q": 8,
+            "status": "failed", "error": str(exc),
+        }
+    fit_secs = time.perf_counter() - t0
+    phi = fit["phi"]
+    metrics = _pl.compute_f2_f14(phi, doc_term)
+    return {
+        "scene_id": scene_id, "recipe": recipe, "scheme": "uniform", "Q": 8,
+        "backbone": "ETM", "K": int(K), "D": int(D), "V": int(V),
+        "mean_doc_length": round(mean_doc, 4),
+        **metrics, "fit_seconds": round(fit_secs, 3), "status": "ok",
+        "generated_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "builder": "build_v_sweep_etm_backbone v0.1",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="V-sweep ETM backbone.")
+    parser.add_argument("--recipes", nargs="+", default=RECIPES, choices=RECIPES)
+    parser.add_argument("--scenes", nargs="+", default=LABELLED_SCENES,
+                        choices=LABELLED_SCENES)
+    args = parser.parse_args()
+
+    ETM_DERIVED.mkdir(parents=True, exist_ok=True)
+    n_ok = n_fail = 0
+    for scene in args.scenes:
+        for recipe in args.recipes:
+            tag = f"{scene} {recipe}"
+            print(f"[etm] {tag} ...", flush=True)
+            res = for_cell(recipe, scene)
+            if res is None:
+                n_fail += 1
+                continue
+            out = ETM_DERIVED / f"{scene}_{recipe}_uniform_Q8.json"
+            with out.open("w", encoding="utf-8") as h:
+                json.dump(res, h, indent=2)
+            if res.get("status") == "ok":
+                n_ok += 1
+                print(
+                    f"  K={res['K']} c_v={res['f2_c_v']:.3f} "
+                    f"jacc={res['f14_mean_pairwise_jaccard']:.3f} "
+                    f"t={res['fit_seconds']}s",
+                    flush=True,
+                )
+            else:
+                n_fail += 1
+                print(f"  FAILED: {res.get('error', 'unknown')}", flush=True)
+    print(f"[etm] done. ok={n_ok} failed={n_fail}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/derived/v_sweep/etm_backbone/botswana_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V10_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2775,
+  "V": 24,
+  "mean_doc_length": 3.0,
+  "f2_c_v": 0.333962,
+  "f14_mean_pairwise_jaccard": 0.878788,
+  "fit_seconds": 5.576,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:39Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V11_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2775,
+  "V": 32,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.227443,
+  "f14_mean_pairwise_jaccard": 0.054581,
+  "fit_seconds": 5.617,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:45Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V12_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 1160,
+  "mean_doc_length": 145.0,
+  "f2_c_v": 0.858427,
+  "f14_mean_pairwise_jaccard": 0.039273,
+  "fit_seconds": 5.955,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:51Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V13_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2775,
+  "V": 128,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.185042,
+  "f14_mean_pairwise_jaccard": 0.414884,
+  "fit_seconds": 5.672,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:57Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V1_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 145,
+  "mean_doc_length": 332.276,
+  "f2_c_v": 0.389478,
+  "f14_mean_pairwise_jaccard": 0.497085,
+  "fit_seconds": 5.782,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:47Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V2_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 8,
+  "mean_doc_length": 145.0,
+  "f2_c_v": 0.353553,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 5.615,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:53Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V3_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 1160,
+  "mean_doc_length": 145.0,
+  "f2_c_v": 0.788154,
+  "f14_mean_pairwise_jaccard": 0.009835,
+  "fit_seconds": 5.982,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:59Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V4_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 145,
+  "mean_doc_length": 545.2184,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.77599,
+  "fit_seconds": 5.748,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:05Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V5_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 145,
+  "mean_doc_length": 452.8876,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.734313,
+  "fit_seconds": 5.782,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:11Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V6_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 171,
+  "mean_doc_length": 59.5845,
+  "f2_c_v": 0.3444,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 5.822,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:16Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V7_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2775,
+  "V": 178,
+  "mean_doc_length": 6.0,
+  "f2_c_v": 0.263617,
+  "f14_mean_pairwise_jaccard": 0.0,
+  "fit_seconds": 5.801,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:22Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V8_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 12,
+  "mean_doc_length": 15.151,
+  "f2_c_v": 0.278009,
+  "f14_mean_pairwise_jaccard": 0.795225,
+  "fit_seconds": 5.643,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:28Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V9_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 4,
+  "D": 2775,
+  "V": 424,
+  "mean_doc_length": 1.0,
+  "f2_c_v": 0.743927,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 5.884,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:08:34Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V10_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2812,
+  "V": 24,
+  "mean_doc_length": 3.0,
+  "f2_c_v": 0.272676,
+  "f14_mean_pairwise_jaccard": 0.767677,
+  "fit_seconds": 5.942,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:13Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V11_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2812,
+  "V": 32,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.24497,
+  "f14_mean_pairwise_jaccard": 0.0,
+  "fit_seconds": 5.954,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:19Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V12_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 1600,
+  "mean_doc_length": 200.0,
+  "f2_c_v": 0.667064,
+  "f14_mean_pairwise_jaccard": 0.022249,
+  "fit_seconds": 6.574,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:25Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V13_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2812,
+  "V": 128,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.269306,
+  "f14_mean_pairwise_jaccard": 0.128655,
+  "fit_seconds": 7.687,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:33Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V1_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 200,
+  "mean_doc_length": 450.0864,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.265515,
+  "fit_seconds": 11.448,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:01:18Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V2_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 8,
+  "mean_doc_length": 200.0,
+  "f2_c_v": 0.353531,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 5.966,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:01:24Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V3_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 1600,
+  "mean_doc_length": 200.0,
+  "f2_c_v": 0.748771,
+  "f14_mean_pairwise_jaccard": 0.03072,
+  "fit_seconds": 6.166,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:01:31Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V4_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 200,
+  "mean_doc_length": 585.1451,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.746627,
+  "fit_seconds": 5.977,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:01:37Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V5_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 200,
+  "mean_doc_length": 621.9018,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.680209,
+  "fit_seconds": 6.314,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:01:43Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V6_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 227,
+  "mean_doc_length": 75.4331,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 5.957,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:01:49Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V7_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2812,
+  "V": 171,
+  "mean_doc_length": 6.0,
+  "f2_c_v": 0.275596,
+  "f14_mean_pairwise_jaccard": 0.0,
+  "fit_seconds": 5.7,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:01:55Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V8_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 12,
+  "mean_doc_length": 14.3695,
+  "f2_c_v": 0.301767,
+  "f14_mean_pairwise_jaccard": 0.706152,
+  "fit_seconds": 5.86,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:01Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V9_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 4,
+  "D": 2812,
+  "V": 536,
+  "mean_doc_length": 1.0,
+  "f2_c_v": 0.730835,
+  "f14_mean_pairwise_jaccard": 0.823232,
+  "fit_seconds": 6.135,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:07Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V10_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2686,
+  "V": 24,
+  "mean_doc_length": 3.0,
+  "f2_c_v": 0.490231,
+  "f14_mean_pairwise_jaccard": 0.878788,
+  "fit_seconds": 6.105,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:24Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V11_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2686,
+  "V": 32,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.230931,
+  "f14_mean_pairwise_jaccard": 0.093911,
+  "fit_seconds": 6.007,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:30Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V12_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 1408,
+  "mean_doc_length": 176.0,
+  "f2_c_v": 0.8673,
+  "f14_mean_pairwise_jaccard": 0.035273,
+  "fit_seconds": 6.135,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:36Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V13_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2686,
+  "V": 128,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.237918,
+  "f14_mean_pairwise_jaccard": 0.333333,
+  "fit_seconds": 5.445,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:42Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V1_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 176,
+  "mean_doc_length": 506.2074,
+  "f2_c_v": 0.99835,
+  "f14_mean_pairwise_jaccard": 0.634986,
+  "fit_seconds": 6.109,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:28Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V2_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 8,
+  "mean_doc_length": 176.0,
+  "f2_c_v": 0.763586,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 5.946,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:34Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V3_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 1408,
+  "mean_doc_length": 176.0,
+  "f2_c_v": 0.930339,
+  "f14_mean_pairwise_jaccard": 0.024458,
+  "fit_seconds": 6.564,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:40Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V4_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 176,
+  "mean_doc_length": 871.0052,
+  "f2_c_v": 0.724298,
+  "f14_mean_pairwise_jaccard": 0.725634,
+  "fit_seconds": 6.448,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:47Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V5_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 176,
+  "mean_doc_length": 672.9531,
+  "f2_c_v": 0.96144,
+  "f14_mean_pairwise_jaccard": 0.760153,
+  "fit_seconds": 6.065,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:53Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V6_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 202,
+  "mean_doc_length": 45.7144,
+  "f2_c_v": 0.824096,
+  "f14_mean_pairwise_jaccard": 0.809413,
+  "fit_seconds": 6.352,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:59Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V7_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 2686,
+  "V": 280,
+  "mean_doc_length": 6.0,
+  "f2_c_v": 0.342237,
+  "f14_mean_pairwise_jaccard": 0.0,
+  "fit_seconds": 6.044,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:05Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V8_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 12,
+  "mean_doc_length": 9.6069,
+  "f2_c_v": 0.465822,
+  "f14_mean_pairwise_jaccard": 0.862259,
+  "fit_seconds": 5.958,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:11Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V9_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 4,
+  "D": 2686,
+  "V": 528,
+  "mean_doc_length": 1.0,
+  "f2_c_v": 0.736863,
+  "f14_mean_pairwise_jaccard": 0.772727,
+  "fit_seconds": 6.502,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:07:18Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V10_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 4,
+  "D": 1980,
+  "V": 24,
+  "mean_doc_length": 1.0,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.627817,
+  "fit_seconds": 4.78,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:07Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V11_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 1980,
+  "V": 32,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.249797,
+  "f14_mean_pairwise_jaccard": 0.054581,
+  "fit_seconds": 4.96,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:12Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V12_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 824,
+  "mean_doc_length": 103.0,
+  "f2_c_v": 0.954644,
+  "f14_mean_pairwise_jaccard": 0.001462,
+  "fit_seconds": 5.091,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:17Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V13_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 1980,
+  "V": 128,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.314138,
+  "f14_mean_pairwise_jaccard": 0.037037,
+  "fit_seconds": 4.579,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:22Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V1_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 103,
+  "mean_doc_length": 377.5838,
+  "f2_c_v": 0.909481,
+  "f14_mean_pairwise_jaccard": 0.125559,
+  "fit_seconds": 4.883,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:22Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V2_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 8,
+  "mean_doc_length": 103.0,
+  "f2_c_v": 0.432289,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 5.014,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:27Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V3_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 824,
+  "mean_doc_length": 103.0,
+  "f2_c_v": 0.967434,
+  "f14_mean_pairwise_jaccard": 0.043066,
+  "fit_seconds": 5.878,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:33Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V4_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 103,
+  "mean_doc_length": 362.1662,
+  "f2_c_v": 0.619658,
+  "f14_mean_pairwise_jaccard": 0.197249,
+  "fit_seconds": 4.828,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:38Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V5_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 103,
+  "mean_doc_length": 332.3722,
+  "f2_c_v": 0.403593,
+  "f14_mean_pairwise_jaccard": 0.135674,
+  "fit_seconds": 4.742,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:43Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V6_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 131,
+  "mean_doc_length": 62.1106,
+  "f2_c_v": 0.628499,
+  "f14_mean_pairwise_jaccard": 0.615644,
+  "fit_seconds": 4.714,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:48Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V7_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 1980,
+  "V": 197,
+  "mean_doc_length": 5.9788,
+  "f2_c_v": 0.299579,
+  "f14_mean_pairwise_jaccard": 0.0,
+  "fit_seconds": 4.82,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:52Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V8_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 9,
+  "mean_doc_length": 12.4449,
+  "f2_c_v": 0.205501,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 4.542,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:57Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V9_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 4,
+  "D": 1980,
+  "V": 1728,
+  "mean_doc_length": 1.0,
+  "f2_c_v": 0.711475,
+  "f14_mean_pairwise_jaccard": 0.909091,
+  "fit_seconds": 5.031,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:06:02Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V10_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 1320,
+  "V": 24,
+  "mean_doc_length": 3.0,
+  "f2_c_v": 0.232348,
+  "f14_mean_pairwise_jaccard": 0.878788,
+  "fit_seconds": 3.336,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:08Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V11_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 1320,
+  "V": 32,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.255625,
+  "f14_mean_pairwise_jaccard": 0.037037,
+  "fit_seconds": 3.06,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:11Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V12_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 1632,
+  "mean_doc_length": 204.0,
+  "f2_c_v": 0.850237,
+  "f14_mean_pairwise_jaccard": 0.010916,
+  "fit_seconds": 3.572,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:14Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V13_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 1320,
+  "V": 128,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.216227,
+  "f14_mean_pairwise_jaccard": 0.878788,
+  "fit_seconds": 3.268,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:17Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V1_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 204,
+  "mean_doc_length": 455.9652,
+  "f2_c_v": 0.99979,
+  "f14_mean_pairwise_jaccard": 0.389588,
+  "fit_seconds": 3.292,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:37Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V2_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 8,
+  "mean_doc_length": 204.0,
+  "f2_c_v": 0.353553,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 3.756,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:40Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V3_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 1632,
+  "mean_doc_length": 204.0,
+  "f2_c_v": 0.774286,
+  "f14_mean_pairwise_jaccard": 0.003509,
+  "fit_seconds": 3.739,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:44Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V4_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 204,
+  "mean_doc_length": 646.7341,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.598056,
+  "fit_seconds": 3.452,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:48Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V5_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 204,
+  "mean_doc_length": 636.2242,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.523573,
+  "fit_seconds": 3.318,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:51Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V6_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 230,
+  "mean_doc_length": 47.5614,
+  "f2_c_v": 0.840542,
+  "f14_mean_pairwise_jaccard": 0.854545,
+  "fit_seconds": 3.326,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:54Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V7_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 1320,
+  "V": 116,
+  "mean_doc_length": 6.0,
+  "f2_c_v": 0.162185,
+  "f14_mean_pairwise_jaccard": 0.0,
+  "fit_seconds": 3.257,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:57Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V8_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 6,
+  "mean_doc_length": 11.9485,
+  "f2_c_v": 0.384315,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 3.474,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:01Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V9_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 4,
+  "D": 1320,
+  "V": 112,
+  "mean_doc_length": 1.0,
+  "f2_c_v": 0.751499,
+  "f14_mean_pairwise_jaccard": 0.848485,
+  "fit_seconds": 3.223,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:05:04Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V10_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 3520,
+  "V": 24,
+  "mean_doc_length": 3.0,
+  "f2_c_v": 0.285645,
+  "f14_mean_pairwise_jaccard": 0.767677,
+  "fit_seconds": 9.464,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:06Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V11_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 3520,
+  "V": 32,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.249421,
+  "f14_mean_pairwise_jaccard": 0.037037,
+  "fit_seconds": 8.834,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:15Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V12_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 1632,
+  "mean_doc_length": 204.0,
+  "f2_c_v": 0.696596,
+  "f14_mean_pairwise_jaccard": 0.043318,
+  "fit_seconds": 9.59,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:25Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V13_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 3520,
+  "V": 128,
+  "mean_doc_length": 4.0,
+  "f2_c_v": 0.290378,
+  "f14_mean_pairwise_jaccard": 0.203704,
+  "fit_seconds": 8.582,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:04:33Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V1_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 204,
+  "mean_doc_length": 458.8105,
+  "f2_c_v": 0.368694,
+  "f14_mean_pairwise_jaccard": 0.533941,
+  "fit_seconds": 10.142,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:43Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V2_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 8,
+  "mean_doc_length": 204.0,
+  "f2_c_v": 0.353553,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 9.197,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:02:52Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V3_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 1632,
+  "mean_doc_length": 204.0,
+  "f2_c_v": 0.546688,
+  "f14_mean_pairwise_jaccard": 0.047046,
+  "fit_seconds": 9.71,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:03:02Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V4_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 204,
+  "mean_doc_length": 646.4099,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.496112,
+  "fit_seconds": 8.383,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:03:11Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V5_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 204,
+  "mean_doc_length": 632.6886,
+  "f2_c_v": 0.316228,
+  "f14_mean_pairwise_jaccard": 0.456352,
+  "fit_seconds": 8.811,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:03:19Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V6_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 230,
+  "mean_doc_length": 48.1972,
+  "f2_c_v": 0.33362,
+  "f14_mean_pairwise_jaccard": 0.664008,
+  "fit_seconds": 9.036,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:03:29Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V7_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 3,
+  "D": 3520,
+  "V": 132,
+  "mean_doc_length": 6.0,
+  "f2_c_v": 0.187849,
+  "f14_mean_pairwise_jaccard": 0.017544,
+  "fit_seconds": 9.303,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:03:38Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V8_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 12,
+  "mean_doc_length": 12.1045,
+  "f2_c_v": 0.236456,
+  "f14_mean_pairwise_jaccard": 0.781451,
+  "fit_seconds": 9.02,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:03:47Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V9_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 4,
+  "D": 3520,
+  "V": 552,
+  "mean_doc_length": 1.0,
+  "f2_c_v": 0.733957,
+  "f14_mean_pairwise_jaccard": 0.767677,
+  "fit_seconds": 9.724,
+  "status": "ok",
+  "generated_at": "2026-05-27T13:03:57Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}


### PR DESCRIPTION
ETM picks V12 (like LDA). HDP picks V7. ProdLDA picks V3. The factorial #617 now has 4 of 5 backbones.