### PR TITLE
c401: ProdLDA backbone × V14/V18/V20 cells

### DIFF
--- a/data/derived/v_sweep/prodlda_backbone/botswana_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/botswana_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2775,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.231292,
+  "f14_mean_pairwise_jaccard": 0.865014,
+  "fit_seconds": 10.339,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:41:39Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/botswana_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/botswana_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2775,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.453123,
+  "f14_mean_pairwise_jaccard": 0.969697,
+  "fit_seconds": 10.171,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:41:49Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/botswana_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/botswana_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2775,
+  "V": 1160,
+  "mean_doc_length": 841.0,
+  "f2_c_v": 0.685584,
+  "f14_mean_pairwise_jaccard": 0.438501,
+  "fit_seconds": 9.977,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:41:59Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/indian-pines-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/indian-pines-corrected_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2812,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.542008,
+  "f14_mean_pairwise_jaccard": 0.837819,
+  "fit_seconds": 24.435,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:10Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/indian-pines-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/indian-pines-corrected_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2812,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.286442,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 13.95,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:24Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/indian-pines-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/indian-pines-corrected_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2812,
+  "V": 1600,
+  "mean_doc_length": 1187.0,
+  "f2_c_v": 0.404559,
+  "f14_mean_pairwise_jaccard": 0.552861,
+  "fit_seconds": 13.652,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:37Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/kennedy-space-center_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/kennedy-space-center_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2686,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.926789,
+  "f14_mean_pairwise_jaccard": 0.781804,
+  "fit_seconds": 9.549,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:41:08Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/kennedy-space-center_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/kennedy-space-center_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2686,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.66188,
+  "f14_mean_pairwise_jaccard": 0.92011,
+  "fit_seconds": 9.899,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:41:18Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/kennedy-space-center_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/kennedy-space-center_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 2686,
+  "V": 1408,
+  "mean_doc_length": 1065.0,
+  "f2_c_v": 0.906574,
+  "f14_mean_pairwise_jaccard": 0.192149,
+  "fit_seconds": 9.911,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:41:28Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/pavia-university_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/pavia-university_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 9,
+  "D": 1980,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.49833,
+  "f14_mean_pairwise_jaccard": 0.616855,
+  "fit_seconds": 7.685,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:44Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/pavia-university_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/pavia-university_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 9,
+  "D": 1980,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.480088,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 7.229,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:52Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/pavia-university_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/pavia-university_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 9,
+  "D": 1980,
+  "V": 824,
+  "mean_doc_length": 670.0,
+  "f2_c_v": 0.82995,
+  "f14_mean_pairwise_jaccard": 0.138787,
+  "fit_seconds": 7.207,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:59Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/salinas-a-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/salinas-a-corrected_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 6,
+  "D": 1320,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.379008,
+  "f14_mean_pairwise_jaccard": 0.439805,
+  "fit_seconds": 5.091,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:26Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/salinas-a-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/salinas-a-corrected_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 6,
+  "D": 1320,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.526809,
+  "f14_mean_pairwise_jaccard": 0.90303,
+  "fit_seconds": 5.616,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:31Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/salinas-a-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/salinas-a-corrected_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 6,
+  "D": 1320,
+  "V": 1632,
+  "mean_doc_length": 1389.0,
+  "f2_c_v": 0.769902,
+  "f14_mean_pairwise_jaccard": 0.107656,
+  "fit_seconds": 5.191,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:37Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/salinas-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/salinas-corrected_V14_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 3520,
+  "V": 1024,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.235298,
+  "f14_mean_pairwise_jaccard": 0.864555,
+  "fit_seconds": 16.873,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:39:54Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/salinas-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/salinas-corrected_V18_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 3520,
+  "V": 128,
+  "mean_doc_length": 16.0,
+  "f2_c_v": 0.471651,
+  "f14_mean_pairwise_jaccard": 1.0,
+  "fit_seconds": 12.968,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:07Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}

--- a/data/derived/v_sweep/prodlda_backbone/salinas-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/prodlda_backbone/salinas-corrected_V20_uniform_Q8.json
@@ -1,0 +1,17 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "backbone": "ProdLDA",
+  "K": 12,
+  "D": 3520,
+  "V": 1632,
+  "mean_doc_length": 1269.0,
+  "f2_c_v": 0.865554,
+  "f14_mean_pairwise_jaccard": 0.569683,
+  "fit_seconds": 13.387,
+  "status": "ok",
+  "generated_at": "2026-05-28T11:40:21Z",
+  "builder": "build_v_sweep_prodlda_backbone v0.1"
+}


### PR DESCRIPTION
Pyro forward-pass complete for V14/V18/V20 × 6 scenes. V20 mean c_v = 0.744 — ranks 4th in ProdLDA, within 0.12 of V3 (0.863).