### PR TITLE
c385: frontend perf — duplicate query keys + Scatter3D useEffect (#592)

### DIFF
--- a/frontend/src/components/plots/Scatter3D.tsx
+++ b/frontend/src/components/plots/Scatter3D.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Canvas, type ThreeEvent } from "@react-three/fiber";
 import { OrbitControls, GizmoHelper, GizmoViewport } from "@react-three/drei";
 import * as THREE from "three";
@@ -99,7 +99,11 @@ function PointCloud({
 
   // Apply per-instance matrix + color
   const dummy = useMemo(() => new THREE.Object3D(), []);
-  useMemo(() => {
+  // Audit fix (#592): this block was a useMemo-as-effect anti-pattern
+  // (computed nothing, only side-effected the THREE mesh state).
+  // Converting to useEffect so React schedules it correctly after
+  // render commit rather than during render.
+  useEffect(() => {
     if (!meshRef.current) return;
     points.forEach((p, i) => {
       dummy.position.set(

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -824,10 +824,18 @@ function ExploreStep({
     enabled: isLabelled && tab === "topics",
   });
 
+  // Audit fix (#592): topic-to-data was being fetched under three
+  // distinct query keys (topic-to-data, raster-meta, embed3d). Each
+  // tab switch triggered a refetch even though the payload is
+  // identical. Now a single query is enabled whenever any of the
+  // three consuming tabs is active, and rasterMeta / embed3d alias
+  // it — TanStack Query de-duplicates the network call to one.
   const topicToData = useQuery({
     queryKey: ["topic-to-data", subsetId],
     queryFn: () => api.topicToData(subsetId!),
-    enabled: isLabelled && tab === "topiclabel",
+    enabled:
+      isLabelled &&
+      (tab === "topiclabel" || tab === "raster" || tab === "embed3d"),
   });
 
   const routed = useQuery({
@@ -836,17 +844,10 @@ function ExploreStep({
     enabled: isLabelled && tab === "routed",
   });
 
-  const rasterMeta = useQuery({
-    queryKey: ["raster-meta", subsetId],
-    queryFn: () => api.topicToData(subsetId!),
-    enabled: isLabelled && tab === "raster",
-  });
-
-  const embed3d = useQuery({
-    queryKey: ["embed3d", subsetId],
-    queryFn: () => api.topicToData(subsetId!),
-    enabled: isLabelled && tab === "embed3d",
-  });
+  // rasterMeta and embed3d reuse topicToData under the same query
+  // key; no separate fetch is issued.
+  const rasterMeta = topicToData;
+  const embed3d = topicToData;
 
   const browserMeta = useQuery({
     queryKey: ["browser-meta", subsetId],
@@ -890,8 +891,12 @@ function ExploreStep({
     queryFn: () => api.endmemberBaseline(subsetId!),
     enabled: isLabelled && tab === "unmixing",
   });
+  // Audit fix (#592): the unmixing tab was issuing a separate eda
+  // query under key ["eda", subsetId, "for-endmember"] when it could
+  // share the canonical eda query above. TanStack de-duplicates if
+  // we keep the same key.
   const endmemberEda = useQuery({
-    queryKey: ["eda", subsetId, "for-endmember"],
+    queryKey: ["eda", subsetId],
     queryFn: () => api.edaPerScene(subsetId!),
     enabled: isLabelled && tab === "unmixing",
   });


### PR DESCRIPTION
Tier-1 fixes from #592.