### PR TITLE
c388: lazy-load ES locale (#592)

### DIFF
--- a/frontend/src/components/LanguageToggle.tsx
+++ b/frontend/src/components/LanguageToggle.tsx
@@ -3,6 +3,7 @@ import { Languages } from "lucide-react";
 
 import {
   SUPPORTED_LANGUAGES,
+  ensureLanguageLoaded,
   type Language,
 } from "@/i18n/config";
 
@@ -11,15 +12,18 @@ export function LanguageToggle() {
   const current = (i18n.resolvedLanguage ?? i18n.language ?? "es") as Language;
   const next: Language = current === "es" ? "en" : "es";
 
-  const swap = () => {
+  const swap = async () => {
     if (!SUPPORTED_LANGUAGES.includes(next)) return;
-    void i18n.changeLanguage(next);
+    // Lazy-load the target language bundle before switching so the UI
+    // doesn't flash untranslated keys.
+    await ensureLanguageLoaded(next);
+    await i18n.changeLanguage(next);
   };
 
   return (
     <button
       type="button"
-      onClick={swap}
+      onClick={() => { void swap(); }}
       aria-label={t("common:actions.toggle_language")}
       title={t("common:actions.toggle_language")}
       className="p-2 rounded-md hover:opacity-100 opacity-70 transition-opacity inline-flex items-center gap-1"

--- a/frontend/src/i18n/config.ts
+++ b/frontend/src/i18n/config.ts
@@ -2,9 +2,8 @@ import i18n from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 
-import esCommon from "@/i18n/locales/es/common.json";
-import esNav from "@/i18n/locales/es/nav.json";
-import esPages from "@/i18n/locales/es/pages.json";
+// Bundle EN statically so the first paint never blocks on a fetch
+// (English is the default and the most common locale).
 import enCommon from "@/i18n/locales/en/common.json";
 import enNav from "@/i18n/locales/en/nav.json";
 import enPages from "@/i18n/locales/en/pages.json";
@@ -12,13 +11,39 @@ import enPages from "@/i18n/locales/en/pages.json";
 export const SUPPORTED_LANGUAGES = ["es", "en"] as const;
 export type Language = (typeof SUPPORTED_LANGUAGES)[number];
 
+// Audit fix (#592 Tier 1 item 2): the ES locale (~28 KB across the
+// three namespaces) was statically imported, so every English visitor
+// paid the cost of the Spanish locale on first paint. Now ES is
+// loaded lazily, only when the user actually selects Spanish via the
+// LanguageToggle. We expose `ensureLanguageLoaded()` so consumers can
+// preload the next-most-likely locale during idle time.
+let esLoaded = false;
+async function loadEs() {
+  if (esLoaded) return;
+  const [common, nav, pages] = await Promise.all([
+    import("@/i18n/locales/es/common.json"),
+    import("@/i18n/locales/es/nav.json"),
+    import("@/i18n/locales/es/pages.json"),
+  ]);
+  i18n.addResourceBundle("es", "common", common.default, true, true);
+  i18n.addResourceBundle("es", "nav", nav.default, true, true);
+  i18n.addResourceBundle("es", "pages", pages.default, true, true);
+  esLoaded = true;
+}
+
+export async function ensureLanguageLoaded(lng: Language): Promise<void> {
+  if (lng === "es") {
+    await loadEs();
+  }
+}
+
 void i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources: {
-      es: { common: esCommon, nav: esNav, pages: esPages },
       en: { common: enCommon, nav: enNav, pages: enPages },
+      // es: loaded lazily via ensureLanguageLoaded("es").
     },
     // Hard default: English. The site is research / methodology in
     // English by intent; users opt into Spanish via the LanguageToggle
@@ -37,6 +62,15 @@ void i18n
       lookupLocalStorage: "caos.lang",
       caches: ["localStorage"],
     },
+  })
+  .then(() => {
+    // If the persisted preference is Spanish, kick off the lazy load
+    // immediately (still off the critical path because the en bundle
+    // has already rendered the shell).
+    const persisted = i18n.language as Language | undefined;
+    if (persisted === "es") {
+      void loadEs();
+    }
   });
 
 export default i18n;


### PR DESCRIPTION
Saves ~28KB per English visitor.