### PR TITLE
release: c406 — V16 catalog tile surfaced

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -857,6 +857,12 @@
         "summary": "Continuous wavelet transform with Morlet mother on 16 log-scales × 8 position buckets. Top-16 magnitude cells per pixel. Vocab 1024.",
         "theory": "V14 differs from V6 (Db4 DWT level-4) by using *continuous* scales. The Morlet mother gives joint time-frequency localization unlike V6 dyadic scales. F-2 c_v 0.46-0.76 across scenes; competitive with V12 on coherence but distinct on the (scale, position, magnitude) vocabulary."
       },
+      "V16": {
+        "tag": "foundation embedding (scaffold)",
+        "title": "HyperSIGMA foundation-model tokens (V16, scaffold)",
+        "summary": "Frozen HyperSIGMA embedding of each pixel, quantised via PQ / VQ-VAE / k-means. Vocab depends on codebook (PQ: 256, VQ-VAE: 128, k-means: 200).",
+        "theory": "V16 uses the TPAMI'25 HyperSIGMA billion-parameter ViT (pre-trained on HyperGlobal-450K) to embed each pixel, then quantises the embedding into LDA tokens. The thesis: a basis learnt on 450K hyperspectral scenes carries discriminative information V1..V15 cannot. **Status (2026-05-28): scaffolded only; weights not vendored; GPU-only in practice.** Highest novelty bet in the V-extension space."
+      },
       "V17": {
         "tag": "sparse-coding dict",
         "title": "Sparse dictionary tokens (V17)",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -857,6 +857,12 @@
         "summary": "Transformada wavelet continua con Morlet sobre 16 escalas log × 8 buckets de posición. Top-16 celdas de magnitud por píxel. Vocab 1024.",
         "theory": "V14 difiere de V6 (DWT Db4 nivel 4) por usar escalas *continuas*. La función madre Morlet da localización tiempo-frecuencia conjunta a diferencia de las escalas diádicas de V6. F-2 c_v 0.46-0.76; competitivo con V12 en coherencia pero con vocabulario (escala, posición, magnitud) distinto."
       },
+      "V16": {
+        "tag": "embedding foundation (scaffold)",
+        "title": "Tokens foundation-model HyperSIGMA (V16, scaffold)",
+        "summary": "Embedding congelado de HyperSIGMA por píxel, cuantizado vía PQ / VQ-VAE / k-means. Vocab según codebook (PQ: 256, VQ-VAE: 128, k-means: 200).",
+        "theory": "V16 usa el ViT mil-millones-de-parámetros HyperSIGMA (TPAMI'25, pre-entrenado en HyperGlobal-450K) para embebir cada píxel, luego cuantiza el embedding en tokens LDA. Tesis: una base aprendida sobre 450K escenas hiperespectrales lleva información discriminativa que V1..V15 no captan. **Estado (2026-05-28): solo scaffold; pesos no vendorizados; GPU-only en práctica.** Mayor apuesta de novedad de la extensión V."
+      },
       "V17": {
         "tag": "dict sparse-coding",
         "title": "Tokens diccionario sparse (V17)",

--- a/frontend/src/pages/workspace/methodCatalog.ts
+++ b/frontend/src/pages/workspace/methodCatalog.ts
@@ -23,6 +23,7 @@ export const METHOD_CATALOG: MethodEntry[] = [
   { id: "V13", family: "wordification", hasSweepArtefacts: true },
   { id: "V14", family: "wordification", hasSweepArtefacts: true },
   { id: "V15", family: "wordification", hasSweepArtefacts: true },
+  { id: "V16", family: "wordification", hasSweepArtefacts: false },
   { id: "V17", family: "wordification", hasSweepArtefacts: true },
   { id: "V18", family: "wordification", hasSweepArtefacts: true },
   { id: "V19", family: "wordification", hasSweepArtefacts: true },


### PR DESCRIPTION
Workspace shows V16 as a scaffold-only tile.