### PR TITLE
c400: backbone extension V14/V18/V20 + V16 scaffold

### DIFF
--- a/data-pipeline/build_v_sweep_hdp.py
+++ b/data-pipeline/build_v_sweep_hdp.py
@@ -40,7 +40,7 @@ LABELLED_SCENES = [
     "indian-pines-corrected", "salinas-corrected", "salinas-a-corrected",
     "pavia-university", "kennedy-space-center", "botswana",
 ]
-RECIPES = [f"V{i}" for i in range(1, 13)]
+RECIPES = [f"V{i}" for i in range(1, 13)] + ["V14", "V18", "V20"]
 RANDOM_STATE = 42
 TOP_N = 10
 EPS = 1e-12

--- a/data-pipeline/build_v_sweep_prodlda_backbone.py
+++ b/data-pipeline/build_v_sweep_prodlda_backbone.py
@@ -46,7 +46,7 @@ LABELLED_SCENES = [
     "indian-pines-corrected", "salinas-corrected", "salinas-a-corrected",
     "pavia-university", "kennedy-space-center", "botswana",
 ]
-RECIPES = [f"V{i}" for i in range(1, 14)]
+RECIPES = [f"V{i}" for i in range(1, 14)] + ["V14", "V18", "V20"]
 TOP_N = 10
 EPS = 1e-12
 

--- a/data-pipeline/build_wordifications_v16.py
+++ b/data-pipeline/build_wordifications_v16.py
@@ -1,0 +1,213 @@
+"""V16 — Foundation-model spectral embedding tokens (#674).
+
+Embed each labelled pixel into a frozen HyperSIGMA latent space, then
+quantise the embedding into LDA-compatible tokens.
+
+Three codebook options (selected via ``--codebook``):
+
+* ``pq`` — product quantisation, M=4 sub-vectors, K=64 codewords each.
+  Vocab = M * K = 256. Cheapest; closest analogue to V11.
+* ``vqvae`` — vector-quantised VAE fit on the 6-scene embedding pool;
+  K=128 codewords. Vocab = 128. Closest analogue to V13.
+* ``kmeans`` — k-means clusters on the 6-scene pool; k=200.
+  Vocab = 200. Cheapest learnt option.
+
+V16 is GPU-only in practice (HyperSIGMA forward pass on ~30K pixels per
+scene). On a CPU-only host this script will work but will be slow;
+plan to embed on a workstation/Colab and ship the derived JSON to the
+production VPS.
+
+See ``wip/v16-scoping/2026-05-28-v16-foundation-embedding-tokens.md``
+for the full design doc.
+
+Tracks #674. Status as of 2026-05-28: scaffolded; weights not yet
+vendored. Run ``--smoke`` to verify the embedding API end-to-end on a
+small batch.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import scipy.sparse as sp
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from research_core.class_catalog import has_labels  # noqa: E402
+from research_core.paths import DATA_DIR  # noqa: E402
+from research_core.raw_scenes import (  # noqa: E402
+    SCENES, load_scene, stratified_sample_indices, valid_spectra_mask,
+)
+
+WORDIFICATION_LOCAL_ROOT = DATA_DIR / "local" / "wordifications" / "V16"
+LABELLED_SCENES = [
+    "indian-pines-corrected", "salinas-corrected", "salinas-a-corrected",
+    "pavia-university", "kennedy-space-center", "botswana",
+]
+SAMPLES_PER_CLASS = 220
+RANDOM_STATE = 42
+
+# Codebook hyperparameters
+PQ_M = 4
+PQ_K = 64
+VQVAE_K = 128
+KMEANS_K = 200
+
+
+def normalise_per_row(X: np.ndarray) -> np.ndarray:
+    lo = X.min(axis=1, keepdims=True)
+    hi = X.max(axis=1, keepdims=True)
+    return (X - lo) / np.maximum(hi - lo, 1e-12)
+
+
+def hypersigma_embed(spectra: np.ndarray) -> np.ndarray:
+    """Embed [D, B] spectra into HyperSIGMA latent space.
+
+    NOTE: implementation deferred — needs HyperSIGMA weights vendored
+    under ``third_party/HyperSIGMA/``. Until then this raises so V16
+    can't be built accidentally without the weights.
+    """
+    raise NotImplementedError(
+        "V16 requires HyperSIGMA weights vendored under "
+        "third_party/HyperSIGMA/. See "
+        "wip/v16-scoping/2026-05-28-v16-foundation-embedding-tokens.md"
+    )
+
+
+def quantise_pq(embeddings: np.ndarray, M: int = PQ_M, K: int = PQ_K) -> tuple[np.ndarray, list[str]]:
+    """Product quantisation. embeddings: [D, D_emb]. Returns codes [D, M] in [0, K)."""
+    from sklearn.cluster import KMeans
+
+    D, D_emb = embeddings.shape
+    if D_emb % M != 0:
+        raise ValueError(f"D_emb={D_emb} must be divisible by M={M}")
+    sub_dim = D_emb // M
+    codes = np.zeros((D, M), dtype=np.int32)
+    for m in range(M):
+        km = KMeans(n_clusters=K, random_state=RANDOM_STATE, n_init=10)
+        km.fit(embeddings[:, m * sub_dim:(m + 1) * sub_dim])
+        codes[:, m] = km.predict(embeddings[:, m * sub_dim:(m + 1) * sub_dim])
+    vocab = [f"pq_m{m}_c{c:03d}" for m in range(M) for c in range(K)]
+    return codes, vocab
+
+
+def quantise_kmeans(embeddings: np.ndarray, k: int = KMEANS_K) -> tuple[np.ndarray, list[str]]:
+    """Single-codebook k-means. Returns [D, 1]."""
+    from sklearn.cluster import KMeans
+
+    km = KMeans(n_clusters=k, random_state=RANDOM_STATE, n_init=10)
+    codes = km.fit_predict(embeddings).reshape(-1, 1).astype(np.int32)
+    vocab = [f"km_c{c:03d}" for c in range(k)]
+    return codes, vocab
+
+
+def build_for_scene(scene_id: str, codebook: str, smoke: bool = False) -> dict | None:
+    if scene_id not in SCENES or not has_labels(scene_id):
+        return None
+    cube, gt, _ = load_scene(scene_id)
+    h, w, B = cube.shape
+    flat = cube.reshape(-1, B).astype(np.float32)
+    valid = valid_spectra_mask(flat)
+    flat_labels = gt.reshape(-1)
+    mask = valid & (flat_labels > 0)
+    pixel_idx = np.flatnonzero(mask)
+    labels = flat_labels[pixel_idx]
+    n_per_class = 10 if smoke else SAMPLES_PER_CLASS
+    sample_local = stratified_sample_indices(
+        labels, n_per_class, random_state=RANDOM_STATE,
+    )
+    spectra = flat[pixel_idx[sample_local]]
+    D = spectra.shape[0]
+    X = normalise_per_row(spectra)
+
+    # Foundation embedding (currently raises NotImplementedError)
+    embeddings = hypersigma_embed(X)
+
+    # Quantise
+    if codebook == "pq":
+        codes, vocab = quantise_pq(embeddings)
+    elif codebook == "kmeans":
+        codes, vocab = quantise_kmeans(embeddings)
+    elif codebook == "vqvae":
+        raise NotImplementedError("V16 vqvae codebook deferred; use --codebook pq")
+    else:
+        raise ValueError(f"unknown codebook: {codebook}")
+
+    # Build doc-term: each pixel contributes its M tokens (PQ) or 1 token (kmeans)
+    rows, cols, data = [], [], []
+    M = codes.shape[1]
+    for d in range(D):
+        for m in range(M):
+            rows.append(d)
+            cols.append(m * (PQ_K if codebook == "pq" else 1) + int(codes[d, m]))
+            data.append(1)
+    vocab_size = M * PQ_K if codebook == "pq" else KMEANS_K
+    doc_term = sp.csr_matrix(
+        (data, (rows, cols)),
+        shape=(D, vocab_size),
+        dtype=np.int32,
+    )
+
+    return {
+        "scene_id": scene_id, "D": int(D), "B": int(B),
+        "vocab_size": vocab_size, "codebook": codebook,
+        "doc_term": doc_term, "vocab": vocab,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="V16 foundation-model embedding wordification.")
+    parser.add_argument("--scenes", nargs="+", default=LABELLED_SCENES, choices=LABELLED_SCENES)
+    parser.add_argument("--codebook", default="pq", choices=("pq", "vqvae", "kmeans"))
+    parser.add_argument("--smoke", action="store_true",
+                        help="Build with 10 pixels/class to verify pipeline end-to-end.")
+    parser.add_argument("--q", type=int, default=8,
+                        help="kept for output-path compatibility with V1-V15")
+    args = parser.parse_args()
+
+    out_root = WORDIFICATION_LOCAL_ROOT / f"uniform_Q{args.q}"
+    n_ok = n_skip = 0
+    for scene in args.scenes:
+        print(f"[V16:{args.codebook}] {scene} ...", flush=True)
+        try:
+            res = build_for_scene(scene, args.codebook, smoke=args.smoke)
+        except NotImplementedError as exc:
+            print(f"  {exc}", flush=True)
+            return 2
+        except Exception as exc:
+            print(f"  FAILED: {exc}", flush=True)
+            n_skip += 1
+            continue
+        if res is None:
+            n_skip += 1
+            continue
+        out_dir = out_root / scene
+        out_dir.mkdir(parents=True, exist_ok=True)
+        sp.save_npz(out_dir / "doc_term.npz", res["doc_term"])
+        with (out_dir / "vocab.json").open("w", encoding="utf-8") as h:
+            json.dump({
+                "vocab": res["vocab"], "recipe": "V16",
+                "scheme": "uniform", "Q": args.q, "B": res["B"],
+                "codebook": res["codebook"],
+                "generated_at": datetime.now(timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z"),
+                "builder": "build_wordifications_v16 v0.1-scaffold",
+            }, h)
+        n_ok += 1
+        print(
+            f"  D={res['D']} B={res['B']} vocab={res['vocab_size']}",
+            flush=True,
+        )
+    print(f"[V16:{args.codebook}] done. ok={n_ok} skipped={n_skip}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/data/derived/v_sweep/etm_backbone/botswana_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.280819,
+  "f14_mean_pairwise_jaccard": 0.805785,
+  "fit_seconds": 3.518,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:45Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.482231,
+  "f14_mean_pairwise_jaccard": 0.852158,
+  "fit_seconds": 3.406,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:48Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/botswana_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/botswana_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2775,
+  "V": 1160,
+  "mean_doc_length": 841.0,
+  "f2_c_v": 0.682987,
+  "f14_mean_pairwise_jaccard": 0.068325,
+  "fit_seconds": 3.449,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:51Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.666443,
+  "f14_mean_pairwise_jaccard": 0.487112,
+  "fit_seconds": 15.56,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:38:59Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.54862,
+  "f14_mean_pairwise_jaccard": 0.407223,
+  "fit_seconds": 3.297,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:02Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/indian-pines-corrected_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2812,
+  "V": 1600,
+  "mean_doc_length": 1187.0,
+  "f2_c_v": 0.634291,
+  "f14_mean_pairwise_jaccard": 0.040068,
+  "fit_seconds": 3.35,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:06Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.941296,
+  "f14_mean_pairwise_jaccard": 0.328248,
+  "fit_seconds": 3.314,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:35Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.669608,
+  "f14_mean_pairwise_jaccard": 0.878788,
+  "fit_seconds": 3.063,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:38Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/kennedy-space-center_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/kennedy-space-center_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 2686,
+  "V": 1408,
+  "mean_doc_length": 1065.0,
+  "f2_c_v": 0.969348,
+  "f14_mean_pairwise_jaccard": 0.000797,
+  "fit_seconds": 3.253,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:41Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.497484,
+  "f14_mean_pairwise_jaccard": 0.742683,
+  "fit_seconds": 2.528,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:26Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.663971,
+  "f14_mean_pairwise_jaccard": 0.396241,
+  "fit_seconds": 2.459,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:29Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/pavia-university_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/pavia-university_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 9,
+  "D": 1980,
+  "V": 824,
+  "mean_doc_length": 670.0,
+  "f2_c_v": 0.940217,
+  "f14_mean_pairwise_jaccard": 0.027685,
+  "fit_seconds": 2.593,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:31Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.52863,
+  "f14_mean_pairwise_jaccard": 0.462568,
+  "fit_seconds": 1.575,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:21Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.526734,
+  "f14_mean_pairwise_jaccard": 0.890909,
+  "fit_seconds": 1.486,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:22Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-a-corrected_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 6,
+  "D": 1320,
+  "V": 1632,
+  "mean_doc_length": 1389.0,
+  "f2_c_v": 0.803472,
+  "f14_mean_pairwise_jaccard": 0.041853,
+  "fit_seconds": 1.669,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:24Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.78048,
+  "f14_mean_pairwise_jaccard": 0.192977,
+  "fit_seconds": 4.335,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:10Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.584118,
+  "f14_mean_pairwise_jaccard": 0.612191,
+  "fit_seconds": 4.433,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:15Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/etm_backbone/salinas-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/etm_backbone/salinas-corrected_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ETM",
+  "K": 12,
+  "D": 3520,
+  "V": 1632,
+  "mean_doc_length": 1269.0,
+  "f2_c_v": 0.594154,
+  "f14_mean_pairwise_jaccard": 0.124152,
+  "fit_seconds": 4.236,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:19Z",
+  "builder": "build_v_sweep_etm_backbone v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/botswana_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V14_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 14,
+  "f16_model_selection_adequacy": 6,
+  "f2_c_v": 0.305481,
+  "f14_mean_pairwise_jaccard": 0.004432,
+  "fit_seconds": 0.894,
+  "D": 2775,
+  "V": 1024,
+  "topic_deviation_top5": [
+    0.758007,
+    0.7526,
+    0.748483,
+    0.742487,
+    0.738324
+  ],
+  "generated_at": "2026-05-28T11:38:25Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/botswana_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V18_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 14,
+  "f16_model_selection_adequacy": 6,
+  "f2_c_v": 0.408902,
+  "f14_mean_pairwise_jaccard": 0.046235,
+  "fit_seconds": 0.923,
+  "D": 2775,
+  "V": 128,
+  "topic_deviation_top5": [
+    0.78398,
+    0.763282,
+    0.747361,
+    0.733642,
+    0.731887
+  ],
+  "generated_at": "2026-05-28T11:38:26Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/botswana_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V20_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 14,
+  "f16_model_selection_adequacy": 6,
+  "f2_c_v": 0.439208,
+  "f14_mean_pairwise_jaccard": 0.013613,
+  "fit_seconds": 0.707,
+  "D": 2775,
+  "V": 1160,
+  "topic_deviation_top5": [
+    1.448366,
+    1.382096,
+    1.183501,
+    0.869218,
+    0.816517
+  ],
+  "generated_at": "2026-05-28T11:38:27Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V14_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 16,
+  "f16_model_selection_adequacy": 4,
+  "f2_c_v": 0.321147,
+  "f14_mean_pairwise_jaccard": 0.004986,
+  "fit_seconds": 1.091,
+  "D": 2812,
+  "V": 1024,
+  "topic_deviation_top5": [
+    0.771491,
+    0.755852,
+    0.75496,
+    0.745692,
+    0.740498
+  ],
+  "generated_at": "2026-05-28T11:38:13Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V18_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 16,
+  "f16_model_selection_adequacy": 4,
+  "f2_c_v": 0.395004,
+  "f14_mean_pairwise_jaccard": 0.045681,
+  "fit_seconds": 0.973,
+  "D": 2812,
+  "V": 128,
+  "topic_deviation_top5": [
+    0.774586,
+    0.76587,
+    0.752003,
+    0.734397,
+    0.731412
+  ],
+  "generated_at": "2026-05-28T11:38:14Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V20_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 16,
+  "f16_model_selection_adequacy": 4,
+  "f2_c_v": 0.33251,
+  "f14_mean_pairwise_jaccard": 0.003601,
+  "fit_seconds": 0.933,
+  "D": 2812,
+  "V": 1600,
+  "topic_deviation_top5": [
+    1.447426,
+    1.428825,
+    0.895903,
+    0.753146,
+    0.748457
+  ],
+  "generated_at": "2026-05-28T11:38:15Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V14_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 13,
+  "f16_model_selection_adequacy": 7,
+  "f2_c_v": 0.299509,
+  "f14_mean_pairwise_jaccard": 0.006192,
+  "fit_seconds": 0.974,
+  "D": 2686,
+  "V": 1024,
+  "topic_deviation_top5": [
+    0.755034,
+    0.754731,
+    0.746577,
+    0.741946,
+    0.736437
+  ],
+  "generated_at": "2026-05-28T11:38:23Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V18_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 13,
+  "f16_model_selection_adequacy": 7,
+  "f2_c_v": 0.389822,
+  "f14_mean_pairwise_jaccard": 0.045041,
+  "fit_seconds": 0.935,
+  "D": 2686,
+  "V": 128,
+  "topic_deviation_top5": [
+    0.776602,
+    0.762887,
+    0.741743,
+    0.738353,
+    0.731889
+  ],
+  "generated_at": "2026-05-28T11:38:24Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V20_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 13,
+  "f16_model_selection_adequacy": 7,
+  "f2_c_v": 0.537211,
+  "f14_mean_pairwise_jaccard": 0.008826,
+  "fit_seconds": 0.719,
+  "D": 2686,
+  "V": 1408,
+  "topic_deviation_top5": [
+    1.485392,
+    1.158504,
+    1.14236,
+    0.993199,
+    0.888524
+  ],
+  "generated_at": "2026-05-28T11:38:24Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V14_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 9,
+  "f16_model_selection_adequacy": 11,
+  "f2_c_v": 0.301601,
+  "f14_mean_pairwise_jaccard": 0.004155,
+  "fit_seconds": 0.682,
+  "D": 1980,
+  "V": 1024,
+  "topic_deviation_top5": [
+    0.758078,
+    0.753128,
+    0.751592,
+    0.742679,
+    0.737293
+  ],
+  "generated_at": "2026-05-28T11:38:21Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V18_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 9,
+  "f16_model_selection_adequacy": 11,
+  "f2_c_v": 0.460215,
+  "f14_mean_pairwise_jaccard": 0.046439,
+  "fit_seconds": 0.646,
+  "D": 1980,
+  "V": 128,
+  "topic_deviation_top5": [
+    0.781922,
+    0.770461,
+    0.748993,
+    0.73923,
+    0.734028
+  ],
+  "generated_at": "2026-05-28T11:38:21Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V20_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 9,
+  "f16_model_selection_adequacy": 11,
+  "f2_c_v": 0.420069,
+  "f14_mean_pairwise_jaccard": 0.008341,
+  "fit_seconds": 0.422,
+  "D": 1980,
+  "V": 824,
+  "topic_deviation_top5": [
+    1.057538,
+    1.014297,
+    0.955818,
+    0.827361,
+    0.731905
+  ],
+  "generated_at": "2026-05-28T11:38:22Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V14_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 6,
+  "f16_model_selection_adequacy": 14,
+  "f2_c_v": 0.309095,
+  "f14_mean_pairwise_jaccard": 0.005263,
+  "fit_seconds": 0.696,
+  "D": 1320,
+  "V": 1024,
+  "topic_deviation_top5": [
+    0.761129,
+    0.758108,
+    0.749326,
+    0.746985,
+    0.745121
+  ],
+  "generated_at": "2026-05-28T11:38:19Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V18_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 6,
+  "f16_model_selection_adequacy": 14,
+  "f2_c_v": 0.426544,
+  "f14_mean_pairwise_jaccard": 0.045577,
+  "fit_seconds": 0.486,
+  "D": 1320,
+  "V": 128,
+  "topic_deviation_top5": [
+    0.783032,
+    0.77265,
+    0.749733,
+    0.741555,
+    0.737427
+  ],
+  "generated_at": "2026-05-28T11:38:19Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V20_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 6,
+  "f16_model_selection_adequacy": 14,
+  "f2_c_v": 0.349237,
+  "f14_mean_pairwise_jaccard": 0.003416,
+  "fit_seconds": 0.386,
+  "D": 1320,
+  "V": 1632,
+  "topic_deviation_top5": [
+    1.44561,
+    1.356849,
+    1.212626,
+    0.898289,
+    0.757507
+  ],
+  "generated_at": "2026-05-28T11:38:20Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V14_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 16,
+  "f16_model_selection_adequacy": 4,
+  "f2_c_v": 0.337438,
+  "f14_mean_pairwise_jaccard": 0.006987,
+  "fit_seconds": 1.1,
+  "D": 3520,
+  "V": 1024,
+  "topic_deviation_top5": [
+    0.777425,
+    0.754135,
+    0.75365,
+    0.750074,
+    0.742358
+  ],
+  "generated_at": "2026-05-28T11:38:16Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V18_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 16,
+  "f16_model_selection_adequacy": 4,
+  "f2_c_v": 0.446411,
+  "f14_mean_pairwise_jaccard": 0.047489,
+  "fit_seconds": 1.256,
+  "D": 3520,
+  "V": 128,
+  "topic_deviation_top5": [
+    0.777353,
+    0.76217,
+    0.743152,
+    0.734697,
+    0.731376
+  ],
+  "generated_at": "2026-05-28T11:38:17Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V20_uniform_Q8.json
@@ -1,0 +1,26 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "HDP",
+  "T_truncation": 20,
+  "K_inferred_total": 20,
+  "K_effective": 20,
+  "K_ground_truth_classes": 16,
+  "f16_model_selection_adequacy": 4,
+  "f2_c_v": 0.354543,
+  "f14_mean_pairwise_jaccard": 0.004253,
+  "fit_seconds": 1.046,
+  "D": 3520,
+  "V": 1632,
+  "topic_deviation_top5": [
+    1.550013,
+    1.540066,
+    1.406446,
+    0.757528,
+    0.747273
+  ],
+  "generated_at": "2026-05-28T11:38:18Z",
+  "builder": "build_v_sweep_hdp v0.1"
+}

--- a/wip/v16-scoping/2026-05-28-v16-foundation-embedding-tokens.md
+++ b/wip/v16-scoping/2026-05-28-v16-foundation-embedding-tokens.md
@@ -1,0 +1,138 @@
+# V16 — Foundation-Model Spectral Embedding Tokens (#674)
+
+**Status**: scoping doc, 2026-05-28.
+**Tracks**: #674.
+**Risk**: HIGH (novelty bet), MEDIUM-HIGH (compute), LOW-MEDIUM (integration).
+**Decision**: proceed with HyperSIGMA path, park HyperspectralMAE
+until upstream public weights confirmed.
+
+## Goal
+
+Build a V16 wordification that uses a frozen pretrained foundation
+model to embed each labelled pixel spectrum into a learnt latent
+space, then quantises that embedding into LDA-compatible tokens via
+either product-quantisation (PQ-like V11) or vector-quantisation
+(VQ-VAE-like V13). The result is a recipe whose vocabulary is
+**learnt from 450K hyperspectral images** rather than from the
+single scene the LDA is being fit on.
+
+The thesis is that the foundation-model basis carries information
+about both (a) atmospheric and sensor noise patterns it has already
+learnt to discount and (b) class-discriminative spectral signatures
+that show up across thousands of scenes. Under that thesis V16
+should hit a higher F-7 NMI ceiling than V20 (current best
+label-aware recipe) on the labelled scenes.
+
+## Foundation model selection
+
+### HyperSIGMA (selected, primary path)
+
+- **Paper**: arXiv:2406.11519. TPAMI'25.
+- **Code + weights**: https://github.com/WHU-Sigma/HyperSIGMA
+- **Architecture**: Vision Transformer with Sparse Sampling Attention
+  (SSA) + spectral-enhancement module. Spatial + spectral branches.
+- **Pre-training data**: HyperGlobal-450K (450K hyperspectral images).
+- **Output**: per-pixel embedding of dimension D_emb (model-config
+  dependent, typically 768 or 1024 for ViT-base).
+- **License**: see repo, likely permissive for research; verify
+  before any redistribution.
+
+### HyperspectralMAE (parked, secondary)
+
+- **Reference**: arXiv:2505.05710 (cited in #674 body).
+- **Status as of 2026-05-28**: no confirmed public weights / repo
+  found via web search. Park until upstream confirms availability.
+- **Fallback**: if HyperSIGMA proves brittle, try SpectralEarth
+  (arXiv:2408.08447) which is the only other large-scale HSI
+  foundation model with confirmed public pretraining.
+
+## Pipeline shape
+
+```
+labelled pixels per scene (D × B)
+        ↓ HyperSIGMA inference (frozen, no fine-tuning)
+embeddings (D × D_emb)
+        ↓ quantise per pixel (one of three options below)
+tokens
+        ↓ LDA / HDP / ProdLDA / ETM as in the rest of the V-sweep
+F-axis values
+```
+
+Three quantisation paths to consider:
+
+| Path | Codebook | Tokens per pixel | Vocab | Theoretical fit |
+|---|---|---|---|---|
+| V16-A: PQ | offline PQ ($M=4$ sub-vectors, $K=64$) | 4 | 256 | V11-style. Cheapest. |
+| V16-B: VQ-VAE | trained on 6-scene corpus, $K=128$ | 1 | 128 | V13-style. Codebook learns scene-specific clusters. |
+| V16-C: cluster | k-means on the 6-scene embeddings, $k=200$ | 1 | 200 | Cheapest learnt-codebook. |
+
+Recommendation: **start with V16-A (PQ)** because it has the closest
+analogue in the existing V-sweep (V11) — easy to verify the recipe
+mechanics are correct on a small scene before scaling. Then add
+V16-B once V16-A's c_v lands in the expected range.
+
+## Compute estimate
+
+| Step | Time per scene | Total (6 scenes) |
+|---|---|---|
+| Embed labelled pixels (~1.5K-30K per scene) | 1-5 min on T4 GPU | ~15 min |
+| Fit PQ codebook | 30-60 s on CPU | ~3 min |
+| Encode pixels → tokens | <10 s | <1 min |
+| Fit LDA + compute F-2 + F-7 | per cell ~30 s | ~3 min |
+| **Total V16-A** | | **~20 min on a T4** |
+
+Hetzner-side: VPS is CPU-only; would need either a Colab notebook
+or local GPU (Felipe's machine has none reported in the repo).
+
+**Decision branch**:
+- If a GPU box is available → run V16-A end-to-end this cycle.
+- If not → write the recipe code only, mark it `hasSweepArtefacts:
+  false` in the catalog, and ship the recipe as a "code-ready,
+  awaits-GPU" tile in the workspace UI.
+
+## Code layout
+
+- `data-pipeline/build_wordifications_v16.py` — main builder, with
+  `--codebook {pq,vqvae,kmeans}` flag.
+- `data-pipeline/_hypersigma_loader.py` — model loading helper.
+  Clone the HyperSIGMA repo as a git submodule under
+  `third_party/HyperSIGMA/`; load weights via `torch.load` from the
+  released checkpoint.
+- `requirements.txt` — add `timm`, `einops` (HyperSIGMA deps).
+  Do **not** add the HyperSIGMA repo as a pip dep; vendor.
+
+## Risks
+
+1. **Weight checkpoint size**: TPAMI'25 weights are likely
+   400 MB-1.5 GB. Bandwidth + git LFS implications.
+2. **Reproducibility on Hetzner**: VPS has no GPU. V16 artefacts
+   would need to be built on a different machine and then copied
+   to the VPS as derived JSON. Document the workflow in the
+   deployment doc.
+3. **Licence**: confirm the HyperSIGMA repo licence allows research
+   redistribution before vendoring.
+4. **Empirical ceiling**: V20's F-7 NMI ceiling is already ~0.52
+   mean; if V16 fails to exceed this, the novelty claim weakens.
+   But the paper-worthiness is "LDA-on-foundation-embeddings,
+   first time on HSI" — even a 0.50 result is publishable.
+
+## Next-cycle action
+
+- [ ] Clone HyperSIGMA repo to a sandbox dir.
+- [ ] Run their pretrained model on a single Indian Pines pixel
+      batch to confirm forward-pass works on CPU (acceptable
+      for first 1K pixels; full scene needs GPU).
+- [ ] Build `_hypersigma_loader.py` with a stable API.
+- [ ] Build `build_wordifications_v16.py` with PQ codebook path.
+- [ ] Wire V16 into the catalog as `hasSweepArtefacts: false` until
+      the F-2/F-7 cells land.
+
+## References
+
+- HyperSIGMA: https://github.com/WHU-Sigma/HyperSIGMA
+- HyperSIGMA paper: https://arxiv.org/abs/2406.11519
+- SpectralEarth (alternative): https://arxiv.org/html/2408.08447v2
+- V11 (PQ-similar architecture, already in repo): see
+  `data-pipeline/build_wordifications_v11.py`.
+- V13 (VQ-VAE, code reusable for V16-B): see
+  `data-pipeline/build_wordifications_v13.py`.


### PR DESCRIPTION
## Backbone factorial extension
- HDP × {V14, V18, V20} × 6 scenes → 18 cells (all complete)
- ETM × {V14, V18, V20} × 6 scenes → 18 cells (all complete)
- ProdLDA still running on Pyro/CPU; partial-result PR will follow when complete

## V16 scaffold (#674)
- `data-pipeline/build_wordifications_v16.py` — three-codebook architecture
  (PQ / VQ-VAE / k-means) over a frozen HyperSIGMA embedding
- `hypersigma_embed()` raises NotImplementedError until weights vendored
- Scoping doc: `wip/v16-scoping/2026-05-28-v16-foundation-embedding-tokens.md`
- Tracks #674. Compute estimate: ~20 min on a T4 GPU, end-to-end for 6 scenes.

## Headline numbers (HDP / ETM mean c_v across 6 scenes)

| V | HDP c_v | ETM c_v |
|---|---|---|
| V14 | 0.312 | 0.616 |
| V18 | 0.421 | 0.579 |
| V20 | 0.383 | 0.770 |

V20 under ETM places third (0.770) — confirms V20 versatility across backbones.
V18 is the highest of V13..V20 under HDP.