### PR TITLE
c421: F-13 SHAP V13-V20 cells (F-13 now 100% × 19 recipes)

### DIFF
--- a/data/derived/v_sweep/f13_shap/botswana_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/botswana_V13_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 82,
+          "token": "vq_m2_c18",
+          "mean_abs_shap": 0.087133
+        },
+        {
+          "vocab_index": 49,
+          "token": "vq_m1_c17",
+          "mean_abs_shap": 0.066345
+        },
+        {
+          "vocab_index": 56,
+          "token": "vq_m1_c24",
+          "mean_abs_shap": 0.064274
+        },
+        {
+          "vocab_index": 61,
+          "token": "vq_m1_c29",
+          "mean_abs_shap": 0.038471
+        },
+        {
+          "vocab_index": 41,
+          "token": "vq_m1_c09",
+          "mean_abs_shap": 0.034208
+        },
+        {
+          "vocab_index": 72,
+          "token": "vq_m2_c08",
+          "mean_abs_shap": 0.028937
+        },
+        {
+          "vocab_index": 14,
+          "token": "vq_m0_c14",
+          "mean_abs_shap": 0.028593
+        },
+        {
+          "vocab_index": 29,
+          "token": "vq_m0_c29",
+          "mean_abs_shap": 0.026984
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 29,
+          "token": "vq_m0_c29",
+          "mean_abs_shap": 0.101594
+        },
+        {
+          "vocab_index": 109,
+          "token": "vq_m3_c13",
+          "mean_abs_shap": 0.085888
+        },
+        {
+          "vocab_index": 22,
+          "token": "vq_m0_c22",
+          "mean_abs_shap": 0.053248
+        },
+        {
+          "vocab_index": 0,
+          "token": "vq_m0_c00",
+          "mean_abs_shap": 0.038834
+        },
+        {
+          "vocab_index": 106,
+          "token": "vq_m3_c10",
+          "mean_abs_shap": 0.037875
+        },
+        {
+          "vocab_index": 56,
+          "token": "vq_m1_c24",
+          "mean_abs_shap": 0.031756
+        },
+        {
+          "vocab_index": 13,
+          "token": "vq_m0_c13",
+          "mean_abs_shap": 0.027462
+        },
+        {
+          "vocab_index": 49,
+          "token": "vq_m1_c17",
+          "mean_abs_shap": 0.026935
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 29,
+          "token": "vq_m0_c29",
+          "mean_abs_shap": 0.065348
+        },
+        {
+          "vocab_index": 82,
+          "token": "vq_m2_c18",
+          "mean_abs_shap": 0.064997
+        },
+        {
+          "vocab_index": 109,
+          "token": "vq_m3_c13",
+          "mean_abs_shap": 0.062439
+        },
+        {
+          "vocab_index": 49,
+          "token": "vq_m1_c17",
+          "mean_abs_shap": 0.038688
+        },
+        {
+          "vocab_index": 96,
+          "token": "vq_m3_c00",
+          "mean_abs_shap": 0.035946
+        },
+        {
+          "vocab_index": 22,
+          "token": "vq_m0_c22",
+          "mean_abs_shap": 0.033344
+        },
+        {
+          "vocab_index": 14,
+          "token": "vq_m0_c14",
+          "mean_abs_shap": 0.032737
+        },
+        {
+          "vocab_index": 56,
+          "token": "vq_m1_c24",
+          "mean_abs_shap": 0.028933
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:11Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.71
+}

--- a/data/derived/v_sweep/f13_shap/botswana_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/botswana_V14_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1024,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 772,
+          "token": "cwt_s12_p0_q04",
+          "mean_abs_shap": 0.000873
+        },
+        {
+          "vocab_index": 1019,
+          "token": "cwt_s15_p7_q03",
+          "mean_abs_shap": 0.000813
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.00076
+        },
+        {
+          "vocab_index": 931,
+          "token": "cwt_s14_p4_q03",
+          "mean_abs_shap": 0.000706
+        },
+        {
+          "vocab_index": 787,
+          "token": "cwt_s12_p2_q03",
+          "mean_abs_shap": 0.000649
+        },
+        {
+          "vocab_index": 1003,
+          "token": "cwt_s15_p5_q03",
+          "mean_abs_shap": 0.000513
+        },
+        {
+          "vocab_index": 996,
+          "token": "cwt_s15_p4_q04",
+          "mean_abs_shap": 0.000504
+        },
+        {
+          "vocab_index": 910,
+          "token": "cwt_s14_p1_q06",
+          "mean_abs_shap": 0.000472
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 780,
+          "token": "cwt_s12_p1_q04",
+          "mean_abs_shap": 0.005322
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.004608
+        },
+        {
+          "vocab_index": 578,
+          "token": "cwt_s09_p0_q02",
+          "mean_abs_shap": 0.003778
+        },
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.002906
+        },
+        {
+          "vocab_index": 714,
+          "token": "cwt_s11_p1_q02",
+          "mean_abs_shap": 0.002869
+        },
+        {
+          "vocab_index": 990,
+          "token": "cwt_s15_p3_q06",
+          "mean_abs_shap": 0.001835
+        },
+        {
+          "vocab_index": 1012,
+          "token": "cwt_s15_p6_q04",
+          "mean_abs_shap": 0.00161
+        },
+        {
+          "vocab_index": 1019,
+          "token": "cwt_s15_p7_q03",
+          "mean_abs_shap": 0.001394
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.011276
+        },
+        {
+          "vocab_index": 843,
+          "token": "cwt_s13_p1_q03",
+          "mean_abs_shap": 0.009836
+        },
+        {
+          "vocab_index": 837,
+          "token": "cwt_s13_p0_q05",
+          "mean_abs_shap": 0.009711
+        },
+        {
+          "vocab_index": 579,
+          "token": "cwt_s09_p0_q03",
+          "mean_abs_shap": 0.009172
+        },
+        {
+          "vocab_index": 995,
+          "token": "cwt_s15_p4_q03",
+          "mean_abs_shap": 0.008795
+        },
+        {
+          "vocab_index": 980,
+          "token": "cwt_s15_p2_q04",
+          "mean_abs_shap": 0.008296
+        },
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 0.006676
+        },
+        {
+          "vocab_index": 964,
+          "token": "cwt_s15_p0_q04",
+          "mean_abs_shap": 0.006379
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 964,
+          "token": "cwt_s15_p0_q04",
+          "mean_abs_shap": 2e-06
+        },
+        {
+          "vocab_index": 843,
+          "token": "cwt_s13_p1_q03",
+          "mean_abs_shap": 2e-06
+        },
+        {
+          "vocab_index": 708,
+          "token": "cwt_s11_p0_q04",
+          "mean_abs_shap": 2e-06
+        },
+        {
+          "vocab_index": 922,
+          "token": "cwt_s14_p3_q02",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 715,
+          "token": "cwt_s11_p1_q03",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 1e-06
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 708,
+          "token": "cwt_s11_p0_q04",
+          "mean_abs_shap": 1241306511849.8447
+        },
+        {
+          "vocab_index": 716,
+          "token": "cwt_s11_p1_q04",
+          "mean_abs_shap": 1241306511849.841
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.017314
+        },
+        {
+          "vocab_index": 983,
+          "token": "cwt_s15_p2_q07",
+          "mean_abs_shap": 0.016883
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.014841
+        },
+        {
+          "vocab_index": 787,
+          "token": "cwt_s12_p2_q03",
+          "mean_abs_shap": 0.014473
+        },
+        {
+          "vocab_index": 979,
+          "token": "cwt_s15_p2_q03",
+          "mean_abs_shap": 0.012282
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.011469
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.000336
+        },
+        {
+          "vocab_index": 714,
+          "token": "cwt_s11_p1_q02",
+          "mean_abs_shap": 0.000245
+        },
+        {
+          "vocab_index": 717,
+          "token": "cwt_s11_p1_q05",
+          "mean_abs_shap": 0.000102
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 9.3e-05
+        },
+        {
+          "vocab_index": 975,
+          "token": "cwt_s15_p1_q07",
+          "mean_abs_shap": 7.6e-05
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 5.9e-05
+        },
+        {
+          "vocab_index": 773,
+          "token": "cwt_s12_p0_q05",
+          "mean_abs_shap": 5.6e-05
+        },
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 3.4e-05
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.017061
+        },
+        {
+          "vocab_index": 995,
+          "token": "cwt_s15_p4_q03",
+          "mean_abs_shap": 0.016449
+        },
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 0.012414
+        },
+        {
+          "vocab_index": 710,
+          "token": "cwt_s11_p0_q06",
+          "mean_abs_shap": 0.009272
+        },
+        {
+          "vocab_index": 718,
+          "token": "cwt_s11_p1_q06",
+          "mean_abs_shap": 0.007684
+        },
+        {
+          "vocab_index": 642,
+          "token": "cwt_s10_p0_q02",
+          "mean_abs_shap": 0.005393
+        },
+        {
+          "vocab_index": 781,
+          "token": "cwt_s12_p1_q05",
+          "mean_abs_shap": 0.003846
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.003137
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 578,
+          "token": "cwt_s09_p0_q02",
+          "mean_abs_shap": 0.000211
+        },
+        {
+          "vocab_index": 974,
+          "token": "cwt_s15_p1_q06",
+          "mean_abs_shap": 0.000148
+        },
+        {
+          "vocab_index": 906,
+          "token": "cwt_s14_p1_q02",
+          "mean_abs_shap": 0.000132
+        },
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 0.000123
+        },
+        {
+          "vocab_index": 997,
+          "token": "cwt_s15_p4_q05",
+          "mean_abs_shap": 0.000101
+        },
+        {
+          "vocab_index": 898,
+          "token": "cwt_s14_p0_q02",
+          "mean_abs_shap": 9.3e-05
+        },
+        {
+          "vocab_index": 715,
+          "token": "cwt_s11_p1_q03",
+          "mean_abs_shap": 9.1e-05
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 9e-05
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 578,
+          "token": "cwt_s09_p0_q02",
+          "mean_abs_shap": 0.000473
+        },
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 0.000429
+        },
+        {
+          "vocab_index": 837,
+          "token": "cwt_s13_p0_q05",
+          "mean_abs_shap": 0.00035
+        },
+        {
+          "vocab_index": 974,
+          "token": "cwt_s15_p1_q06",
+          "mean_abs_shap": 0.000346
+        },
+        {
+          "vocab_index": 906,
+          "token": "cwt_s14_p1_q02",
+          "mean_abs_shap": 0.000322
+        },
+        {
+          "vocab_index": 902,
+          "token": "cwt_s14_p0_q06",
+          "mean_abs_shap": 0.000313
+        },
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.000312
+        },
+        {
+          "vocab_index": 579,
+          "token": "cwt_s09_p0_q03",
+          "mean_abs_shap": 0.000291
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.020452
+        },
+        {
+          "vocab_index": 836,
+          "token": "cwt_s13_p0_q04",
+          "mean_abs_shap": 0.014578
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.014093
+        },
+        {
+          "vocab_index": 773,
+          "token": "cwt_s12_p0_q05",
+          "mean_abs_shap": 0.012251
+        },
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 0.011785
+        },
+        {
+          "vocab_index": 995,
+          "token": "cwt_s15_p4_q03",
+          "mean_abs_shap": 0.010266
+        },
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 0.010184
+        },
+        {
+          "vocab_index": 722,
+          "token": "cwt_s11_p2_q02",
+          "mean_abs_shap": 0.009988
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 715,
+          "token": "cwt_s11_p1_q03",
+          "mean_abs_shap": 0.015066
+        },
+        {
+          "vocab_index": 836,
+          "token": "cwt_s13_p0_q04",
+          "mean_abs_shap": 0.014463
+        },
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 0.013073
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.013011
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.012355
+        },
+        {
+          "vocab_index": 924,
+          "token": "cwt_s14_p3_q04",
+          "mean_abs_shap": 0.011838
+        },
+        {
+          "vocab_index": 716,
+          "token": "cwt_s11_p1_q04",
+          "mean_abs_shap": 0.011795
+        },
+        {
+          "vocab_index": 983,
+          "token": "cwt_s15_p2_q07",
+          "mean_abs_shap": 0.011688
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 988,
+          "token": "cwt_s15_p3_q04",
+          "mean_abs_shap": 0.013569
+        },
+        {
+          "vocab_index": 997,
+          "token": "cwt_s15_p4_q05",
+          "mean_abs_shap": 0.012886
+        },
+        {
+          "vocab_index": 996,
+          "token": "cwt_s15_p4_q04",
+          "mean_abs_shap": 0.011416
+        },
+        {
+          "vocab_index": 779,
+          "token": "cwt_s12_p1_q03",
+          "mean_abs_shap": 0.011263
+        },
+        {
+          "vocab_index": 982,
+          "token": "cwt_s15_p2_q06",
+          "mean_abs_shap": 0.010838
+        },
+        {
+          "vocab_index": 716,
+          "token": "cwt_s11_p1_q04",
+          "mean_abs_shap": 0.009437
+        },
+        {
+          "vocab_index": 715,
+          "token": "cwt_s11_p1_q03",
+          "mean_abs_shap": 0.009132
+        },
+        {
+          "vocab_index": 787,
+          "token": "cwt_s12_p2_q03",
+          "mean_abs_shap": 0.008641
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:15Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 3.71
+}

--- a/data/derived/v_sweep/f13_shap/botswana_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/botswana_V15_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 48,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 45,
+          "token": "SAVI_q05",
+          "mean_abs_shap": 0.023732
+        },
+        {
+          "vocab_index": 36,
+          "token": "NDVI_q04",
+          "mean_abs_shap": 0.021108
+        },
+        {
+          "vocab_index": 3,
+          "token": "EVI_q03",
+          "mean_abs_shap": 0.019825
+        },
+        {
+          "vocab_index": 38,
+          "token": "NDVI_q06",
+          "mean_abs_shap": 0.0165
+        },
+        {
+          "vocab_index": 26,
+          "token": "NDSI_q02",
+          "mean_abs_shap": 0.016016
+        },
+        {
+          "vocab_index": 20,
+          "token": "NBR_q04",
+          "mean_abs_shap": 0.011995
+        },
+        {
+          "vocab_index": 10,
+          "token": "MNDWI_q02",
+          "mean_abs_shap": 0.011704
+        },
+        {
+          "vocab_index": 8,
+          "token": "MNDWI_q00",
+          "mean_abs_shap": 0.010907
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 36,
+          "token": "NDVI_q04",
+          "mean_abs_shap": 0.038126
+        },
+        {
+          "vocab_index": 9,
+          "token": "MNDWI_q01",
+          "mean_abs_shap": 0.034577
+        },
+        {
+          "vocab_index": 10,
+          "token": "MNDWI_q02",
+          "mean_abs_shap": 0.031341
+        },
+        {
+          "vocab_index": 26,
+          "token": "NDSI_q02",
+          "mean_abs_shap": 0.030551
+        },
+        {
+          "vocab_index": 20,
+          "token": "NBR_q04",
+          "mean_abs_shap": 0.026167
+        },
+        {
+          "vocab_index": 8,
+          "token": "MNDWI_q00",
+          "mean_abs_shap": 0.025857
+        },
+        {
+          "vocab_index": 25,
+          "token": "NDSI_q01",
+          "mean_abs_shap": 0.024486
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.019484
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 26,
+          "token": "NDSI_q02",
+          "mean_abs_shap": 0.04465
+        },
+        {
+          "vocab_index": 10,
+          "token": "MNDWI_q02",
+          "mean_abs_shap": 0.043046
+        },
+        {
+          "vocab_index": 36,
+          "token": "NDVI_q04",
+          "mean_abs_shap": 0.02269
+        },
+        {
+          "vocab_index": 9,
+          "token": "MNDWI_q01",
+          "mean_abs_shap": 0.021549
+        },
+        {
+          "vocab_index": 8,
+          "token": "MNDWI_q00",
+          "mean_abs_shap": 0.019755
+        },
+        {
+          "vocab_index": 40,
+          "token": "SAVI_q00",
+          "mean_abs_shap": 0.018167
+        },
+        {
+          "vocab_index": 17,
+          "token": "NBR_q01",
+          "mean_abs_shap": 0.015817
+        },
+        {
+          "vocab_index": 34,
+          "token": "NDVI_q02",
+          "mean_abs_shap": 0.014453
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:16Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.6
+}

--- a/data/derived/v_sweep/f13_shap/botswana_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/botswana_V17_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 512,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 120,
+          "token": "atom_a015_q00",
+          "mean_abs_shap": 0.014148
+        },
+        {
+          "vocab_index": 264,
+          "token": "atom_a033_q00",
+          "mean_abs_shap": 0.014064
+        },
+        {
+          "vocab_index": 251,
+          "token": "atom_a031_q03",
+          "mean_abs_shap": 0.013236
+        },
+        {
+          "vocab_index": 128,
+          "token": "atom_a016_q00",
+          "mean_abs_shap": 0.01273
+        },
+        {
+          "vocab_index": 408,
+          "token": "atom_a051_q00",
+          "mean_abs_shap": 0.012277
+        },
+        {
+          "vocab_index": 112,
+          "token": "atom_a014_q00",
+          "mean_abs_shap": 0.011981
+        },
+        {
+          "vocab_index": 232,
+          "token": "atom_a029_q00",
+          "mean_abs_shap": 0.011467
+        },
+        {
+          "vocab_index": 249,
+          "token": "atom_a031_q01",
+          "mean_abs_shap": 0.010902
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 120,
+          "token": "atom_a015_q00",
+          "mean_abs_shap": 0.012758
+        },
+        {
+          "vocab_index": 232,
+          "token": "atom_a029_q00",
+          "mean_abs_shap": 0.011203
+        },
+        {
+          "vocab_index": 104,
+          "token": "atom_a013_q00",
+          "mean_abs_shap": 0.010765
+        },
+        {
+          "vocab_index": 136,
+          "token": "atom_a017_q00",
+          "mean_abs_shap": 0.010394
+        },
+        {
+          "vocab_index": 489,
+          "token": "atom_a061_q01",
+          "mean_abs_shap": 0.010193
+        },
+        {
+          "vocab_index": 312,
+          "token": "atom_a039_q00",
+          "mean_abs_shap": 0.010162
+        },
+        {
+          "vocab_index": 128,
+          "token": "atom_a016_q00",
+          "mean_abs_shap": 0.009767
+        },
+        {
+          "vocab_index": 56,
+          "token": "atom_a007_q00",
+          "mean_abs_shap": 0.009054
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 120,
+          "token": "atom_a015_q00",
+          "mean_abs_shap": 0.01912
+        },
+        {
+          "vocab_index": 186,
+          "token": "atom_a023_q02",
+          "mean_abs_shap": 0.014238
+        },
+        {
+          "vocab_index": 56,
+          "token": "atom_a007_q00",
+          "mean_abs_shap": 0.01123
+        },
+        {
+          "vocab_index": 429,
+          "token": "atom_a053_q05",
+          "mean_abs_shap": 0.010149
+        },
+        {
+          "vocab_index": 437,
+          "token": "atom_a054_q05",
+          "mean_abs_shap": 0.008939
+        },
+        {
+          "vocab_index": 128,
+          "token": "atom_a016_q00",
+          "mean_abs_shap": 0.008888
+        },
+        {
+          "vocab_index": 188,
+          "token": "atom_a023_q04",
+          "mean_abs_shap": 0.008359
+        },
+        {
+          "vocab_index": 375,
+          "token": "atom_a046_q07",
+          "mean_abs_shap": 0.007983
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:17Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.49
+}

--- a/data/derived/v_sweep/f13_shap/botswana_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/botswana_V18_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 74,
+          "token": "lap_e09_q02",
+          "mean_abs_shap": 0.01425
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.007415
+        },
+        {
+          "vocab_index": 71,
+          "token": "lap_e08_q07",
+          "mean_abs_shap": 0.005689
+        },
+        {
+          "vocab_index": 73,
+          "token": "lap_e09_q01",
+          "mean_abs_shap": 0.005661
+        },
+        {
+          "vocab_index": 117,
+          "token": "lap_e14_q05",
+          "mean_abs_shap": 0.00457
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.004522
+        },
+        {
+          "vocab_index": 17,
+          "token": "lap_e02_q01",
+          "mean_abs_shap": 0.00349
+        },
+        {
+          "vocab_index": 95,
+          "token": "lap_e11_q07",
+          "mean_abs_shap": 0.003057
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 81,
+          "token": "lap_e10_q01",
+          "mean_abs_shap": 0.020508
+        },
+        {
+          "vocab_index": 94,
+          "token": "lap_e11_q06",
+          "mean_abs_shap": 0.017901
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.009249
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.008269
+        },
+        {
+          "vocab_index": 112,
+          "token": "lap_e14_q00",
+          "mean_abs_shap": 0.00799
+        },
+        {
+          "vocab_index": 73,
+          "token": "lap_e09_q01",
+          "mean_abs_shap": 0.00783
+        },
+        {
+          "vocab_index": 18,
+          "token": "lap_e02_q02",
+          "mean_abs_shap": 0.00778
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.007671
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.026952
+        },
+        {
+          "vocab_index": 32,
+          "token": "lap_e04_q00",
+          "mean_abs_shap": 0.014865
+        },
+        {
+          "vocab_index": 23,
+          "token": "lap_e02_q07",
+          "mean_abs_shap": 0.011276
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.010628
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.007827
+        },
+        {
+          "vocab_index": 82,
+          "token": "lap_e10_q02",
+          "mean_abs_shap": 0.007287
+        },
+        {
+          "vocab_index": 93,
+          "token": "lap_e11_q05",
+          "mean_abs_shap": 0.006351
+        },
+        {
+          "vocab_index": 115,
+          "token": "lap_e14_q03",
+          "mean_abs_shap": 0.004483
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 86,
+          "token": "lap_e10_q06",
+          "mean_abs_shap": 0.036357
+        },
+        {
+          "vocab_index": 89,
+          "token": "lap_e11_q01",
+          "mean_abs_shap": 0.030762
+        },
+        {
+          "vocab_index": 72,
+          "token": "lap_e09_q00",
+          "mean_abs_shap": 0.010644
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.007476
+        },
+        {
+          "vocab_index": 22,
+          "token": "lap_e02_q06",
+          "mean_abs_shap": 0.007132
+        },
+        {
+          "vocab_index": 34,
+          "token": "lap_e04_q02",
+          "mean_abs_shap": 0.006928
+        },
+        {
+          "vocab_index": 114,
+          "token": "lap_e14_q02",
+          "mean_abs_shap": 0.006845
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.006833
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 18,
+          "token": "lap_e02_q02",
+          "mean_abs_shap": 0.030386
+        },
+        {
+          "vocab_index": 90,
+          "token": "lap_e11_q02",
+          "mean_abs_shap": 0.019887
+        },
+        {
+          "vocab_index": 86,
+          "token": "lap_e10_q06",
+          "mean_abs_shap": 0.01761
+        },
+        {
+          "vocab_index": 84,
+          "token": "lap_e10_q04",
+          "mean_abs_shap": 0.017218
+        },
+        {
+          "vocab_index": 10,
+          "token": "lap_e01_q02",
+          "mean_abs_shap": 0.015618
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.014891
+        },
+        {
+          "vocab_index": 119,
+          "token": "lap_e14_q07",
+          "mean_abs_shap": 0.01389
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.013171
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 95,
+          "token": "lap_e11_q07",
+          "mean_abs_shap": 0.030037
+        },
+        {
+          "vocab_index": 72,
+          "token": "lap_e09_q00",
+          "mean_abs_shap": 0.012926
+        },
+        {
+          "vocab_index": 80,
+          "token": "lap_e10_q00",
+          "mean_abs_shap": 0.010325
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.010273
+        },
+        {
+          "vocab_index": 94,
+          "token": "lap_e11_q06",
+          "mean_abs_shap": 0.008202
+        },
+        {
+          "vocab_index": 11,
+          "token": "lap_e01_q03",
+          "mean_abs_shap": 0.008083
+        },
+        {
+          "vocab_index": 86,
+          "token": "lap_e10_q06",
+          "mean_abs_shap": 0.007863
+        },
+        {
+          "vocab_index": 1,
+          "token": "lap_e00_q01",
+          "mean_abs_shap": 0.007456
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 21,
+          "token": "lap_e02_q05",
+          "mean_abs_shap": 0.014079
+        },
+        {
+          "vocab_index": 93,
+          "token": "lap_e11_q05",
+          "mean_abs_shap": 0.013249
+        },
+        {
+          "vocab_index": 82,
+          "token": "lap_e10_q02",
+          "mean_abs_shap": 0.011121
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.009205
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.00747
+        },
+        {
+          "vocab_index": 10,
+          "token": "lap_e01_q02",
+          "mean_abs_shap": 0.006332
+        },
+        {
+          "vocab_index": 85,
+          "token": "lap_e10_q05",
+          "mean_abs_shap": 0.005578
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.004765
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.01156
+        },
+        {
+          "vocab_index": 94,
+          "token": "lap_e11_q06",
+          "mean_abs_shap": 0.011098
+        },
+        {
+          "vocab_index": 93,
+          "token": "lap_e11_q05",
+          "mean_abs_shap": 0.009516
+        },
+        {
+          "vocab_index": 22,
+          "token": "lap_e02_q06",
+          "mean_abs_shap": 0.008544
+        },
+        {
+          "vocab_index": 116,
+          "token": "lap_e14_q04",
+          "mean_abs_shap": 0.006773
+        },
+        {
+          "vocab_index": 117,
+          "token": "lap_e14_q05",
+          "mean_abs_shap": 0.006367
+        },
+        {
+          "vocab_index": 72,
+          "token": "lap_e09_q00",
+          "mean_abs_shap": 0.006332
+        },
+        {
+          "vocab_index": 73,
+          "token": "lap_e09_q01",
+          "mean_abs_shap": 0.006114
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 116,
+          "token": "lap_e14_q04",
+          "mean_abs_shap": 0.006357
+        },
+        {
+          "vocab_index": 23,
+          "token": "lap_e02_q07",
+          "mean_abs_shap": 0.004454
+        },
+        {
+          "vocab_index": 1,
+          "token": "lap_e00_q01",
+          "mean_abs_shap": 0.003742
+        },
+        {
+          "vocab_index": 83,
+          "token": "lap_e10_q03",
+          "mean_abs_shap": 0.003367
+        },
+        {
+          "vocab_index": 70,
+          "token": "lap_e08_q06",
+          "mean_abs_shap": 0.003043
+        },
+        {
+          "vocab_index": 11,
+          "token": "lap_e01_q03",
+          "mean_abs_shap": 0.003039
+        },
+        {
+          "vocab_index": 92,
+          "token": "lap_e11_q04",
+          "mean_abs_shap": 0.003015
+        },
+        {
+          "vocab_index": 115,
+          "token": "lap_e14_q03",
+          "mean_abs_shap": 0.003014
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 83,
+          "token": "lap_e10_q03",
+          "mean_abs_shap": 0.023067
+        },
+        {
+          "vocab_index": 92,
+          "token": "lap_e11_q04",
+          "mean_abs_shap": 0.016687
+        },
+        {
+          "vocab_index": 93,
+          "token": "lap_e11_q05",
+          "mean_abs_shap": 0.013606
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.013011
+        },
+        {
+          "vocab_index": 84,
+          "token": "lap_e10_q04",
+          "mean_abs_shap": 0.01199
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.011676
+        },
+        {
+          "vocab_index": 72,
+          "token": "lap_e09_q00",
+          "mean_abs_shap": 0.011424
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.010951
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 90,
+          "token": "lap_e11_q02",
+          "mean_abs_shap": 0.035818
+        },
+        {
+          "vocab_index": 85,
+          "token": "lap_e10_q05",
+          "mean_abs_shap": 0.028024
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.025986
+        },
+        {
+          "vocab_index": 84,
+          "token": "lap_e10_q04",
+          "mean_abs_shap": 0.022527
+        },
+        {
+          "vocab_index": 119,
+          "token": "lap_e14_q07",
+          "mean_abs_shap": 0.018707
+        },
+        {
+          "vocab_index": 18,
+          "token": "lap_e02_q02",
+          "mean_abs_shap": 0.012924
+        },
+        {
+          "vocab_index": 118,
+          "token": "lap_e14_q06",
+          "mean_abs_shap": 0.012369
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.011116
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 3,
+          "token": "lap_e00_q03",
+          "mean_abs_shap": 0.010647
+        },
+        {
+          "vocab_index": 1,
+          "token": "lap_e00_q01",
+          "mean_abs_shap": 0.005964
+        },
+        {
+          "vocab_index": 100,
+          "token": "lap_e12_q04",
+          "mean_abs_shap": 0.005906
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.003719
+        },
+        {
+          "vocab_index": 92,
+          "token": "lap_e11_q04",
+          "mean_abs_shap": 0.003077
+        },
+        {
+          "vocab_index": 11,
+          "token": "lap_e01_q03",
+          "mean_abs_shap": 0.002438
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.002258
+        },
+        {
+          "vocab_index": 23,
+          "token": "lap_e02_q07",
+          "mean_abs_shap": 0.002148
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:19Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.82
+}

--- a/data/derived/v_sweep/f13_shap/botswana_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/botswana_V19_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 24,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.064193
+        },
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.061575
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.053902
+        },
+        {
+          "vocab_index": 13,
+          "token": "umap_d1_q05",
+          "mean_abs_shap": 0.04874
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.045186
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.026029
+        },
+        {
+          "vocab_index": 15,
+          "token": "umap_d1_q07",
+          "mean_abs_shap": 0.025696
+        },
+        {
+          "vocab_index": 23,
+          "token": "umap_d2_q07",
+          "mean_abs_shap": 0.022603
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 13,
+          "token": "umap_d1_q05",
+          "mean_abs_shap": 0.133134
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.047386
+        },
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.040672
+        },
+        {
+          "vocab_index": 17,
+          "token": "umap_d2_q01",
+          "mean_abs_shap": 0.039589
+        },
+        {
+          "vocab_index": 18,
+          "token": "umap_d2_q02",
+          "mean_abs_shap": 0.033998
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.033184
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.025152
+        },
+        {
+          "vocab_index": 21,
+          "token": "umap_d2_q05",
+          "mean_abs_shap": 0.025055
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.102366
+        },
+        {
+          "vocab_index": 13,
+          "token": "umap_d1_q05",
+          "mean_abs_shap": 0.073015
+        },
+        {
+          "vocab_index": 15,
+          "token": "umap_d1_q07",
+          "mean_abs_shap": 0.051994
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.043289
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.035212
+        },
+        {
+          "vocab_index": 18,
+          "token": "umap_d2_q02",
+          "mean_abs_shap": 0.027172
+        },
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.024302
+        },
+        {
+          "vocab_index": 22,
+          "token": "umap_d2_q06",
+          "mean_abs_shap": 0.02323
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:20Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.49
+}

--- a/data/derived/v_sweep/f13_shap/botswana_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/botswana_V20_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1160,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 62,
+          "token": "miw_b007_q06",
+          "mean_abs_shap": 0.016925
+        },
+        {
+          "vocab_index": 22,
+          "token": "miw_b002_q06",
+          "mean_abs_shap": 0.015707
+        },
+        {
+          "vocab_index": 15,
+          "token": "miw_b001_q07",
+          "mean_abs_shap": 0.009734
+        },
+        {
+          "vocab_index": 7,
+          "token": "miw_b000_q07",
+          "mean_abs_shap": 0.006137
+        },
+        {
+          "vocab_index": 618,
+          "token": "miw_b077_q02",
+          "mean_abs_shap": 0.005709
+        },
+        {
+          "vocab_index": 38,
+          "token": "miw_b004_q06",
+          "mean_abs_shap": 0.005436
+        },
+        {
+          "vocab_index": 147,
+          "token": "miw_b018_q03",
+          "mean_abs_shap": 0.0052
+        },
+        {
+          "vocab_index": 52,
+          "token": "miw_b006_q04",
+          "mean_abs_shap": 0.0036
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 204,
+          "token": "miw_b025_q04",
+          "mean_abs_shap": 0.026232
+        },
+        {
+          "vocab_index": 287,
+          "token": "miw_b035_q07",
+          "mean_abs_shap": 0.015887
+        },
+        {
+          "vocab_index": 220,
+          "token": "miw_b027_q04",
+          "mean_abs_shap": 0.01523
+        },
+        {
+          "vocab_index": 62,
+          "token": "miw_b007_q06",
+          "mean_abs_shap": 0.014853
+        },
+        {
+          "vocab_index": 793,
+          "token": "miw_b099_q01",
+          "mean_abs_shap": 0.014836
+        },
+        {
+          "vocab_index": 226,
+          "token": "miw_b028_q02",
+          "mean_abs_shap": 0.011619
+        },
+        {
+          "vocab_index": 30,
+          "token": "miw_b003_q06",
+          "mean_abs_shap": 0.010853
+        },
+        {
+          "vocab_index": 68,
+          "token": "miw_b008_q04",
+          "mean_abs_shap": 0.01062
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 196,
+          "token": "miw_b024_q04",
+          "mean_abs_shap": 0.046565
+        },
+        {
+          "vocab_index": 149,
+          "token": "miw_b018_q05",
+          "mean_abs_shap": 0.04
+        },
+        {
+          "vocab_index": 365,
+          "token": "miw_b045_q05",
+          "mean_abs_shap": 0.037836
+        },
+        {
+          "vocab_index": 289,
+          "token": "miw_b036_q01",
+          "mean_abs_shap": 0.030182
+        },
+        {
+          "vocab_index": 76,
+          "token": "miw_b009_q04",
+          "mean_abs_shap": 0.024821
+        },
+        {
+          "vocab_index": 284,
+          "token": "miw_b035_q04",
+          "mean_abs_shap": 0.023166
+        },
+        {
+          "vocab_index": 131,
+          "token": "miw_b016_q03",
+          "mean_abs_shap": 0.021737
+        },
+        {
+          "vocab_index": 275,
+          "token": "miw_b034_q03",
+          "mean_abs_shap": 0.020805
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 197,
+          "token": "miw_b024_q05",
+          "mean_abs_shap": 0.00664
+        },
+        {
+          "vocab_index": 193,
+          "token": "miw_b024_q01",
+          "mean_abs_shap": 0.00664
+        },
+        {
+          "vocab_index": 77,
+          "token": "miw_b009_q05",
+          "mean_abs_shap": 0.003519
+        },
+        {
+          "vocab_index": 100,
+          "token": "miw_b012_q04",
+          "mean_abs_shap": 0.003121
+        },
+        {
+          "vocab_index": 294,
+          "token": "miw_b036_q06",
+          "mean_abs_shap": 7.9e-05
+        },
+        {
+          "vocab_index": 0,
+          "token": "miw_b000_q00",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 1159,
+          "token": "miw_b144_q07",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 1158,
+          "token": "miw_b144_q06",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 99,
+          "token": "miw_b012_q03",
+          "mean_abs_shap": 0.007695
+        },
+        {
+          "vocab_index": 325,
+          "token": "miw_b040_q05",
+          "mean_abs_shap": 0.005083
+        },
+        {
+          "vocab_index": 22,
+          "token": "miw_b002_q06",
+          "mean_abs_shap": 0.004375
+        },
+        {
+          "vocab_index": 283,
+          "token": "miw_b035_q03",
+          "mean_abs_shap": 0.00392
+        },
+        {
+          "vocab_index": 688,
+          "token": "miw_b086_q00",
+          "mean_abs_shap": 0.003776
+        },
+        {
+          "vocab_index": 346,
+          "token": "miw_b043_q02",
+          "mean_abs_shap": 0.003669
+        },
+        {
+          "vocab_index": 817,
+          "token": "miw_b102_q01",
+          "mean_abs_shap": 0.003373
+        },
+        {
+          "vocab_index": 448,
+          "token": "miw_b056_q00",
+          "mean_abs_shap": 0.003242
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 45,
+          "token": "miw_b005_q05",
+          "mean_abs_shap": 0.015
+        },
+        {
+          "vocab_index": 327,
+          "token": "miw_b040_q07",
+          "mean_abs_shap": 0.0116
+        },
+        {
+          "vocab_index": 265,
+          "token": "miw_b033_q01",
+          "mean_abs_shap": 0.01
+        },
+        {
+          "vocab_index": 505,
+          "token": "miw_b063_q01",
+          "mean_abs_shap": 0.0085
+        },
+        {
+          "vocab_index": 117,
+          "token": "miw_b014_q05",
+          "mean_abs_shap": 0.007875
+        },
+        {
+          "vocab_index": 569,
+          "token": "miw_b071_q01",
+          "mean_abs_shap": 0.00678
+        },
+        {
+          "vocab_index": 15,
+          "token": "miw_b001_q07",
+          "mean_abs_shap": 0.00411
+        },
+        {
+          "vocab_index": 440,
+          "token": "miw_b055_q00",
+          "mean_abs_shap": 0.002386
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 132,
+          "token": "miw_b016_q04",
+          "mean_abs_shap": 3166593487994.881
+        },
+        {
+          "vocab_index": 77,
+          "token": "miw_b009_q05",
+          "mean_abs_shap": 3166593487994.88
+        },
+        {
+          "vocab_index": 54,
+          "token": "miw_b006_q06",
+          "mean_abs_shap": 3166593487994.88
+        },
+        {
+          "vocab_index": 285,
+          "token": "miw_b035_q05",
+          "mean_abs_shap": 3166593487994.878
+        },
+        {
+          "vocab_index": 417,
+          "token": "miw_b052_q01",
+          "mean_abs_shap": 3166593487994.878
+        },
+        {
+          "vocab_index": 449,
+          "token": "miw_b056_q01",
+          "mean_abs_shap": 3166593487994.878
+        },
+        {
+          "vocab_index": 246,
+          "token": "miw_b030_q06",
+          "mean_abs_shap": 0.01367
+        },
+        {
+          "vocab_index": 231,
+          "token": "miw_b028_q07",
+          "mean_abs_shap": 0.0104
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 321,
+          "token": "miw_b040_q01",
+          "mean_abs_shap": 0.060456
+        },
+        {
+          "vocab_index": 46,
+          "token": "miw_b005_q06",
+          "mean_abs_shap": 0.057342
+        },
+        {
+          "vocab_index": 673,
+          "token": "miw_b084_q01",
+          "mean_abs_shap": 0.027092
+        },
+        {
+          "vocab_index": 341,
+          "token": "miw_b042_q05",
+          "mean_abs_shap": 0.026395
+        },
+        {
+          "vocab_index": 180,
+          "token": "miw_b022_q04",
+          "mean_abs_shap": 0.021493
+        },
+        {
+          "vocab_index": 377,
+          "token": "miw_b047_q01",
+          "mean_abs_shap": 0.01709
+        },
+        {
+          "vocab_index": 6,
+          "token": "miw_b000_q06",
+          "mean_abs_shap": 0.016359
+        },
+        {
+          "vocab_index": 107,
+          "token": "miw_b013_q03",
+          "mean_abs_shap": 0.011394
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 705,
+          "token": "miw_b088_q01",
+          "mean_abs_shap": 0.025034
+        },
+        {
+          "vocab_index": 769,
+          "token": "miw_b096_q01",
+          "mean_abs_shap": 0.020881
+        },
+        {
+          "vocab_index": 54,
+          "token": "miw_b006_q06",
+          "mean_abs_shap": 0.0208
+        },
+        {
+          "vocab_index": 392,
+          "token": "miw_b049_q00",
+          "mean_abs_shap": 0.020181
+        },
+        {
+          "vocab_index": 171,
+          "token": "miw_b021_q03",
+          "mean_abs_shap": 0.015999
+        },
+        {
+          "vocab_index": 78,
+          "token": "miw_b009_q06",
+          "mean_abs_shap": 0.014886
+        },
+        {
+          "vocab_index": 369,
+          "token": "miw_b046_q01",
+          "mean_abs_shap": 0.014634
+        },
+        {
+          "vocab_index": 434,
+          "token": "miw_b054_q02",
+          "mean_abs_shap": 0.0146
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 553,
+          "token": "miw_b069_q01",
+          "mean_abs_shap": 6593994159847.815
+        },
+        {
+          "vocab_index": 189,
+          "token": "miw_b023_q05",
+          "mean_abs_shap": 6593994159847.812
+        },
+        {
+          "vocab_index": 449,
+          "token": "miw_b056_q01",
+          "mean_abs_shap": 0.022294
+        },
+        {
+          "vocab_index": 229,
+          "token": "miw_b028_q05",
+          "mean_abs_shap": 0.011002
+        },
+        {
+          "vocab_index": 419,
+          "token": "miw_b052_q03",
+          "mean_abs_shap": 0.0108
+        },
+        {
+          "vocab_index": 107,
+          "token": "miw_b013_q03",
+          "mean_abs_shap": 0.010497
+        },
+        {
+          "vocab_index": 197,
+          "token": "miw_b024_q05",
+          "mean_abs_shap": 0.009771
+        },
+        {
+          "vocab_index": 417,
+          "token": "miw_b052_q01",
+          "mean_abs_shap": 0.009599
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 536,
+          "token": "miw_b067_q00",
+          "mean_abs_shap": 0.01
+        },
+        {
+          "vocab_index": 235,
+          "token": "miw_b029_q03",
+          "mean_abs_shap": 0.009608
+        },
+        {
+          "vocab_index": 188,
+          "token": "miw_b023_q04",
+          "mean_abs_shap": 0.0096
+        },
+        {
+          "vocab_index": 125,
+          "token": "miw_b015_q05",
+          "mean_abs_shap": 0.007701
+        },
+        {
+          "vocab_index": 139,
+          "token": "miw_b017_q03",
+          "mean_abs_shap": 0.006083
+        },
+        {
+          "vocab_index": 361,
+          "token": "miw_b045_q01",
+          "mean_abs_shap": 0.004972
+        },
+        {
+          "vocab_index": 154,
+          "token": "miw_b019_q02",
+          "mean_abs_shap": 0.004911
+        },
+        {
+          "vocab_index": 60,
+          "token": "miw_b007_q04",
+          "mean_abs_shap": 0.004673
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 318,
+          "token": "miw_b039_q06",
+          "mean_abs_shap": 35473477130422.52
+        },
+        {
+          "vocab_index": 403,
+          "token": "miw_b050_q03",
+          "mean_abs_shap": 35473477130422.51
+        },
+        {
+          "vocab_index": 340,
+          "token": "miw_b042_q04",
+          "mean_abs_shap": 0.005417
+        },
+        {
+          "vocab_index": 46,
+          "token": "miw_b005_q06",
+          "mean_abs_shap": 0.001532
+        },
+        {
+          "vocab_index": 401,
+          "token": "miw_b050_q01",
+          "mean_abs_shap": 0.000926
+        },
+        {
+          "vocab_index": 705,
+          "token": "miw_b088_q01",
+          "mean_abs_shap": 0.00074
+        },
+        {
+          "vocab_index": 408,
+          "token": "miw_b051_q00",
+          "mean_abs_shap": 0.000714
+        },
+        {
+          "vocab_index": 689,
+          "token": "miw_b086_q01",
+          "mean_abs_shap": 0.000593
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:25Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 4.95
+}

--- a/data/derived/v_sweep/f13_shap/indian-pines-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/indian-pines-corrected_V13_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "vq_m0_c20",
+          "mean_abs_shap": 0.079823
+        },
+        {
+          "vocab_index": 14,
+          "token": "vq_m0_c14",
+          "mean_abs_shap": 0.056649
+        },
+        {
+          "vocab_index": 94,
+          "token": "vq_m2_c30",
+          "mean_abs_shap": 0.028567
+        },
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.027613
+        },
+        {
+          "vocab_index": 101,
+          "token": "vq_m3_c05",
+          "mean_abs_shap": 0.02731
+        },
+        {
+          "vocab_index": 73,
+          "token": "vq_m2_c09",
+          "mean_abs_shap": 0.025956
+        },
+        {
+          "vocab_index": 105,
+          "token": "vq_m3_c09",
+          "mean_abs_shap": 0.023068
+        },
+        {
+          "vocab_index": 63,
+          "token": "vq_m1_c31",
+          "mean_abs_shap": 0.02181
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 94,
+          "token": "vq_m2_c30",
+          "mean_abs_shap": 0.03006
+        },
+        {
+          "vocab_index": 27,
+          "token": "vq_m0_c27",
+          "mean_abs_shap": 0.02677
+        },
+        {
+          "vocab_index": 20,
+          "token": "vq_m0_c20",
+          "mean_abs_shap": 0.017675
+        },
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.016209
+        },
+        {
+          "vocab_index": 35,
+          "token": "vq_m1_c03",
+          "mean_abs_shap": 0.016036
+        },
+        {
+          "vocab_index": 57,
+          "token": "vq_m1_c25",
+          "mean_abs_shap": 0.012037
+        },
+        {
+          "vocab_index": 14,
+          "token": "vq_m0_c14",
+          "mean_abs_shap": 0.010923
+        },
+        {
+          "vocab_index": 63,
+          "token": "vq_m1_c31",
+          "mean_abs_shap": 0.009955
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "vq_m0_c20",
+          "mean_abs_shap": 0.066321
+        },
+        {
+          "vocab_index": 14,
+          "token": "vq_m0_c14",
+          "mean_abs_shap": 0.060579
+        },
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.039471
+        },
+        {
+          "vocab_index": 101,
+          "token": "vq_m3_c05",
+          "mean_abs_shap": 0.029679
+        },
+        {
+          "vocab_index": 94,
+          "token": "vq_m2_c30",
+          "mean_abs_shap": 0.027825
+        },
+        {
+          "vocab_index": 63,
+          "token": "vq_m1_c31",
+          "mean_abs_shap": 0.027546
+        },
+        {
+          "vocab_index": 57,
+          "token": "vq_m1_c25",
+          "mean_abs_shap": 0.027466
+        },
+        {
+          "vocab_index": 73,
+          "token": "vq_m2_c09",
+          "mean_abs_shap": 0.023562
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:13Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 11.49
+}

--- a/data/derived/v_sweep/f13_shap/indian-pines-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/indian-pines-corrected_V14_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1024,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 924,
+          "token": "cwt_s14_p3_q04",
+          "mean_abs_shap": 0.001686
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.000978
+        },
+        {
+          "vocab_index": 925,
+          "token": "cwt_s14_p3_q05",
+          "mean_abs_shap": 0.000964
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 0.000736
+        },
+        {
+          "vocab_index": 1012,
+          "token": "cwt_s15_p6_q04",
+          "mean_abs_shap": 0.000552
+        },
+        {
+          "vocab_index": 965,
+          "token": "cwt_s15_p0_q05",
+          "mean_abs_shap": 0.000531
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.000486
+        },
+        {
+          "vocab_index": 967,
+          "token": "cwt_s15_p0_q07",
+          "mean_abs_shap": 0.000451
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 836,
+          "token": "cwt_s13_p0_q04",
+          "mean_abs_shap": 0.014381
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.014371
+        },
+        {
+          "vocab_index": 966,
+          "token": "cwt_s15_p0_q06",
+          "mean_abs_shap": 0.011831
+        },
+        {
+          "vocab_index": 991,
+          "token": "cwt_s15_p3_q07",
+          "mean_abs_shap": 0.01172
+        },
+        {
+          "vocab_index": 642,
+          "token": "cwt_s10_p0_q02",
+          "mean_abs_shap": 0.011613
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.011156
+        },
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 0.011051
+        },
+        {
+          "vocab_index": 999,
+          "token": "cwt_s15_p4_q07",
+          "mean_abs_shap": 0.010927
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.000875
+        },
+        {
+          "vocab_index": 989,
+          "token": "cwt_s15_p3_q05",
+          "mean_abs_shap": 0.000734
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.000631
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.000551
+        },
+        {
+          "vocab_index": 910,
+          "token": "cwt_s14_p1_q06",
+          "mean_abs_shap": 0.000479
+        },
+        {
+          "vocab_index": 981,
+          "token": "cwt_s15_p2_q05",
+          "mean_abs_shap": 0.000471
+        },
+        {
+          "vocab_index": 965,
+          "token": "cwt_s15_p0_q05",
+          "mean_abs_shap": 0.000453
+        },
+        {
+          "vocab_index": 642,
+          "token": "cwt_s10_p0_q02",
+          "mean_abs_shap": 0.000415
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 999,
+          "token": "cwt_s15_p4_q07",
+          "mean_abs_shap": 0.000543
+        },
+        {
+          "vocab_index": 924,
+          "token": "cwt_s14_p3_q04",
+          "mean_abs_shap": 0.000401
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.000349
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.000297
+        },
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 0.00029
+        },
+        {
+          "vocab_index": 965,
+          "token": "cwt_s15_p0_q05",
+          "mean_abs_shap": 0.000281
+        },
+        {
+          "vocab_index": 707,
+          "token": "cwt_s11_p0_q03",
+          "mean_abs_shap": 0.000234
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.000234
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 779,
+          "token": "cwt_s12_p1_q03",
+          "mean_abs_shap": 0.022518
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.0197
+        },
+        {
+          "vocab_index": 1019,
+          "token": "cwt_s15_p7_q03",
+          "mean_abs_shap": 0.01892
+        },
+        {
+          "vocab_index": 716,
+          "token": "cwt_s11_p1_q04",
+          "mean_abs_shap": 0.015688
+        },
+        {
+          "vocab_index": 982,
+          "token": "cwt_s15_p2_q06",
+          "mean_abs_shap": 0.014086
+        },
+        {
+          "vocab_index": 659,
+          "token": "cwt_s10_p2_q03",
+          "mean_abs_shap": 0.013818
+        },
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 0.013184
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 0.012757
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 666,
+          "token": "cwt_s10_p3_q02",
+          "mean_abs_shap": 0.001978
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.000669
+        },
+        {
+          "vocab_index": 999,
+          "token": "cwt_s15_p4_q07",
+          "mean_abs_shap": 0.000604
+        },
+        {
+          "vocab_index": 1002,
+          "token": "cwt_s15_p5_q02",
+          "mean_abs_shap": 0.000589
+        },
+        {
+          "vocab_index": 1010,
+          "token": "cwt_s15_p6_q02",
+          "mean_abs_shap": 0.000521
+        },
+        {
+          "vocab_index": 779,
+          "token": "cwt_s12_p1_q03",
+          "mean_abs_shap": 0.000456
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.000433
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.000432
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.001325
+        },
+        {
+          "vocab_index": 986,
+          "token": "cwt_s15_p3_q02",
+          "mean_abs_shap": 0.000972
+        },
+        {
+          "vocab_index": 924,
+          "token": "cwt_s14_p3_q04",
+          "mean_abs_shap": 0.000659
+        },
+        {
+          "vocab_index": 643,
+          "token": "cwt_s10_p0_q03",
+          "mean_abs_shap": 0.000658
+        },
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 0.000567
+        },
+        {
+          "vocab_index": 965,
+          "token": "cwt_s15_p0_q05",
+          "mean_abs_shap": 0.000563
+        },
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 0.000542
+        },
+        {
+          "vocab_index": 988,
+          "token": "cwt_s15_p3_q04",
+          "mean_abs_shap": 0.000517
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.004409
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.00277
+        },
+        {
+          "vocab_index": 989,
+          "token": "cwt_s15_p3_q05",
+          "mean_abs_shap": 0.002138
+        },
+        {
+          "vocab_index": 642,
+          "token": "cwt_s10_p0_q02",
+          "mean_abs_shap": 0.002085
+        },
+        {
+          "vocab_index": 716,
+          "token": "cwt_s11_p1_q04",
+          "mean_abs_shap": 0.001877
+        },
+        {
+          "vocab_index": 981,
+          "token": "cwt_s15_p2_q05",
+          "mean_abs_shap": 0.001811
+        },
+        {
+          "vocab_index": 924,
+          "token": "cwt_s14_p3_q04",
+          "mean_abs_shap": 0.00158
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 0.001572
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.000667
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.000504
+        },
+        {
+          "vocab_index": 666,
+          "token": "cwt_s10_p3_q02",
+          "mean_abs_shap": 0.000366
+        },
+        {
+          "vocab_index": 772,
+          "token": "cwt_s12_p0_q04",
+          "mean_abs_shap": 0.000286
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.000275
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.000269
+        },
+        {
+          "vocab_index": 938,
+          "token": "cwt_s14_p5_q02",
+          "mean_abs_shap": 0.000243
+        },
+        {
+          "vocab_index": 914,
+          "token": "cwt_s14_p2_q02",
+          "mean_abs_shap": 0.000237
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 931,
+          "token": "cwt_s14_p4_q03",
+          "mean_abs_shap": 0.01597
+        },
+        {
+          "vocab_index": 965,
+          "token": "cwt_s15_p0_q05",
+          "mean_abs_shap": 0.011646
+        },
+        {
+          "vocab_index": 666,
+          "token": "cwt_s10_p3_q02",
+          "mean_abs_shap": 0.009813
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.009117
+        },
+        {
+          "vocab_index": 914,
+          "token": "cwt_s14_p2_q02",
+          "mean_abs_shap": 0.008825
+        },
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.008509
+        },
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 0.007711
+        },
+        {
+          "vocab_index": 996,
+          "token": "cwt_s15_p4_q04",
+          "mean_abs_shap": 0.007421
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.004207
+        },
+        {
+          "vocab_index": 714,
+          "token": "cwt_s11_p1_q02",
+          "mean_abs_shap": 0.002649
+        },
+        {
+          "vocab_index": 996,
+          "token": "cwt_s15_p4_q04",
+          "mean_abs_shap": 0.002087
+        },
+        {
+          "vocab_index": 991,
+          "token": "cwt_s15_p3_q07",
+          "mean_abs_shap": 0.001919
+        },
+        {
+          "vocab_index": 772,
+          "token": "cwt_s12_p0_q04",
+          "mean_abs_shap": 0.001916
+        },
+        {
+          "vocab_index": 779,
+          "token": "cwt_s12_p1_q03",
+          "mean_abs_shap": 0.001836
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.001822
+        },
+        {
+          "vocab_index": 837,
+          "token": "cwt_s13_p0_q05",
+          "mean_abs_shap": 0.00178
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 779,
+          "token": "cwt_s12_p1_q03",
+          "mean_abs_shap": 0.019544
+        },
+        {
+          "vocab_index": 991,
+          "token": "cwt_s15_p3_q07",
+          "mean_abs_shap": 0.016477
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.013174
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 0.012438
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.012142
+        },
+        {
+          "vocab_index": 1019,
+          "token": "cwt_s15_p7_q03",
+          "mean_abs_shap": 0.010455
+        },
+        {
+          "vocab_index": 986,
+          "token": "cwt_s15_p3_q02",
+          "mean_abs_shap": 0.01029
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.010109
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:15Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 2.07
+}

--- a/data/derived/v_sweep/f13_shap/indian-pines-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/indian-pines-corrected_V15_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 48,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 9,
+          "token": "MNDWI_q01",
+          "mean_abs_shap": 0.039595
+        },
+        {
+          "vocab_index": 25,
+          "token": "NDSI_q01",
+          "mean_abs_shap": 0.039369
+        },
+        {
+          "vocab_index": 8,
+          "token": "MNDWI_q00",
+          "mean_abs_shap": 0.027217
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.024806
+        },
+        {
+          "vocab_index": 43,
+          "token": "SAVI_q03",
+          "mean_abs_shap": 0.019222
+        },
+        {
+          "vocab_index": 34,
+          "token": "NDVI_q02",
+          "mean_abs_shap": 0.017895
+        },
+        {
+          "vocab_index": 42,
+          "token": "SAVI_q02",
+          "mean_abs_shap": 0.015896
+        },
+        {
+          "vocab_index": 33,
+          "token": "NDVI_q01",
+          "mean_abs_shap": 0.01337
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 23,
+          "token": "NBR_q07",
+          "mean_abs_shap": 0.024546
+        },
+        {
+          "vocab_index": 25,
+          "token": "NDSI_q01",
+          "mean_abs_shap": 0.023499
+        },
+        {
+          "vocab_index": 9,
+          "token": "MNDWI_q01",
+          "mean_abs_shap": 0.022862
+        },
+        {
+          "vocab_index": 33,
+          "token": "NDVI_q01",
+          "mean_abs_shap": 0.02215
+        },
+        {
+          "vocab_index": 22,
+          "token": "NBR_q06",
+          "mean_abs_shap": 0.021983
+        },
+        {
+          "vocab_index": 47,
+          "token": "SAVI_q07",
+          "mean_abs_shap": 0.02043
+        },
+        {
+          "vocab_index": 15,
+          "token": "MNDWI_q07",
+          "mean_abs_shap": 0.017618
+        },
+        {
+          "vocab_index": 45,
+          "token": "SAVI_q05",
+          "mean_abs_shap": 0.015209
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 9,
+          "token": "MNDWI_q01",
+          "mean_abs_shap": 0.082984
+        },
+        {
+          "vocab_index": 25,
+          "token": "NDSI_q01",
+          "mean_abs_shap": 0.081547
+        },
+        {
+          "vocab_index": 8,
+          "token": "MNDWI_q00",
+          "mean_abs_shap": 0.030781
+        },
+        {
+          "vocab_index": 23,
+          "token": "NBR_q07",
+          "mean_abs_shap": 0.022295
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.019031
+        },
+        {
+          "vocab_index": 33,
+          "token": "NDVI_q01",
+          "mean_abs_shap": 0.017243
+        },
+        {
+          "vocab_index": 43,
+          "token": "SAVI_q03",
+          "mean_abs_shap": 0.016599
+        },
+        {
+          "vocab_index": 41,
+          "token": "SAVI_q01",
+          "mean_abs_shap": 0.015539
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:15Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.32
+}

--- a/data/derived/v_sweep/f13_shap/indian-pines-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/indian-pines-corrected_V17_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 512,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 0,
+          "token": "atom_a000_q00",
+          "mean_abs_shap": 0.014581
+        },
+        {
+          "vocab_index": 1,
+          "token": "atom_a000_q01",
+          "mean_abs_shap": 0.013797
+        },
+        {
+          "vocab_index": 79,
+          "token": "atom_a009_q07",
+          "mean_abs_shap": 0.012043
+        },
+        {
+          "vocab_index": 146,
+          "token": "atom_a018_q02",
+          "mean_abs_shap": 0.011345
+        },
+        {
+          "vocab_index": 397,
+          "token": "atom_a049_q05",
+          "mean_abs_shap": 0.011006
+        },
+        {
+          "vocab_index": 412,
+          "token": "atom_a051_q04",
+          "mean_abs_shap": 0.010869
+        },
+        {
+          "vocab_index": 304,
+          "token": "atom_a038_q00",
+          "mean_abs_shap": 0.010813
+        },
+        {
+          "vocab_index": 226,
+          "token": "atom_a028_q02",
+          "mean_abs_shap": 0.010642
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 344,
+          "token": "atom_a043_q00",
+          "mean_abs_shap": 0.014207
+        },
+        {
+          "vocab_index": 146,
+          "token": "atom_a018_q02",
+          "mean_abs_shap": 0.012715
+        },
+        {
+          "vocab_index": 401,
+          "token": "atom_a050_q01",
+          "mean_abs_shap": 0.011799
+        },
+        {
+          "vocab_index": 45,
+          "token": "atom_a005_q05",
+          "mean_abs_shap": 0.011617
+        },
+        {
+          "vocab_index": 225,
+          "token": "atom_a028_q01",
+          "mean_abs_shap": 0.010781
+        },
+        {
+          "vocab_index": 461,
+          "token": "atom_a057_q05",
+          "mean_abs_shap": 0.009962
+        },
+        {
+          "vocab_index": 167,
+          "token": "atom_a020_q07",
+          "mean_abs_shap": 0.009896
+        },
+        {
+          "vocab_index": 351,
+          "token": "atom_a043_q07",
+          "mean_abs_shap": 0.009887
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 224,
+          "token": "atom_a028_q00",
+          "mean_abs_shap": 0.01499
+        },
+        {
+          "vocab_index": 304,
+          "token": "atom_a038_q00",
+          "mean_abs_shap": 0.013594
+        },
+        {
+          "vocab_index": 0,
+          "token": "atom_a000_q00",
+          "mean_abs_shap": 0.01329
+        },
+        {
+          "vocab_index": 412,
+          "token": "atom_a051_q04",
+          "mean_abs_shap": 0.012779
+        },
+        {
+          "vocab_index": 45,
+          "token": "atom_a005_q05",
+          "mean_abs_shap": 0.01139
+        },
+        {
+          "vocab_index": 458,
+          "token": "atom_a057_q02",
+          "mean_abs_shap": 0.010474
+        },
+        {
+          "vocab_index": 172,
+          "token": "atom_a021_q04",
+          "mean_abs_shap": 0.009675
+        },
+        {
+          "vocab_index": 401,
+          "token": "atom_a050_q01",
+          "mean_abs_shap": 0.009615
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:16Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.88
+}

--- a/data/derived/v_sweep/f13_shap/indian-pines-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/indian-pines-corrected_V18_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.006812
+        },
+        {
+          "vocab_index": 84,
+          "token": "lap_e10_q04",
+          "mean_abs_shap": 0.004866
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.004809
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.004747
+        },
+        {
+          "vocab_index": 52,
+          "token": "lap_e06_q04",
+          "mean_abs_shap": 0.004385
+        },
+        {
+          "vocab_index": 57,
+          "token": "lap_e07_q01",
+          "mean_abs_shap": 0.004165
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.003688
+        },
+        {
+          "vocab_index": 125,
+          "token": "lap_e15_q05",
+          "mean_abs_shap": 0.003385
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 115,
+          "token": "lap_e14_q03",
+          "mean_abs_shap": 0.017598
+        },
+        {
+          "vocab_index": 6,
+          "token": "lap_e00_q06",
+          "mean_abs_shap": 0.012405
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.009853
+        },
+        {
+          "vocab_index": 53,
+          "token": "lap_e06_q05",
+          "mean_abs_shap": 0.009621
+        },
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.007349
+        },
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.00726
+        },
+        {
+          "vocab_index": 10,
+          "token": "lap_e01_q02",
+          "mean_abs_shap": 0.005899
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.005199
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.014035
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.011453
+        },
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.010501
+        },
+        {
+          "vocab_index": 57,
+          "token": "lap_e07_q01",
+          "mean_abs_shap": 0.010444
+        },
+        {
+          "vocab_index": 50,
+          "token": "lap_e06_q02",
+          "mean_abs_shap": 0.00893
+        },
+        {
+          "vocab_index": 49,
+          "token": "lap_e06_q01",
+          "mean_abs_shap": 0.006895
+        },
+        {
+          "vocab_index": 99,
+          "token": "lap_e12_q03",
+          "mean_abs_shap": 0.006884
+        },
+        {
+          "vocab_index": 94,
+          "token": "lap_e11_q06",
+          "mean_abs_shap": 0.006864
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.019683
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.017415
+        },
+        {
+          "vocab_index": 52,
+          "token": "lap_e06_q04",
+          "mean_abs_shap": 0.014024
+        },
+        {
+          "vocab_index": 86,
+          "token": "lap_e10_q06",
+          "mean_abs_shap": 0.010159
+        },
+        {
+          "vocab_index": 69,
+          "token": "lap_e08_q05",
+          "mean_abs_shap": 0.008509
+        },
+        {
+          "vocab_index": 53,
+          "token": "lap_e06_q05",
+          "mean_abs_shap": 0.008354
+        },
+        {
+          "vocab_index": 117,
+          "token": "lap_e14_q05",
+          "mean_abs_shap": 0.00752
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.007463
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.01678
+        },
+        {
+          "vocab_index": 71,
+          "token": "lap_e08_q07",
+          "mean_abs_shap": 0.01115
+        },
+        {
+          "vocab_index": 40,
+          "token": "lap_e05_q00",
+          "mean_abs_shap": 0.009814
+        },
+        {
+          "vocab_index": 127,
+          "token": "lap_e15_q07",
+          "mean_abs_shap": 0.0081
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.007211
+        },
+        {
+          "vocab_index": 100,
+          "token": "lap_e12_q04",
+          "mean_abs_shap": 0.007145
+        },
+        {
+          "vocab_index": 22,
+          "token": "lap_e02_q06",
+          "mean_abs_shap": 0.006585
+        },
+        {
+          "vocab_index": 23,
+          "token": "lap_e02_q07",
+          "mean_abs_shap": 0.005934
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 99,
+          "token": "lap_e12_q03",
+          "mean_abs_shap": 0.01331
+        },
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.00647
+        },
+        {
+          "vocab_index": 50,
+          "token": "lap_e06_q02",
+          "mean_abs_shap": 0.006185
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.005918
+        },
+        {
+          "vocab_index": 86,
+          "token": "lap_e10_q06",
+          "mean_abs_shap": 0.005105
+        },
+        {
+          "vocab_index": 64,
+          "token": "lap_e08_q00",
+          "mean_abs_shap": 0.002465
+        },
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.002462
+        },
+        {
+          "vocab_index": 124,
+          "token": "lap_e15_q04",
+          "mean_abs_shap": 0.002405
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.01282
+        },
+        {
+          "vocab_index": 51,
+          "token": "lap_e06_q03",
+          "mean_abs_shap": 0.01067
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.010454
+        },
+        {
+          "vocab_index": 53,
+          "token": "lap_e06_q05",
+          "mean_abs_shap": 0.009717
+        },
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.009484
+        },
+        {
+          "vocab_index": 104,
+          "token": "lap_e13_q00",
+          "mean_abs_shap": 0.008202
+        },
+        {
+          "vocab_index": 21,
+          "token": "lap_e02_q05",
+          "mean_abs_shap": 0.008037
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.007403
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.014515
+        },
+        {
+          "vocab_index": 7,
+          "token": "lap_e00_q07",
+          "mean_abs_shap": 0.00538
+        },
+        {
+          "vocab_index": 64,
+          "token": "lap_e08_q00",
+          "mean_abs_shap": 0.004903
+        },
+        {
+          "vocab_index": 102,
+          "token": "lap_e12_q06",
+          "mean_abs_shap": 0.004875
+        },
+        {
+          "vocab_index": 107,
+          "token": "lap_e13_q03",
+          "mean_abs_shap": 0.00482
+        },
+        {
+          "vocab_index": 127,
+          "token": "lap_e15_q07",
+          "mean_abs_shap": 0.00443
+        },
+        {
+          "vocab_index": 97,
+          "token": "lap_e12_q01",
+          "mean_abs_shap": 0.004344
+        },
+        {
+          "vocab_index": 115,
+          "token": "lap_e14_q03",
+          "mean_abs_shap": 0.004281
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 105,
+          "token": "lap_e13_q01",
+          "mean_abs_shap": 0.009234
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.007723
+        },
+        {
+          "vocab_index": 116,
+          "token": "lap_e14_q04",
+          "mean_abs_shap": 0.006232
+        },
+        {
+          "vocab_index": 100,
+          "token": "lap_e12_q04",
+          "mean_abs_shap": 0.006078
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.004662
+        },
+        {
+          "vocab_index": 84,
+          "token": "lap_e10_q04",
+          "mean_abs_shap": 0.004317
+        },
+        {
+          "vocab_index": 10,
+          "token": "lap_e01_q02",
+          "mean_abs_shap": 0.003573
+        },
+        {
+          "vocab_index": 85,
+          "token": "lap_e10_q05",
+          "mean_abs_shap": 0.003314
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.01976
+        },
+        {
+          "vocab_index": 6,
+          "token": "lap_e00_q06",
+          "mean_abs_shap": 0.012046
+        },
+        {
+          "vocab_index": 102,
+          "token": "lap_e12_q06",
+          "mean_abs_shap": 0.009784
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.008962
+        },
+        {
+          "vocab_index": 116,
+          "token": "lap_e14_q04",
+          "mean_abs_shap": 0.008864
+        },
+        {
+          "vocab_index": 17,
+          "token": "lap_e02_q01",
+          "mean_abs_shap": 0.008828
+        },
+        {
+          "vocab_index": 114,
+          "token": "lap_e14_q02",
+          "mean_abs_shap": 0.008404
+        },
+        {
+          "vocab_index": 83,
+          "token": "lap_e10_q03",
+          "mean_abs_shap": 0.007893
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 6,
+          "token": "lap_e00_q06",
+          "mean_abs_shap": 0.018697
+        },
+        {
+          "vocab_index": 86,
+          "token": "lap_e10_q06",
+          "mean_abs_shap": 0.013547
+        },
+        {
+          "vocab_index": 117,
+          "token": "lap_e14_q05",
+          "mean_abs_shap": 0.013338
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.012105
+        },
+        {
+          "vocab_index": 118,
+          "token": "lap_e14_q06",
+          "mean_abs_shap": 0.011682
+        },
+        {
+          "vocab_index": 17,
+          "token": "lap_e02_q01",
+          "mean_abs_shap": 0.011535
+        },
+        {
+          "vocab_index": 64,
+          "token": "lap_e08_q00",
+          "mean_abs_shap": 0.009758
+        },
+        {
+          "vocab_index": 51,
+          "token": "lap_e06_q03",
+          "mean_abs_shap": 0.0074
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.021561
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.014887
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.01407
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.013784
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.012774
+        },
+        {
+          "vocab_index": 3,
+          "token": "lap_e00_q03",
+          "mean_abs_shap": 0.012547
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.010833
+        },
+        {
+          "vocab_index": 124,
+          "token": "lap_e15_q04",
+          "mean_abs_shap": 0.008736
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:17Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.14
+}

--- a/data/derived/v_sweep/f13_shap/indian-pines-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/indian-pines-corrected_V19_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 24,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.061697
+        },
+        {
+          "vocab_index": 10,
+          "token": "umap_d1_q02",
+          "mean_abs_shap": 0.043485
+        },
+        {
+          "vocab_index": 21,
+          "token": "umap_d2_q05",
+          "mean_abs_shap": 0.043396
+        },
+        {
+          "vocab_index": 6,
+          "token": "umap_d0_q06",
+          "mean_abs_shap": 0.038221
+        },
+        {
+          "vocab_index": 1,
+          "token": "umap_d0_q01",
+          "mean_abs_shap": 0.0306
+        },
+        {
+          "vocab_index": 16,
+          "token": "umap_d2_q00",
+          "mean_abs_shap": 0.026042
+        },
+        {
+          "vocab_index": 7,
+          "token": "umap_d0_q07",
+          "mean_abs_shap": 0.024128
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.023912
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 6,
+          "token": "umap_d0_q06",
+          "mean_abs_shap": 0.101681
+        },
+        {
+          "vocab_index": 7,
+          "token": "umap_d0_q07",
+          "mean_abs_shap": 0.077162
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.049138
+        },
+        {
+          "vocab_index": 17,
+          "token": "umap_d2_q01",
+          "mean_abs_shap": 0.047514
+        },
+        {
+          "vocab_index": 10,
+          "token": "umap_d1_q02",
+          "mean_abs_shap": 0.03667
+        },
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.036669
+        },
+        {
+          "vocab_index": 11,
+          "token": "umap_d1_q03",
+          "mean_abs_shap": 0.032312
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.030574
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 7,
+          "token": "umap_d0_q07",
+          "mean_abs_shap": 0.107898
+        },
+        {
+          "vocab_index": 10,
+          "token": "umap_d1_q02",
+          "mean_abs_shap": 0.085399
+        },
+        {
+          "vocab_index": 6,
+          "token": "umap_d0_q06",
+          "mean_abs_shap": 0.062513
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.043681
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.036124
+        },
+        {
+          "vocab_index": 17,
+          "token": "umap_d2_q01",
+          "mean_abs_shap": 0.031838
+        },
+        {
+          "vocab_index": 11,
+          "token": "umap_d1_q03",
+          "mean_abs_shap": 0.024836
+        },
+        {
+          "vocab_index": 9,
+          "token": "umap_d1_q01",
+          "mean_abs_shap": 0.020665
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:18Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.43
+}

--- a/data/derived/v_sweep/f13_shap/indian-pines-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/indian-pines-corrected_V20_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1600,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 14,
+          "token": "miw_b001_q06",
+          "mean_abs_shap": 0.024446
+        },
+        {
+          "vocab_index": 3,
+          "token": "miw_b000_q03",
+          "mean_abs_shap": 0.016548
+        },
+        {
+          "vocab_index": 993,
+          "token": "miw_b124_q01",
+          "mean_abs_shap": 0.012233
+        },
+        {
+          "vocab_index": 11,
+          "token": "miw_b001_q03",
+          "mean_abs_shap": 0.011933
+        },
+        {
+          "vocab_index": 76,
+          "token": "miw_b009_q04",
+          "mean_abs_shap": 0.011817
+        },
+        {
+          "vocab_index": 148,
+          "token": "miw_b018_q04",
+          "mean_abs_shap": 0.010676
+        },
+        {
+          "vocab_index": 27,
+          "token": "miw_b003_q03",
+          "mean_abs_shap": 0.009892
+        },
+        {
+          "vocab_index": 103,
+          "token": "miw_b012_q07",
+          "mean_abs_shap": 0.009847
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 944,
+          "token": "miw_b118_q00",
+          "mean_abs_shap": 0.035294
+        },
+        {
+          "vocab_index": 23,
+          "token": "miw_b002_q07",
+          "mean_abs_shap": 0.022215
+        },
+        {
+          "vocab_index": 243,
+          "token": "miw_b030_q03",
+          "mean_abs_shap": 0.012831
+        },
+        {
+          "vocab_index": 616,
+          "token": "miw_b077_q00",
+          "mean_abs_shap": 0.012431
+        },
+        {
+          "vocab_index": 266,
+          "token": "miw_b033_q02",
+          "mean_abs_shap": 0.012351
+        },
+        {
+          "vocab_index": 565,
+          "token": "miw_b070_q05",
+          "mean_abs_shap": 0.012137
+        },
+        {
+          "vocab_index": 43,
+          "token": "miw_b005_q03",
+          "mean_abs_shap": 0.007439
+        },
+        {
+          "vocab_index": 986,
+          "token": "miw_b123_q02",
+          "mean_abs_shap": 0.006799
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "miw_b002_q00",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 18,
+          "token": "miw_b002_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 19,
+          "token": "miw_b002_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 20,
+          "token": "miw_b002_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 21,
+          "token": "miw_b002_q05",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 22,
+          "token": "miw_b002_q06",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 23,
+          "token": "miw_b002_q07",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 14,
+          "token": "miw_b001_q06",
+          "mean_abs_shap": 0.033851
+        },
+        {
+          "vocab_index": 730,
+          "token": "miw_b091_q02",
+          "mean_abs_shap": 0.030992
+        },
+        {
+          "vocab_index": 177,
+          "token": "miw_b022_q01",
+          "mean_abs_shap": 0.02917
+        },
+        {
+          "vocab_index": 78,
+          "token": "miw_b009_q06",
+          "mean_abs_shap": 0.0241
+        },
+        {
+          "vocab_index": 1073,
+          "token": "miw_b134_q01",
+          "mean_abs_shap": 0.010149
+        },
+        {
+          "vocab_index": 30,
+          "token": "miw_b003_q06",
+          "mean_abs_shap": 0.009976
+        },
+        {
+          "vocab_index": 3,
+          "token": "miw_b000_q03",
+          "mean_abs_shap": 0.009232
+        },
+        {
+          "vocab_index": 97,
+          "token": "miw_b012_q01",
+          "mean_abs_shap": 0.008905
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 79,
+          "token": "miw_b009_q07",
+          "mean_abs_shap": 43787725724979.83
+        },
+        {
+          "vocab_index": 542,
+          "token": "miw_b067_q06",
+          "mean_abs_shap": 43787725724979.83
+        },
+        {
+          "vocab_index": 141,
+          "token": "miw_b017_q05",
+          "mean_abs_shap": 0.012507
+        },
+        {
+          "vocab_index": 77,
+          "token": "miw_b009_q05",
+          "mean_abs_shap": 0.010255
+        },
+        {
+          "vocab_index": 616,
+          "token": "miw_b077_q00",
+          "mean_abs_shap": 0.009056
+        },
+        {
+          "vocab_index": 20,
+          "token": "miw_b002_q04",
+          "mean_abs_shap": 0.006365
+        },
+        {
+          "vocab_index": 71,
+          "token": "miw_b008_q07",
+          "mean_abs_shap": 0.006364
+        },
+        {
+          "vocab_index": 45,
+          "token": "miw_b005_q05",
+          "mean_abs_shap": 0.006364
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 1113,
+          "token": "miw_b139_q01",
+          "mean_abs_shap": 0.0098
+        },
+        {
+          "vocab_index": 47,
+          "token": "miw_b005_q07",
+          "mean_abs_shap": 0.008255
+        },
+        {
+          "vocab_index": 39,
+          "token": "miw_b004_q07",
+          "mean_abs_shap": 0.007193
+        },
+        {
+          "vocab_index": 127,
+          "token": "miw_b015_q07",
+          "mean_abs_shap": 0.004524
+        },
+        {
+          "vocab_index": 106,
+          "token": "miw_b013_q02",
+          "mean_abs_shap": 0.004201
+        },
+        {
+          "vocab_index": 23,
+          "token": "miw_b002_q07",
+          "mean_abs_shap": 0.002852
+        },
+        {
+          "vocab_index": 115,
+          "token": "miw_b014_q03",
+          "mean_abs_shap": 0.00265
+        },
+        {
+          "vocab_index": 95,
+          "token": "miw_b011_q07",
+          "mean_abs_shap": 0.002398
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 13,
+          "token": "miw_b001_q05",
+          "mean_abs_shap": 0.018407
+        },
+        {
+          "vocab_index": 95,
+          "token": "miw_b011_q07",
+          "mean_abs_shap": 0.014237
+        },
+        {
+          "vocab_index": 182,
+          "token": "miw_b022_q06",
+          "mean_abs_shap": 0.006521
+        },
+        {
+          "vocab_index": 189,
+          "token": "miw_b023_q05",
+          "mean_abs_shap": 0.006054
+        },
+        {
+          "vocab_index": 92,
+          "token": "miw_b011_q04",
+          "mean_abs_shap": 0.004467
+        },
+        {
+          "vocab_index": 69,
+          "token": "miw_b008_q05",
+          "mean_abs_shap": 0.004416
+        },
+        {
+          "vocab_index": 244,
+          "token": "miw_b030_q04",
+          "mean_abs_shap": 0.004033
+        },
+        {
+          "vocab_index": 183,
+          "token": "miw_b022_q07",
+          "mean_abs_shap": 0.003727
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 38,
+          "token": "miw_b004_q06",
+          "mean_abs_shap": 0.011816
+        },
+        {
+          "vocab_index": 269,
+          "token": "miw_b033_q05",
+          "mean_abs_shap": 0.0092
+        },
+        {
+          "vocab_index": 276,
+          "token": "miw_b034_q04",
+          "mean_abs_shap": 0.009055
+        },
+        {
+          "vocab_index": 977,
+          "token": "miw_b122_q01",
+          "mean_abs_shap": 0.009
+        },
+        {
+          "vocab_index": 10,
+          "token": "miw_b001_q02",
+          "mean_abs_shap": 0.007995
+        },
+        {
+          "vocab_index": 82,
+          "token": "miw_b010_q02",
+          "mean_abs_shap": 0.006913
+        },
+        {
+          "vocab_index": 21,
+          "token": "miw_b002_q05",
+          "mean_abs_shap": 0.005995
+        },
+        {
+          "vocab_index": 39,
+          "token": "miw_b004_q07",
+          "mean_abs_shap": 0.0052
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 11,
+          "token": "miw_b001_q03",
+          "mean_abs_shap": 0.031229
+        },
+        {
+          "vocab_index": 920,
+          "token": "miw_b115_q00",
+          "mean_abs_shap": 0.028661
+        },
+        {
+          "vocab_index": 706,
+          "token": "miw_b088_q02",
+          "mean_abs_shap": 0.025
+        },
+        {
+          "vocab_index": 22,
+          "token": "miw_b002_q06",
+          "mean_abs_shap": 0.0234
+        },
+        {
+          "vocab_index": 146,
+          "token": "miw_b018_q02",
+          "mean_abs_shap": 0.022378
+        },
+        {
+          "vocab_index": 501,
+          "token": "miw_b062_q05",
+          "mean_abs_shap": 0.0194
+        },
+        {
+          "vocab_index": 227,
+          "token": "miw_b028_q03",
+          "mean_abs_shap": 0.017081
+        },
+        {
+          "vocab_index": 2,
+          "token": "miw_b000_q02",
+          "mean_abs_shap": 0.016107
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 676,
+          "token": "miw_b084_q04",
+          "mean_abs_shap": 0.007811
+        },
+        {
+          "vocab_index": 293,
+          "token": "miw_b036_q05",
+          "mean_abs_shap": 0.003474
+        },
+        {
+          "vocab_index": 549,
+          "token": "miw_b068_q05",
+          "mean_abs_shap": 0.003448
+        },
+        {
+          "vocab_index": 1040,
+          "token": "miw_b130_q00",
+          "mean_abs_shap": 0.003059
+        },
+        {
+          "vocab_index": 801,
+          "token": "miw_b100_q01",
+          "mean_abs_shap": 0.002663
+        },
+        {
+          "vocab_index": 475,
+          "token": "miw_b059_q03",
+          "mean_abs_shap": 0.002355
+        },
+        {
+          "vocab_index": 904,
+          "token": "miw_b113_q00",
+          "mean_abs_shap": 0.002337
+        },
+        {
+          "vocab_index": 699,
+          "token": "miw_b087_q03",
+          "mean_abs_shap": 0.001905
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 558,
+          "token": "miw_b069_q06",
+          "mean_abs_shap": 520485803217.3072
+        },
+        {
+          "vocab_index": 334,
+          "token": "miw_b041_q06",
+          "mean_abs_shap": 520485803217.3041
+        },
+        {
+          "vocab_index": 77,
+          "token": "miw_b009_q05",
+          "mean_abs_shap": 0.016802
+        },
+        {
+          "vocab_index": 108,
+          "token": "miw_b013_q04",
+          "mean_abs_shap": 0.013344
+        },
+        {
+          "vocab_index": 267,
+          "token": "miw_b033_q03",
+          "mean_abs_shap": 0.012801
+        },
+        {
+          "vocab_index": 1064,
+          "token": "miw_b133_q00",
+          "mean_abs_shap": 0.0116
+        },
+        {
+          "vocab_index": 126,
+          "token": "miw_b015_q06",
+          "mean_abs_shap": 0.009284
+        },
+        {
+          "vocab_index": 114,
+          "token": "miw_b014_q02",
+          "mean_abs_shap": 0.008948
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 914,
+          "token": "miw_b114_q02",
+          "mean_abs_shap": 0.009144
+        },
+        {
+          "vocab_index": 518,
+          "token": "miw_b064_q06",
+          "mean_abs_shap": 0.006433
+        },
+        {
+          "vocab_index": 1073,
+          "token": "miw_b134_q01",
+          "mean_abs_shap": 0.005943
+        },
+        {
+          "vocab_index": 150,
+          "token": "miw_b018_q06",
+          "mean_abs_shap": 0.004715
+        },
+        {
+          "vocab_index": 365,
+          "token": "miw_b045_q05",
+          "mean_abs_shap": 0.004071
+        },
+        {
+          "vocab_index": 114,
+          "token": "miw_b014_q02",
+          "mean_abs_shap": 0.00386
+        },
+        {
+          "vocab_index": 10,
+          "token": "miw_b001_q02",
+          "mean_abs_shap": 0.003638
+        },
+        {
+          "vocab_index": 106,
+          "token": "miw_b013_q02",
+          "mean_abs_shap": 0.003078
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:24Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 6.41
+}

--- a/data/derived/v_sweep/f13_shap/kennedy-space-center_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/kennedy-space-center_V13_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.04968
+        },
+        {
+          "vocab_index": 34,
+          "token": "vq_m1_c02",
+          "mean_abs_shap": 0.044406
+        },
+        {
+          "vocab_index": 102,
+          "token": "vq_m3_c06",
+          "mean_abs_shap": 0.041472
+        },
+        {
+          "vocab_index": 24,
+          "token": "vq_m0_c24",
+          "mean_abs_shap": 0.035199
+        },
+        {
+          "vocab_index": 115,
+          "token": "vq_m3_c19",
+          "mean_abs_shap": 0.034694
+        },
+        {
+          "vocab_index": 74,
+          "token": "vq_m2_c10",
+          "mean_abs_shap": 0.034283
+        },
+        {
+          "vocab_index": 45,
+          "token": "vq_m1_c13",
+          "mean_abs_shap": 0.025288
+        },
+        {
+          "vocab_index": 58,
+          "token": "vq_m1_c26",
+          "mean_abs_shap": 0.020069
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 115,
+          "token": "vq_m3_c19",
+          "mean_abs_shap": 0.070801
+        },
+        {
+          "vocab_index": 24,
+          "token": "vq_m0_c24",
+          "mean_abs_shap": 0.04669
+        },
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.034468
+        },
+        {
+          "vocab_index": 34,
+          "token": "vq_m1_c02",
+          "mean_abs_shap": 0.033376
+        },
+        {
+          "vocab_index": 102,
+          "token": "vq_m3_c06",
+          "mean_abs_shap": 0.027503
+        },
+        {
+          "vocab_index": 72,
+          "token": "vq_m2_c08",
+          "mean_abs_shap": 0.023122
+        },
+        {
+          "vocab_index": 124,
+          "token": "vq_m3_c28",
+          "mean_abs_shap": 0.022374
+        },
+        {
+          "vocab_index": 118,
+          "token": "vq_m3_c22",
+          "mean_abs_shap": 0.020611
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 45,
+          "token": "vq_m1_c13",
+          "mean_abs_shap": 0.040094
+        },
+        {
+          "vocab_index": 115,
+          "token": "vq_m3_c19",
+          "mean_abs_shap": 0.030241
+        },
+        {
+          "vocab_index": 44,
+          "token": "vq_m1_c12",
+          "mean_abs_shap": 0.026891
+        },
+        {
+          "vocab_index": 78,
+          "token": "vq_m2_c14",
+          "mean_abs_shap": 0.026146
+        },
+        {
+          "vocab_index": 102,
+          "token": "vq_m3_c06",
+          "mean_abs_shap": 0.023177
+        },
+        {
+          "vocab_index": 27,
+          "token": "vq_m0_c27",
+          "mean_abs_shap": 0.018628
+        },
+        {
+          "vocab_index": 91,
+          "token": "vq_m2_c27",
+          "mean_abs_shap": 0.017976
+        },
+        {
+          "vocab_index": 72,
+          "token": "vq_m2_c08",
+          "mean_abs_shap": 0.01662
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:00Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.72
+}

--- a/data/derived/v_sweep/f13_shap/kennedy-space-center_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/kennedy-space-center_V14_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1024,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 906,
+          "token": "cwt_s14_p1_q02",
+          "mean_abs_shap": 0.022584
+        },
+        {
+          "vocab_index": 809,
+          "token": "cwt_s12_p5_q01",
+          "mean_abs_shap": 0.020937
+        },
+        {
+          "vocab_index": 859,
+          "token": "cwt_s13_p3_q03",
+          "mean_abs_shap": 0.018751
+        },
+        {
+          "vocab_index": 923,
+          "token": "cwt_s14_p3_q03",
+          "mean_abs_shap": 0.015966
+        },
+        {
+          "vocab_index": 1007,
+          "token": "cwt_s15_p5_q07",
+          "mean_abs_shap": 0.009943
+        },
+        {
+          "vocab_index": 961,
+          "token": "cwt_s15_p0_q01",
+          "mean_abs_shap": 0.009147
+        },
+        {
+          "vocab_index": 947,
+          "token": "cwt_s14_p6_q03",
+          "mean_abs_shap": 0.00511
+        },
+        {
+          "vocab_index": 842,
+          "token": "cwt_s13_p1_q02",
+          "mean_abs_shap": 0.004287
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 851,
+          "token": "cwt_s13_p2_q03",
+          "mean_abs_shap": 0.010589
+        },
+        {
+          "vocab_index": 967,
+          "token": "cwt_s15_p0_q07",
+          "mean_abs_shap": 0.00948
+        },
+        {
+          "vocab_index": 991,
+          "token": "cwt_s15_p3_q07",
+          "mean_abs_shap": 0.008324
+        },
+        {
+          "vocab_index": 866,
+          "token": "cwt_s13_p4_q02",
+          "mean_abs_shap": 0.007119
+        },
+        {
+          "vocab_index": 850,
+          "token": "cwt_s13_p2_q02",
+          "mean_abs_shap": 0.006879
+        },
+        {
+          "vocab_index": 916,
+          "token": "cwt_s14_p2_q04",
+          "mean_abs_shap": 0.006832
+        },
+        {
+          "vocab_index": 722,
+          "token": "cwt_s11_p2_q02",
+          "mean_abs_shap": 0.005566
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.005312
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 697,
+          "token": "cwt_s10_p7_q01",
+          "mean_abs_shap": 0.01176
+        },
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 0.010986
+        },
+        {
+          "vocab_index": 838,
+          "token": "cwt_s13_p0_q06",
+          "mean_abs_shap": 0.00636
+        },
+        {
+          "vocab_index": 917,
+          "token": "cwt_s14_p2_q05",
+          "mean_abs_shap": 0.002808
+        },
+        {
+          "vocab_index": 932,
+          "token": "cwt_s14_p4_q04",
+          "mean_abs_shap": 0.002806
+        },
+        {
+          "vocab_index": 916,
+          "token": "cwt_s14_p2_q04",
+          "mean_abs_shap": 0.002363
+        },
+        {
+          "vocab_index": 946,
+          "token": "cwt_s14_p6_q02",
+          "mean_abs_shap": 0.002316
+        },
+        {
+          "vocab_index": 929,
+          "token": "cwt_s14_p4_q01",
+          "mean_abs_shap": 0.001865
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 967,
+          "token": "cwt_s15_p0_q07",
+          "mean_abs_shap": 0.003042
+        },
+        {
+          "vocab_index": 913,
+          "token": "cwt_s14_p2_q01",
+          "mean_abs_shap": 0.002113
+        },
+        {
+          "vocab_index": 932,
+          "token": "cwt_s14_p4_q04",
+          "mean_abs_shap": 0.001926
+        },
+        {
+          "vocab_index": 817,
+          "token": "cwt_s12_p6_q01",
+          "mean_abs_shap": 0.001737
+        },
+        {
+          "vocab_index": 1006,
+          "token": "cwt_s15_p5_q06",
+          "mean_abs_shap": 0.00163
+        },
+        {
+          "vocab_index": 930,
+          "token": "cwt_s14_p4_q02",
+          "mean_abs_shap": 0.001625
+        },
+        {
+          "vocab_index": 1007,
+          "token": "cwt_s15_p5_q07",
+          "mean_abs_shap": 0.001618
+        },
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 0.001548
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 967,
+          "token": "cwt_s15_p0_q07",
+          "mean_abs_shap": 0.000966
+        },
+        {
+          "vocab_index": 932,
+          "token": "cwt_s14_p4_q04",
+          "mean_abs_shap": 0.000908
+        },
+        {
+          "vocab_index": 715,
+          "token": "cwt_s11_p1_q03",
+          "mean_abs_shap": 0.000728
+        },
+        {
+          "vocab_index": 1007,
+          "token": "cwt_s15_p5_q07",
+          "mean_abs_shap": 0.000688
+        },
+        {
+          "vocab_index": 980,
+          "token": "cwt_s15_p2_q04",
+          "mean_abs_shap": 0.000634
+        },
+        {
+          "vocab_index": 810,
+          "token": "cwt_s12_p5_q02",
+          "mean_abs_shap": 0.000585
+        },
+        {
+          "vocab_index": 801,
+          "token": "cwt_s12_p4_q01",
+          "mean_abs_shap": 0.000556
+        },
+        {
+          "vocab_index": 737,
+          "token": "cwt_s11_p4_q01",
+          "mean_abs_shap": 0.000526
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 801,
+          "token": "cwt_s12_p4_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 810,
+          "token": "cwt_s12_p5_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 969,
+          "token": "cwt_s15_p1_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 930,
+          "token": "cwt_s14_p4_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 674,
+          "token": "cwt_s10_p4_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 737,
+          "token": "cwt_s11_p4_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 932,
+          "token": "cwt_s14_p4_q04",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 1007,
+          "token": "cwt_s15_p5_q07",
+          "mean_abs_shap": 0.016243
+        },
+        {
+          "vocab_index": 946,
+          "token": "cwt_s14_p6_q02",
+          "mean_abs_shap": 0.015624
+        },
+        {
+          "vocab_index": 923,
+          "token": "cwt_s14_p3_q03",
+          "mean_abs_shap": 0.00604
+        },
+        {
+          "vocab_index": 938,
+          "token": "cwt_s14_p5_q02",
+          "mean_abs_shap": 0.005697
+        },
+        {
+          "vocab_index": 990,
+          "token": "cwt_s15_p3_q06",
+          "mean_abs_shap": 0.005592
+        },
+        {
+          "vocab_index": 937,
+          "token": "cwt_s14_p5_q01",
+          "mean_abs_shap": 0.004784
+        },
+        {
+          "vocab_index": 945,
+          "token": "cwt_s14_p6_q01",
+          "mean_abs_shap": 0.003768
+        },
+        {
+          "vocab_index": 991,
+          "token": "cwt_s15_p3_q07",
+          "mean_abs_shap": 0.003764
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 1007,
+          "token": "cwt_s15_p5_q07",
+          "mean_abs_shap": 0.026466
+        },
+        {
+          "vocab_index": 983,
+          "token": "cwt_s15_p2_q07",
+          "mean_abs_shap": 0.018248
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.017773
+        },
+        {
+          "vocab_index": 971,
+          "token": "cwt_s15_p1_q03",
+          "mean_abs_shap": 0.015089
+        },
+        {
+          "vocab_index": 689,
+          "token": "cwt_s10_p6_q01",
+          "mean_abs_shap": 0.01492
+        },
+        {
+          "vocab_index": 937,
+          "token": "cwt_s14_p5_q01",
+          "mean_abs_shap": 0.013138
+        },
+        {
+          "vocab_index": 817,
+          "token": "cwt_s12_p6_q01",
+          "mean_abs_shap": 0.012766
+        },
+        {
+          "vocab_index": 938,
+          "token": "cwt_s14_p5_q02",
+          "mean_abs_shap": 0.012051
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "cwt_s00_p2_q00",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 17,
+          "token": "cwt_s00_p2_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 18,
+          "token": "cwt_s00_p2_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 19,
+          "token": "cwt_s00_p2_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 20,
+          "token": "cwt_s00_p2_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 21,
+          "token": "cwt_s00_p2_q05",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 22,
+          "token": "cwt_s00_p2_q06",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 23,
+          "token": "cwt_s00_p2_q07",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 931,
+          "token": "cwt_s14_p4_q03",
+          "mean_abs_shap": 0.012907
+        },
+        {
+          "vocab_index": 753,
+          "token": "cwt_s11_p6_q01",
+          "mean_abs_shap": 0.009913
+        },
+        {
+          "vocab_index": 916,
+          "token": "cwt_s14_p2_q04",
+          "mean_abs_shap": 0.008124
+        },
+        {
+          "vocab_index": 825,
+          "token": "cwt_s12_p7_q01",
+          "mean_abs_shap": 0.007989
+        },
+        {
+          "vocab_index": 890,
+          "token": "cwt_s13_p7_q02",
+          "mean_abs_shap": 0.00671
+        },
+        {
+          "vocab_index": 674,
+          "token": "cwt_s10_p4_q02",
+          "mean_abs_shap": 0.006632
+        },
+        {
+          "vocab_index": 633,
+          "token": "cwt_s09_p7_q01",
+          "mean_abs_shap": 0.006561
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 0.005616
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.013213
+        },
+        {
+          "vocab_index": 938,
+          "token": "cwt_s14_p5_q02",
+          "mean_abs_shap": 0.010958
+        },
+        {
+          "vocab_index": 945,
+          "token": "cwt_s14_p6_q01",
+          "mean_abs_shap": 0.005414
+        },
+        {
+          "vocab_index": 714,
+          "token": "cwt_s11_p1_q02",
+          "mean_abs_shap": 0.004593
+        },
+        {
+          "vocab_index": 715,
+          "token": "cwt_s11_p1_q03",
+          "mean_abs_shap": 0.00433
+        },
+        {
+          "vocab_index": 1003,
+          "token": "cwt_s15_p5_q03",
+          "mean_abs_shap": 0.004307
+        },
+        {
+          "vocab_index": 937,
+          "token": "cwt_s14_p5_q01",
+          "mean_abs_shap": 0.00268
+        },
+        {
+          "vocab_index": 1009,
+          "token": "cwt_s15_p6_q01",
+          "mean_abs_shap": 0.002493
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 971,
+          "token": "cwt_s15_p1_q03",
+          "mean_abs_shap": 0.015636
+        },
+        {
+          "vocab_index": 689,
+          "token": "cwt_s10_p6_q01",
+          "mean_abs_shap": 0.015112
+        },
+        {
+          "vocab_index": 983,
+          "token": "cwt_s15_p2_q07",
+          "mean_abs_shap": 0.013534
+        },
+        {
+          "vocab_index": 809,
+          "token": "cwt_s12_p5_q01",
+          "mean_abs_shap": 0.01306
+        },
+        {
+          "vocab_index": 817,
+          "token": "cwt_s12_p6_q01",
+          "mean_abs_shap": 0.012722
+        },
+        {
+          "vocab_index": 753,
+          "token": "cwt_s11_p6_q01",
+          "mean_abs_shap": 0.01202
+        },
+        {
+          "vocab_index": 967,
+          "token": "cwt_s15_p0_q07",
+          "mean_abs_shap": 0.010959
+        },
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.010384
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:02Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 2.01
+}

--- a/data/derived/v_sweep/f13_shap/kennedy-space-center_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/kennedy-space-center_V15_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 48,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 6,
+          "token": "EVI_q06",
+          "mean_abs_shap": 0.014819
+        },
+        {
+          "vocab_index": 44,
+          "token": "SAVI_q04",
+          "mean_abs_shap": 0.007117
+        },
+        {
+          "vocab_index": 7,
+          "token": "EVI_q07",
+          "mean_abs_shap": 0.006729
+        },
+        {
+          "vocab_index": 15,
+          "token": "MNDWI_q07",
+          "mean_abs_shap": 0.006552
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.00519
+        },
+        {
+          "vocab_index": 14,
+          "token": "MNDWI_q06",
+          "mean_abs_shap": 0.004382
+        },
+        {
+          "vocab_index": 30,
+          "token": "NDSI_q06",
+          "mean_abs_shap": 0.004286
+        },
+        {
+          "vocab_index": 36,
+          "token": "NDVI_q04",
+          "mean_abs_shap": 0.003379
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 47,
+          "token": "SAVI_q07",
+          "mean_abs_shap": 0.040071
+        },
+        {
+          "vocab_index": 39,
+          "token": "NDVI_q07",
+          "mean_abs_shap": 0.03301
+        },
+        {
+          "vocab_index": 7,
+          "token": "EVI_q07",
+          "mean_abs_shap": 0.028802
+        },
+        {
+          "vocab_index": 6,
+          "token": "EVI_q06",
+          "mean_abs_shap": 0.025785
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.022965
+        },
+        {
+          "vocab_index": 23,
+          "token": "NBR_q07",
+          "mean_abs_shap": 0.022685
+        },
+        {
+          "vocab_index": 45,
+          "token": "SAVI_q05",
+          "mean_abs_shap": 0.022628
+        },
+        {
+          "vocab_index": 8,
+          "token": "MNDWI_q00",
+          "mean_abs_shap": 0.022555
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 47,
+          "token": "SAVI_q07",
+          "mean_abs_shap": 0.037268
+        },
+        {
+          "vocab_index": 39,
+          "token": "NDVI_q07",
+          "mean_abs_shap": 0.033531
+        },
+        {
+          "vocab_index": 6,
+          "token": "EVI_q06",
+          "mean_abs_shap": 0.029639
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.024999
+        },
+        {
+          "vocab_index": 44,
+          "token": "SAVI_q04",
+          "mean_abs_shap": 0.023917
+        },
+        {
+          "vocab_index": 22,
+          "token": "NBR_q06",
+          "mean_abs_shap": 0.022782
+        },
+        {
+          "vocab_index": 37,
+          "token": "NDVI_q05",
+          "mean_abs_shap": 0.022726
+        },
+        {
+          "vocab_index": 7,
+          "token": "EVI_q07",
+          "mean_abs_shap": 0.022664
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:02Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.26
+}

--- a/data/derived/v_sweep/f13_shap/kennedy-space-center_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/kennedy-space-center_V17_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 512,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 114,
+          "token": "atom_a014_q02",
+          "mean_abs_shap": 0.014511
+        },
+        {
+          "vocab_index": 89,
+          "token": "atom_a011_q01",
+          "mean_abs_shap": 0.011848
+        },
+        {
+          "vocab_index": 504,
+          "token": "atom_a063_q00",
+          "mean_abs_shap": 0.010909
+        },
+        {
+          "vocab_index": 104,
+          "token": "atom_a013_q00",
+          "mean_abs_shap": 0.010433
+        },
+        {
+          "vocab_index": 489,
+          "token": "atom_a061_q01",
+          "mean_abs_shap": 0.010122
+        },
+        {
+          "vocab_index": 344,
+          "token": "atom_a043_q00",
+          "mean_abs_shap": 0.009744
+        },
+        {
+          "vocab_index": 203,
+          "token": "atom_a025_q03",
+          "mean_abs_shap": 0.009365
+        },
+        {
+          "vocab_index": 454,
+          "token": "atom_a056_q06",
+          "mean_abs_shap": 0.008851
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 344,
+          "token": "atom_a043_q00",
+          "mean_abs_shap": 0.014367
+        },
+        {
+          "vocab_index": 489,
+          "token": "atom_a061_q01",
+          "mean_abs_shap": 0.013224
+        },
+        {
+          "vocab_index": 196,
+          "token": "atom_a024_q04",
+          "mean_abs_shap": 0.012415
+        },
+        {
+          "vocab_index": 376,
+          "token": "atom_a047_q00",
+          "mean_abs_shap": 0.012062
+        },
+        {
+          "vocab_index": 192,
+          "token": "atom_a024_q00",
+          "mean_abs_shap": 0.011804
+        },
+        {
+          "vocab_index": 257,
+          "token": "atom_a032_q01",
+          "mean_abs_shap": 0.011089
+        },
+        {
+          "vocab_index": 400,
+          "token": "atom_a050_q00",
+          "mean_abs_shap": 0.011015
+        },
+        {
+          "vocab_index": 263,
+          "token": "atom_a032_q07",
+          "mean_abs_shap": 0.010371
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 203,
+          "token": "atom_a025_q03",
+          "mean_abs_shap": 0.01631
+        },
+        {
+          "vocab_index": 489,
+          "token": "atom_a061_q01",
+          "mean_abs_shap": 0.012107
+        },
+        {
+          "vocab_index": 492,
+          "token": "atom_a061_q04",
+          "mean_abs_shap": 0.011372
+        },
+        {
+          "vocab_index": 85,
+          "token": "atom_a010_q05",
+          "mean_abs_shap": 0.011338
+        },
+        {
+          "vocab_index": 445,
+          "token": "atom_a055_q05",
+          "mean_abs_shap": 0.010761
+        },
+        {
+          "vocab_index": 217,
+          "token": "atom_a027_q01",
+          "mean_abs_shap": 0.010656
+        },
+        {
+          "vocab_index": 483,
+          "token": "atom_a060_q03",
+          "mean_abs_shap": 0.010109
+        },
+        {
+          "vocab_index": 162,
+          "token": "atom_a020_q02",
+          "mean_abs_shap": 0.01003
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:03Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.8
+}

--- a/data/derived/v_sweep/f13_shap/kennedy-space-center_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/kennedy-space-center_V18_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 35,
+          "token": "lap_e04_q03",
+          "mean_abs_shap": 0.04503
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.044859
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.040147
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.021128
+        },
+        {
+          "vocab_index": 34,
+          "token": "lap_e04_q02",
+          "mean_abs_shap": 0.020241
+        },
+        {
+          "vocab_index": 51,
+          "token": "lap_e06_q03",
+          "mean_abs_shap": 0.019938
+        },
+        {
+          "vocab_index": 52,
+          "token": "lap_e06_q04",
+          "mean_abs_shap": 0.014326
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.013295
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 33,
+          "token": "lap_e04_q01",
+          "mean_abs_shap": 0.019041
+        },
+        {
+          "vocab_index": 49,
+          "token": "lap_e06_q01",
+          "mean_abs_shap": 0.017302
+        },
+        {
+          "vocab_index": 22,
+          "token": "lap_e02_q06",
+          "mean_abs_shap": 0.014134
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.011372
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.010402
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.009278
+        },
+        {
+          "vocab_index": 41,
+          "token": "lap_e05_q01",
+          "mean_abs_shap": 0.00909
+        },
+        {
+          "vocab_index": 3,
+          "token": "lap_e00_q03",
+          "mean_abs_shap": 0.008981
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 62,
+          "token": "lap_e07_q06",
+          "mean_abs_shap": 0.005456
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.002602
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.002227
+        },
+        {
+          "vocab_index": 105,
+          "token": "lap_e13_q01",
+          "mean_abs_shap": 0.00187
+        },
+        {
+          "vocab_index": 3,
+          "token": "lap_e00_q03",
+          "mean_abs_shap": 0.001824
+        },
+        {
+          "vocab_index": 2,
+          "token": "lap_e00_q02",
+          "mean_abs_shap": 0.001728
+        },
+        {
+          "vocab_index": 34,
+          "token": "lap_e04_q02",
+          "mean_abs_shap": 0.001121
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.001121
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.000864
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.000711
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.000668
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.000634
+        },
+        {
+          "vocab_index": 34,
+          "token": "lap_e04_q02",
+          "mean_abs_shap": 0.000628
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.000614
+        },
+        {
+          "vocab_index": 110,
+          "token": "lap_e13_q06",
+          "mean_abs_shap": 0.000581
+        },
+        {
+          "vocab_index": 35,
+          "token": "lap_e04_q03",
+          "mean_abs_shap": 0.000543
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 34,
+          "token": "lap_e04_q02",
+          "mean_abs_shap": 0.041266
+        },
+        {
+          "vocab_index": 50,
+          "token": "lap_e06_q02",
+          "mean_abs_shap": 0.03375
+        },
+        {
+          "vocab_index": 21,
+          "token": "lap_e02_q05",
+          "mean_abs_shap": 0.023743
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.022421
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.021784
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.021732
+        },
+        {
+          "vocab_index": 35,
+          "token": "lap_e04_q03",
+          "mean_abs_shap": 0.017771
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.014925
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 111,
+          "token": "lap_e13_q07",
+          "mean_abs_shap": 0.012898
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.01163
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.003524
+        },
+        {
+          "vocab_index": 39,
+          "token": "lap_e04_q07",
+          "mean_abs_shap": 0.00303
+        },
+        {
+          "vocab_index": 3,
+          "token": "lap_e00_q03",
+          "mean_abs_shap": 0.002918
+        },
+        {
+          "vocab_index": 43,
+          "token": "lap_e05_q03",
+          "mean_abs_shap": 0.002648
+        },
+        {
+          "vocab_index": 35,
+          "token": "lap_e04_q03",
+          "mean_abs_shap": 0.002607
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.002243
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 39,
+          "token": "lap_e04_q07",
+          "mean_abs_shap": 0.007401
+        },
+        {
+          "vocab_index": 47,
+          "token": "lap_e05_q07",
+          "mean_abs_shap": 0.007107
+        },
+        {
+          "vocab_index": 64,
+          "token": "lap_e08_q00",
+          "mean_abs_shap": 0.006832
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.005772
+        },
+        {
+          "vocab_index": 46,
+          "token": "lap_e05_q06",
+          "mean_abs_shap": 0.005069
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.004782
+        },
+        {
+          "vocab_index": 66,
+          "token": "lap_e08_q02",
+          "mean_abs_shap": 0.004697
+        },
+        {
+          "vocab_index": 3,
+          "token": "lap_e00_q03",
+          "mean_abs_shap": 0.00374
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 110,
+          "token": "lap_e13_q06",
+          "mean_abs_shap": 0.003282
+        },
+        {
+          "vocab_index": 43,
+          "token": "lap_e05_q03",
+          "mean_abs_shap": 0.002632
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.002515
+        },
+        {
+          "vocab_index": 2,
+          "token": "lap_e00_q02",
+          "mean_abs_shap": 0.002445
+        },
+        {
+          "vocab_index": 72,
+          "token": "lap_e09_q00",
+          "mean_abs_shap": 0.00241
+        },
+        {
+          "vocab_index": 35,
+          "token": "lap_e04_q03",
+          "mean_abs_shap": 0.002176
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.001984
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.001655
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 44,
+          "token": "lap_e05_q04",
+          "mean_abs_shap": 0.000936
+        },
+        {
+          "vocab_index": 18,
+          "token": "lap_e02_q02",
+          "mean_abs_shap": 0.000867
+        },
+        {
+          "vocab_index": 2,
+          "token": "lap_e00_q02",
+          "mean_abs_shap": 0.000846
+        },
+        {
+          "vocab_index": 37,
+          "token": "lap_e04_q05",
+          "mean_abs_shap": 0.000649
+        },
+        {
+          "vocab_index": 53,
+          "token": "lap_e06_q05",
+          "mean_abs_shap": 0.000637
+        },
+        {
+          "vocab_index": 52,
+          "token": "lap_e06_q04",
+          "mean_abs_shap": 0.00059
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.000515
+        },
+        {
+          "vocab_index": 43,
+          "token": "lap_e05_q03",
+          "mean_abs_shap": 0.000498
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.001287
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.001124
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.001105
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.001104
+        },
+        {
+          "vocab_index": 4,
+          "token": "lap_e00_q04",
+          "mean_abs_shap": 0.001021
+        },
+        {
+          "vocab_index": 110,
+          "token": "lap_e13_q06",
+          "mean_abs_shap": 0.000965
+        },
+        {
+          "vocab_index": 35,
+          "token": "lap_e04_q03",
+          "mean_abs_shap": 0.00088
+        },
+        {
+          "vocab_index": 41,
+          "token": "lap_e05_q01",
+          "mean_abs_shap": 0.000869
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 39,
+          "token": "lap_e04_q07",
+          "mean_abs_shap": 0.026735
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.021667
+        },
+        {
+          "vocab_index": 46,
+          "token": "lap_e05_q06",
+          "mean_abs_shap": 0.021369
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.016506
+        },
+        {
+          "vocab_index": 52,
+          "token": "lap_e06_q04",
+          "mean_abs_shap": 0.015407
+        },
+        {
+          "vocab_index": 21,
+          "token": "lap_e02_q05",
+          "mean_abs_shap": 0.014663
+        },
+        {
+          "vocab_index": 55,
+          "token": "lap_e06_q07",
+          "mean_abs_shap": 0.014344
+        },
+        {
+          "vocab_index": 110,
+          "token": "lap_e13_q06",
+          "mean_abs_shap": 0.013926
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 52,
+          "token": "lap_e06_q04",
+          "mean_abs_shap": 0.02334
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.022088
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.019876
+        },
+        {
+          "vocab_index": 3,
+          "token": "lap_e00_q03",
+          "mean_abs_shap": 0.017492
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.017264
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.016389
+        },
+        {
+          "vocab_index": 35,
+          "token": "lap_e04_q03",
+          "mean_abs_shap": 0.014543
+        },
+        {
+          "vocab_index": 44,
+          "token": "lap_e05_q04",
+          "mean_abs_shap": 0.014138
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:04Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.89
+}

--- a/data/derived/v_sweep/f13_shap/kennedy-space-center_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/kennedy-space-center_V19_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 24,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.079738
+        },
+        {
+          "vocab_index": 18,
+          "token": "umap_d2_q02",
+          "mean_abs_shap": 0.066139
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.065818
+        },
+        {
+          "vocab_index": 10,
+          "token": "umap_d1_q02",
+          "mean_abs_shap": 0.059314
+        },
+        {
+          "vocab_index": 15,
+          "token": "umap_d1_q07",
+          "mean_abs_shap": 0.052512
+        },
+        {
+          "vocab_index": 14,
+          "token": "umap_d1_q06",
+          "mean_abs_shap": 0.045657
+        },
+        {
+          "vocab_index": 3,
+          "token": "umap_d0_q03",
+          "mean_abs_shap": 0.039817
+        },
+        {
+          "vocab_index": 17,
+          "token": "umap_d2_q01",
+          "mean_abs_shap": 0.037349
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 14,
+          "token": "umap_d1_q06",
+          "mean_abs_shap": 0.125755
+        },
+        {
+          "vocab_index": 17,
+          "token": "umap_d2_q01",
+          "mean_abs_shap": 0.084972
+        },
+        {
+          "vocab_index": 4,
+          "token": "umap_d0_q04",
+          "mean_abs_shap": 0.062491
+        },
+        {
+          "vocab_index": 21,
+          "token": "umap_d2_q05",
+          "mean_abs_shap": 0.060748
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.032631
+        },
+        {
+          "vocab_index": 3,
+          "token": "umap_d0_q03",
+          "mean_abs_shap": 0.031781
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.03159
+        },
+        {
+          "vocab_index": 16,
+          "token": "umap_d2_q00",
+          "mean_abs_shap": 0.031373
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.098883
+        },
+        {
+          "vocab_index": 21,
+          "token": "umap_d2_q05",
+          "mean_abs_shap": 0.090107
+        },
+        {
+          "vocab_index": 14,
+          "token": "umap_d1_q06",
+          "mean_abs_shap": 0.07388
+        },
+        {
+          "vocab_index": 18,
+          "token": "umap_d2_q02",
+          "mean_abs_shap": 0.070308
+        },
+        {
+          "vocab_index": 4,
+          "token": "umap_d0_q04",
+          "mean_abs_shap": 0.054157
+        },
+        {
+          "vocab_index": 16,
+          "token": "umap_d2_q00",
+          "mean_abs_shap": 0.053943
+        },
+        {
+          "vocab_index": 17,
+          "token": "umap_d2_q01",
+          "mean_abs_shap": 0.048836
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.047384
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:04Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.25
+}

--- a/data/derived/v_sweep/f13_shap/kennedy-space-center_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/kennedy-space-center_V20_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1408,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 129,
+          "token": "miw_b016_q01",
+          "mean_abs_shap": 0.017924
+        },
+        {
+          "vocab_index": 96,
+          "token": "miw_b012_q00",
+          "mean_abs_shap": 0.014766
+        },
+        {
+          "vocab_index": 104,
+          "token": "miw_b013_q00",
+          "mean_abs_shap": 0.014692
+        },
+        {
+          "vocab_index": 177,
+          "token": "miw_b022_q01",
+          "mean_abs_shap": 0.011226
+        },
+        {
+          "vocab_index": 144,
+          "token": "miw_b018_q00",
+          "mean_abs_shap": 0.009343
+        },
+        {
+          "vocab_index": 1403,
+          "token": "miw_b175_q03",
+          "mean_abs_shap": 0.008806
+        },
+        {
+          "vocab_index": 654,
+          "token": "miw_b081_q06",
+          "mean_abs_shap": 0.008458
+        },
+        {
+          "vocab_index": 48,
+          "token": "miw_b006_q00",
+          "mean_abs_shap": 0.008
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 136,
+          "token": "miw_b017_q00",
+          "mean_abs_shap": 0.009656
+        },
+        {
+          "vocab_index": 299,
+          "token": "miw_b037_q03",
+          "mean_abs_shap": 0.00854
+        },
+        {
+          "vocab_index": 128,
+          "token": "miw_b016_q00",
+          "mean_abs_shap": 0.006622
+        },
+        {
+          "vocab_index": 526,
+          "token": "miw_b065_q06",
+          "mean_abs_shap": 0.006354
+        },
+        {
+          "vocab_index": 803,
+          "token": "miw_b100_q03",
+          "mean_abs_shap": 0.006037
+        },
+        {
+          "vocab_index": 324,
+          "token": "miw_b040_q04",
+          "mean_abs_shap": 0.006037
+        },
+        {
+          "vocab_index": 9,
+          "token": "miw_b001_q01",
+          "mean_abs_shap": 0.005969
+        },
+        {
+          "vocab_index": 224,
+          "token": "miw_b028_q00",
+          "mean_abs_shap": 0.005913
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 1104,
+          "token": "miw_b138_q00",
+          "mean_abs_shap": 63122.165075
+        },
+        {
+          "vocab_index": 615,
+          "token": "miw_b076_q07",
+          "mean_abs_shap": 63122.165046
+        },
+        {
+          "vocab_index": 129,
+          "token": "miw_b016_q01",
+          "mean_abs_shap": 0.015841
+        },
+        {
+          "vocab_index": 323,
+          "token": "miw_b040_q03",
+          "mean_abs_shap": 0.015346
+        },
+        {
+          "vocab_index": 96,
+          "token": "miw_b012_q00",
+          "mean_abs_shap": 0.014267
+        },
+        {
+          "vocab_index": 258,
+          "token": "miw_b032_q02",
+          "mean_abs_shap": 0.0132
+        },
+        {
+          "vocab_index": 81,
+          "token": "miw_b010_q01",
+          "mean_abs_shap": 0.011198
+        },
+        {
+          "vocab_index": 518,
+          "token": "miw_b064_q06",
+          "mean_abs_shap": 0.010527
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 53,
+          "token": "miw_b006_q05",
+          "mean_abs_shap": 0.02288
+        },
+        {
+          "vocab_index": 240,
+          "token": "miw_b030_q00",
+          "mean_abs_shap": 0.008
+        },
+        {
+          "vocab_index": 341,
+          "token": "miw_b042_q05",
+          "mean_abs_shap": 0.00504
+        },
+        {
+          "vocab_index": 129,
+          "token": "miw_b016_q01",
+          "mean_abs_shap": 0.00328
+        },
+        {
+          "vocab_index": 415,
+          "token": "miw_b051_q07",
+          "mean_abs_shap": 0.00176
+        },
+        {
+          "vocab_index": 667,
+          "token": "miw_b083_q03",
+          "mean_abs_shap": 0.00136
+        },
+        {
+          "vocab_index": 259,
+          "token": "miw_b032_q03",
+          "mean_abs_shap": 0.0004
+        },
+        {
+          "vocab_index": 451,
+          "token": "miw_b056_q03",
+          "mean_abs_shap": 0.0004
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 340,
+          "token": "miw_b042_q04",
+          "mean_abs_shap": 0.01
+        },
+        {
+          "vocab_index": 390,
+          "token": "miw_b048_q06",
+          "mean_abs_shap": 0.005997
+        },
+        {
+          "vocab_index": 282,
+          "token": "miw_b035_q02",
+          "mean_abs_shap": 0.005997
+        },
+        {
+          "vocab_index": 1289,
+          "token": "miw_b161_q01",
+          "mean_abs_shap": 0.005992
+        },
+        {
+          "vocab_index": 1023,
+          "token": "miw_b127_q07",
+          "mean_abs_shap": 0.004797
+        },
+        {
+          "vocab_index": 121,
+          "token": "miw_b015_q01",
+          "mean_abs_shap": 0.001612
+        },
+        {
+          "vocab_index": 1403,
+          "token": "miw_b175_q03",
+          "mean_abs_shap": 0.001318
+        },
+        {
+          "vocab_index": 767,
+          "token": "miw_b095_q07",
+          "mean_abs_shap": 0.0012
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 186,
+          "token": "miw_b023_q02",
+          "mean_abs_shap": 0.028
+        },
+        {
+          "vocab_index": 145,
+          "token": "miw_b018_q01",
+          "mean_abs_shap": 0.0168
+        },
+        {
+          "vocab_index": 405,
+          "token": "miw_b050_q05",
+          "mean_abs_shap": 0.014499
+        },
+        {
+          "vocab_index": 81,
+          "token": "miw_b010_q01",
+          "mean_abs_shap": 0.0144
+        },
+        {
+          "vocab_index": 121,
+          "token": "miw_b015_q01",
+          "mean_abs_shap": 0.011
+        },
+        {
+          "vocab_index": 128,
+          "token": "miw_b016_q00",
+          "mean_abs_shap": 0.0108
+        },
+        {
+          "vocab_index": 1402,
+          "token": "miw_b175_q02",
+          "mean_abs_shap": 0.0096
+        },
+        {
+          "vocab_index": 144,
+          "token": "miw_b018_q00",
+          "mean_abs_shap": 0.0096
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "miw_b002_q00",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 18,
+          "token": "miw_b002_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 19,
+          "token": "miw_b002_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 20,
+          "token": "miw_b002_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 21,
+          "token": "miw_b002_q05",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 22,
+          "token": "miw_b002_q06",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 23,
+          "token": "miw_b002_q07",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 81,
+          "token": "miw_b010_q01",
+          "mean_abs_shap": 0.015487
+        },
+        {
+          "vocab_index": 72,
+          "token": "miw_b009_q00",
+          "mean_abs_shap": 0.012849
+        },
+        {
+          "vocab_index": 144,
+          "token": "miw_b018_q00",
+          "mean_abs_shap": 0.009399
+        },
+        {
+          "vocab_index": 184,
+          "token": "miw_b023_q00",
+          "mean_abs_shap": 0.007425
+        },
+        {
+          "vocab_index": 104,
+          "token": "miw_b013_q00",
+          "mean_abs_shap": 0.007376
+        },
+        {
+          "vocab_index": 153,
+          "token": "miw_b019_q01",
+          "mean_abs_shap": 0.007353
+        },
+        {
+          "vocab_index": 241,
+          "token": "miw_b030_q01",
+          "mean_abs_shap": 0.00666
+        },
+        {
+          "vocab_index": 446,
+          "token": "miw_b055_q06",
+          "mean_abs_shap": 0.005738
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 1402,
+          "token": "miw_b175_q02",
+          "mean_abs_shap": 356967260465375.5
+        },
+        {
+          "vocab_index": 510,
+          "token": "miw_b063_q06",
+          "mean_abs_shap": 356967260465375.5
+        },
+        {
+          "vocab_index": 399,
+          "token": "miw_b049_q07",
+          "mean_abs_shap": 356967260465375.5
+        },
+        {
+          "vocab_index": 1401,
+          "token": "miw_b175_q01",
+          "mean_abs_shap": 356967260465375.44
+        },
+        {
+          "vocab_index": 366,
+          "token": "miw_b045_q06",
+          "mean_abs_shap": 0.09
+        },
+        {
+          "vocab_index": 128,
+          "token": "miw_b016_q00",
+          "mean_abs_shap": 0.016421
+        },
+        {
+          "vocab_index": 9,
+          "token": "miw_b001_q01",
+          "mean_abs_shap": 0.013696
+        },
+        {
+          "vocab_index": 104,
+          "token": "miw_b013_q00",
+          "mean_abs_shap": 0.013265
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 828,
+          "token": "miw_b103_q04",
+          "mean_abs_shap": 1.159581
+        },
+        {
+          "vocab_index": 241,
+          "token": "miw_b030_q01",
+          "mean_abs_shap": 1.159106
+        },
+        {
+          "vocab_index": 365,
+          "token": "miw_b045_q05",
+          "mean_abs_shap": 0.007218
+        },
+        {
+          "vocab_index": 484,
+          "token": "miw_b060_q04",
+          "mean_abs_shap": 0.0052
+        },
+        {
+          "vocab_index": 177,
+          "token": "miw_b022_q01",
+          "mean_abs_shap": 0.0052
+        },
+        {
+          "vocab_index": 1376,
+          "token": "miw_b172_q00",
+          "mean_abs_shap": 0.003374
+        },
+        {
+          "vocab_index": 574,
+          "token": "miw_b071_q06",
+          "mean_abs_shap": 0.003218
+        },
+        {
+          "vocab_index": 715,
+          "token": "miw_b089_q03",
+          "mean_abs_shap": 0.002726
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 381,
+          "token": "miw_b047_q05",
+          "mean_abs_shap": 645938657115.5856
+        },
+        {
+          "vocab_index": 452,
+          "token": "miw_b056_q04",
+          "mean_abs_shap": 645938657115.5856
+        },
+        {
+          "vocab_index": 11,
+          "token": "miw_b001_q03",
+          "mean_abs_shap": 0.0172
+        },
+        {
+          "vocab_index": 128,
+          "token": "miw_b016_q00",
+          "mean_abs_shap": 0.0168
+        },
+        {
+          "vocab_index": 323,
+          "token": "miw_b040_q03",
+          "mean_abs_shap": 0.015795
+        },
+        {
+          "vocab_index": 96,
+          "token": "miw_b012_q00",
+          "mean_abs_shap": 0.010504
+        },
+        {
+          "vocab_index": 41,
+          "token": "miw_b005_q01",
+          "mean_abs_shap": 0.01045
+        },
+        {
+          "vocab_index": 32,
+          "token": "miw_b004_q00",
+          "mean_abs_shap": 0.01032
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 128,
+          "token": "miw_b016_q00",
+          "mean_abs_shap": 3559316480759.0737
+        },
+        {
+          "vocab_index": 185,
+          "token": "miw_b023_q01",
+          "mean_abs_shap": 3559316480759.072
+        },
+        {
+          "vocab_index": 73,
+          "token": "miw_b009_q01",
+          "mean_abs_shap": 0.017949
+        },
+        {
+          "vocab_index": 339,
+          "token": "miw_b042_q03",
+          "mean_abs_shap": 0.014898
+        },
+        {
+          "vocab_index": 300,
+          "token": "miw_b037_q04",
+          "mean_abs_shap": 0.006602
+        },
+        {
+          "vocab_index": 234,
+          "token": "miw_b029_q02",
+          "mean_abs_shap": 0.005202
+        },
+        {
+          "vocab_index": 129,
+          "token": "miw_b016_q01",
+          "mean_abs_shap": 0.003651
+        },
+        {
+          "vocab_index": 390,
+          "token": "miw_b048_q06",
+          "mean_abs_shap": 0.003419
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:04:11Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 6.45
+}

--- a/data/derived/v_sweep/f13_shap/pavia-university_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/pavia-university_V13_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 71,
+          "token": "vq_m2_c07",
+          "mean_abs_shap": 0.052918
+        },
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.02569
+        },
+        {
+          "vocab_index": 82,
+          "token": "vq_m2_c18",
+          "mean_abs_shap": 0.023827
+        },
+        {
+          "vocab_index": 40,
+          "token": "vq_m1_c08",
+          "mean_abs_shap": 0.022855
+        },
+        {
+          "vocab_index": 112,
+          "token": "vq_m3_c16",
+          "mean_abs_shap": 0.02194
+        },
+        {
+          "vocab_index": 62,
+          "token": "vq_m1_c30",
+          "mean_abs_shap": 0.020639
+        },
+        {
+          "vocab_index": 38,
+          "token": "vq_m1_c06",
+          "mean_abs_shap": 0.019982
+        },
+        {
+          "vocab_index": 125,
+          "token": "vq_m3_c29",
+          "mean_abs_shap": 0.017948
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 40,
+          "token": "vq_m1_c08",
+          "mean_abs_shap": 0.036305
+        },
+        {
+          "vocab_index": 97,
+          "token": "vq_m3_c01",
+          "mean_abs_shap": 0.020248
+        },
+        {
+          "vocab_index": 71,
+          "token": "vq_m2_c07",
+          "mean_abs_shap": 0.016783
+        },
+        {
+          "vocab_index": 84,
+          "token": "vq_m2_c20",
+          "mean_abs_shap": 0.014662
+        },
+        {
+          "vocab_index": 18,
+          "token": "vq_m0_c18",
+          "mean_abs_shap": 0.012574
+        },
+        {
+          "vocab_index": 38,
+          "token": "vq_m1_c06",
+          "mean_abs_shap": 0.012497
+        },
+        {
+          "vocab_index": 96,
+          "token": "vq_m3_c00",
+          "mean_abs_shap": 0.01247
+        },
+        {
+          "vocab_index": 93,
+          "token": "vq_m2_c29",
+          "mean_abs_shap": 0.012016
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 71,
+          "token": "vq_m2_c07",
+          "mean_abs_shap": 0.036211
+        },
+        {
+          "vocab_index": 112,
+          "token": "vq_m3_c16",
+          "mean_abs_shap": 0.025932
+        },
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.020002
+        },
+        {
+          "vocab_index": 82,
+          "token": "vq_m2_c18",
+          "mean_abs_shap": 0.019595
+        },
+        {
+          "vocab_index": 45,
+          "token": "vq_m1_c13",
+          "mean_abs_shap": 0.016877
+        },
+        {
+          "vocab_index": 38,
+          "token": "vq_m1_c06",
+          "mean_abs_shap": 0.016645
+        },
+        {
+          "vocab_index": 119,
+          "token": "vq_m3_c23",
+          "mean_abs_shap": 0.016422
+        },
+        {
+          "vocab_index": 96,
+          "token": "vq_m3_c00",
+          "mean_abs_shap": 0.013406
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:48Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.77
+}

--- a/data/derived/v_sweep/f13_shap/pavia-university_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/pavia-university_V14_uniform_Q8.json
@@ -1,0 +1,422 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "V": 1024,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 890,
+          "token": "cwt_s13_p7_q02",
+          "mean_abs_shap": 0.020052
+        },
+        {
+          "vocab_index": 957,
+          "token": "cwt_s14_p7_q05",
+          "mean_abs_shap": 0.019618
+        },
+        {
+          "vocab_index": 941,
+          "token": "cwt_s14_p5_q05",
+          "mean_abs_shap": 0.017292
+        },
+        {
+          "vocab_index": 875,
+          "token": "cwt_s13_p5_q03",
+          "mean_abs_shap": 0.014873
+        },
+        {
+          "vocab_index": 761,
+          "token": "cwt_s11_p7_q01",
+          "mean_abs_shap": 0.014613
+        },
+        {
+          "vocab_index": 1015,
+          "token": "cwt_s15_p6_q07",
+          "mean_abs_shap": 0.010836
+        },
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 0.009944
+        },
+        {
+          "vocab_index": 978,
+          "token": "cwt_s15_p2_q02",
+          "mean_abs_shap": 0.009569
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 875,
+          "token": "cwt_s13_p5_q03",
+          "mean_abs_shap": 0.014472
+        },
+        {
+          "vocab_index": 969,
+          "token": "cwt_s15_p1_q01",
+          "mean_abs_shap": 0.011615
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.011594
+        },
+        {
+          "vocab_index": 1012,
+          "token": "cwt_s15_p6_q04",
+          "mean_abs_shap": 0.010283
+        },
+        {
+          "vocab_index": 841,
+          "token": "cwt_s13_p1_q01",
+          "mean_abs_shap": 0.010141
+        },
+        {
+          "vocab_index": 634,
+          "token": "cwt_s09_p7_q02",
+          "mean_abs_shap": 0.009801
+        },
+        {
+          "vocab_index": 937,
+          "token": "cwt_s14_p5_q01",
+          "mean_abs_shap": 0.0098
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.00779
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 634,
+          "token": "cwt_s09_p7_q02",
+          "mean_abs_shap": 0.009631
+        },
+        {
+          "vocab_index": 922,
+          "token": "cwt_s14_p3_q02",
+          "mean_abs_shap": 0.008214
+        },
+        {
+          "vocab_index": 841,
+          "token": "cwt_s13_p1_q01",
+          "mean_abs_shap": 0.007551
+        },
+        {
+          "vocab_index": 889,
+          "token": "cwt_s13_p7_q01",
+          "mean_abs_shap": 0.007043
+        },
+        {
+          "vocab_index": 953,
+          "token": "cwt_s14_p7_q01",
+          "mean_abs_shap": 0.006092
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.005757
+        },
+        {
+          "vocab_index": 891,
+          "token": "cwt_s13_p7_q03",
+          "mean_abs_shap": 0.005246
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.005056
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 890,
+          "token": "cwt_s13_p7_q02",
+          "mean_abs_shap": 0.003736
+        },
+        {
+          "vocab_index": 897,
+          "token": "cwt_s14_p0_q01",
+          "mean_abs_shap": 0.003116
+        },
+        {
+          "vocab_index": 634,
+          "token": "cwt_s09_p7_q02",
+          "mean_abs_shap": 0.002879
+        },
+        {
+          "vocab_index": 642,
+          "token": "cwt_s10_p0_q02",
+          "mean_abs_shap": 0.002492
+        },
+        {
+          "vocab_index": 916,
+          "token": "cwt_s14_p2_q04",
+          "mean_abs_shap": 0.002437
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 0.002395
+        },
+        {
+          "vocab_index": 973,
+          "token": "cwt_s15_p1_q05",
+          "mean_abs_shap": 0.002296
+        },
+        {
+          "vocab_index": 321,
+          "token": "cwt_s05_p0_q01",
+          "mean_abs_shap": 0.002061
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 0.011573
+        },
+        {
+          "vocab_index": 698,
+          "token": "cwt_s10_p7_q02",
+          "mean_abs_shap": 0.009113
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.008941
+        },
+        {
+          "vocab_index": 875,
+          "token": "cwt_s13_p5_q03",
+          "mean_abs_shap": 0.008702
+        },
+        {
+          "vocab_index": 947,
+          "token": "cwt_s14_p6_q03",
+          "mean_abs_shap": 0.007844
+        },
+        {
+          "vocab_index": 827,
+          "token": "cwt_s12_p7_q03",
+          "mean_abs_shap": 0.007544
+        },
+        {
+          "vocab_index": 634,
+          "token": "cwt_s09_p7_q02",
+          "mean_abs_shap": 0.007529
+        },
+        {
+          "vocab_index": 985,
+          "token": "cwt_s15_p3_q01",
+          "mean_abs_shap": 0.007351
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 916,
+          "token": "cwt_s14_p2_q04",
+          "mean_abs_shap": 0.02695
+        },
+        {
+          "vocab_index": 922,
+          "token": "cwt_s14_p3_q02",
+          "mean_abs_shap": 0.014244
+        },
+        {
+          "vocab_index": 634,
+          "token": "cwt_s09_p7_q02",
+          "mean_abs_shap": 0.010765
+        },
+        {
+          "vocab_index": 958,
+          "token": "cwt_s14_p7_q06",
+          "mean_abs_shap": 0.009696
+        },
+        {
+          "vocab_index": 876,
+          "token": "cwt_s13_p5_q04",
+          "mean_abs_shap": 0.009594
+        },
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 0.00838
+        },
+        {
+          "vocab_index": 985,
+          "token": "cwt_s15_p3_q01",
+          "mean_abs_shap": 0.008359
+        },
+        {
+          "vocab_index": 957,
+          "token": "cwt_s14_p7_q05",
+          "mean_abs_shap": 0.006903
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 890,
+          "token": "cwt_s13_p7_q02",
+          "mean_abs_shap": 0.018009
+        },
+        {
+          "vocab_index": 875,
+          "token": "cwt_s13_p5_q03",
+          "mean_abs_shap": 0.01432
+        },
+        {
+          "vocab_index": 951,
+          "token": "cwt_s14_p6_q07",
+          "mean_abs_shap": 0.013977
+        },
+        {
+          "vocab_index": 634,
+          "token": "cwt_s09_p7_q02",
+          "mean_abs_shap": 0.013262
+        },
+        {
+          "vocab_index": 957,
+          "token": "cwt_s14_p7_q05",
+          "mean_abs_shap": 0.012485
+        },
+        {
+          "vocab_index": 1021,
+          "token": "cwt_s15_p7_q05",
+          "mean_abs_shap": 0.012215
+        },
+        {
+          "vocab_index": 817,
+          "token": "cwt_s12_p6_q01",
+          "mean_abs_shap": 0.012187
+        },
+        {
+          "vocab_index": 979,
+          "token": "cwt_s15_p2_q03",
+          "mean_abs_shap": 0.012029
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 956,
+          "token": "cwt_s14_p7_q04",
+          "mean_abs_shap": 0.012182
+        },
+        {
+          "vocab_index": 833,
+          "token": "cwt_s13_p0_q01",
+          "mean_abs_shap": 0.006665
+        },
+        {
+          "vocab_index": 883,
+          "token": "cwt_s13_p6_q03",
+          "mean_abs_shap": 0.00556
+        },
+        {
+          "vocab_index": 935,
+          "token": "cwt_s14_p4_q07",
+          "mean_abs_shap": 0.004577
+        },
+        {
+          "vocab_index": 969,
+          "token": "cwt_s15_p1_q01",
+          "mean_abs_shap": 0.004325
+        },
+        {
+          "vocab_index": 841,
+          "token": "cwt_s13_p1_q01",
+          "mean_abs_shap": 0.004181
+        },
+        {
+          "vocab_index": 835,
+          "token": "cwt_s13_p0_q03",
+          "mean_abs_shap": 0.003114
+        },
+        {
+          "vocab_index": 964,
+          "token": "cwt_s15_p0_q04",
+          "mean_abs_shap": 0.003033
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 843,
+          "token": "cwt_s13_p1_q03",
+          "mean_abs_shap": 0.001435
+        },
+        {
+          "vocab_index": 897,
+          "token": "cwt_s14_p0_q01",
+          "mean_abs_shap": 0.001091
+        },
+        {
+          "vocab_index": 972,
+          "token": "cwt_s15_p1_q04",
+          "mean_abs_shap": 0.001083
+        },
+        {
+          "vocab_index": 1015,
+          "token": "cwt_s15_p6_q07",
+          "mean_abs_shap": 0.00091
+        },
+        {
+          "vocab_index": 873,
+          "token": "cwt_s13_p5_q01",
+          "mean_abs_shap": 0.000726
+        },
+        {
+          "vocab_index": 762,
+          "token": "cwt_s11_p7_q02",
+          "mean_abs_shap": 0.000539
+        },
+        {
+          "vocab_index": 634,
+          "token": "cwt_s09_p7_q02",
+          "mean_abs_shap": 0.000503
+        },
+        {
+          "vocab_index": 876,
+          "token": "cwt_s13_p5_q04",
+          "mean_abs_shap": 0.000452
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:51Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 3.28
+}

--- a/data/derived/v_sweep/f13_shap/pavia-university_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/pavia-university_V15_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 24,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 4,
+          "token": "EVI_q04",
+          "mean_abs_shap": 0.056073
+        },
+        {
+          "vocab_index": 21,
+          "token": "SAVI_q05",
+          "mean_abs_shap": 0.052343
+        },
+        {
+          "vocab_index": 23,
+          "token": "SAVI_q07",
+          "mean_abs_shap": 0.04535
+        },
+        {
+          "vocab_index": 15,
+          "token": "NDVI_q07",
+          "mean_abs_shap": 0.044649
+        },
+        {
+          "vocab_index": 3,
+          "token": "EVI_q03",
+          "mean_abs_shap": 0.042854
+        },
+        {
+          "vocab_index": 22,
+          "token": "SAVI_q06",
+          "mean_abs_shap": 0.030252
+        },
+        {
+          "vocab_index": 16,
+          "token": "SAVI_q00",
+          "mean_abs_shap": 0.029084
+        },
+        {
+          "vocab_index": 8,
+          "token": "NDVI_q00",
+          "mean_abs_shap": 0.024081
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 10,
+          "token": "NDVI_q02",
+          "mean_abs_shap": 0.094907
+        },
+        {
+          "vocab_index": 18,
+          "token": "SAVI_q02",
+          "mean_abs_shap": 0.071054
+        },
+        {
+          "vocab_index": 21,
+          "token": "SAVI_q05",
+          "mean_abs_shap": 0.044677
+        },
+        {
+          "vocab_index": 17,
+          "token": "SAVI_q01",
+          "mean_abs_shap": 0.043737
+        },
+        {
+          "vocab_index": 9,
+          "token": "NDVI_q01",
+          "mean_abs_shap": 0.034669
+        },
+        {
+          "vocab_index": 4,
+          "token": "EVI_q04",
+          "mean_abs_shap": 0.027162
+        },
+        {
+          "vocab_index": 22,
+          "token": "SAVI_q06",
+          "mean_abs_shap": 0.023853
+        },
+        {
+          "vocab_index": 23,
+          "token": "SAVI_q07",
+          "mean_abs_shap": 0.023478
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 21,
+          "token": "SAVI_q05",
+          "mean_abs_shap": 0.104688
+        },
+        {
+          "vocab_index": 10,
+          "token": "NDVI_q02",
+          "mean_abs_shap": 0.067757
+        },
+        {
+          "vocab_index": 18,
+          "token": "SAVI_q02",
+          "mean_abs_shap": 0.051949
+        },
+        {
+          "vocab_index": 4,
+          "token": "EVI_q04",
+          "mean_abs_shap": 0.039942
+        },
+        {
+          "vocab_index": 22,
+          "token": "SAVI_q06",
+          "mean_abs_shap": 0.039678
+        },
+        {
+          "vocab_index": 23,
+          "token": "SAVI_q07",
+          "mean_abs_shap": 0.036275
+        },
+        {
+          "vocab_index": 3,
+          "token": "EVI_q03",
+          "mean_abs_shap": 0.036184
+        },
+        {
+          "vocab_index": 17,
+          "token": "SAVI_q01",
+          "mean_abs_shap": 0.029935
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:51Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.51
+}

--- a/data/derived/v_sweep/f13_shap/pavia-university_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/pavia-university_V17_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 512,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 321,
+          "token": "atom_a040_q01",
+          "mean_abs_shap": 0.011819
+        },
+        {
+          "vocab_index": 449,
+          "token": "atom_a056_q01",
+          "mean_abs_shap": 0.011612
+        },
+        {
+          "vocab_index": 64,
+          "token": "atom_a008_q00",
+          "mean_abs_shap": 0.010143
+        },
+        {
+          "vocab_index": 394,
+          "token": "atom_a049_q02",
+          "mean_abs_shap": 0.010016
+        },
+        {
+          "vocab_index": 424,
+          "token": "atom_a053_q00",
+          "mean_abs_shap": 0.009919
+        },
+        {
+          "vocab_index": 432,
+          "token": "atom_a054_q00",
+          "mean_abs_shap": 0.009166
+        },
+        {
+          "vocab_index": 207,
+          "token": "atom_a025_q07",
+          "mean_abs_shap": 0.009122
+        },
+        {
+          "vocab_index": 192,
+          "token": "atom_a024_q00",
+          "mean_abs_shap": 0.008884
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 470,
+          "token": "atom_a058_q06",
+          "mean_abs_shap": 0.013515
+        },
+        {
+          "vocab_index": 354,
+          "token": "atom_a044_q02",
+          "mean_abs_shap": 0.012537
+        },
+        {
+          "vocab_index": 72,
+          "token": "atom_a009_q00",
+          "mean_abs_shap": 0.012459
+        },
+        {
+          "vocab_index": 361,
+          "token": "atom_a045_q01",
+          "mean_abs_shap": 0.011676
+        },
+        {
+          "vocab_index": 224,
+          "token": "atom_a028_q00",
+          "mean_abs_shap": 0.011432
+        },
+        {
+          "vocab_index": 421,
+          "token": "atom_a052_q05",
+          "mean_abs_shap": 0.01059
+        },
+        {
+          "vocab_index": 504,
+          "token": "atom_a063_q00",
+          "mean_abs_shap": 0.010213
+        },
+        {
+          "vocab_index": 133,
+          "token": "atom_a016_q05",
+          "mean_abs_shap": 0.010012
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 401,
+          "token": "atom_a050_q01",
+          "mean_abs_shap": 0.009929
+        },
+        {
+          "vocab_index": 449,
+          "token": "atom_a056_q01",
+          "mean_abs_shap": 0.009721
+        },
+        {
+          "vocab_index": 451,
+          "token": "atom_a056_q03",
+          "mean_abs_shap": 0.008952
+        },
+        {
+          "vocab_index": 296,
+          "token": "atom_a037_q00",
+          "mean_abs_shap": 0.008881
+        },
+        {
+          "vocab_index": 432,
+          "token": "atom_a054_q00",
+          "mean_abs_shap": 0.008833
+        },
+        {
+          "vocab_index": 466,
+          "token": "atom_a058_q02",
+          "mean_abs_shap": 0.008633
+        },
+        {
+          "vocab_index": 388,
+          "token": "atom_a048_q04",
+          "mean_abs_shap": 0.008319
+        },
+        {
+          "vocab_index": 160,
+          "token": "atom_a020_q00",
+          "mean_abs_shap": 0.007972
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:53Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.43
+}

--- a/data/derived/v_sweep/f13_shap/pavia-university_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/pavia-university_V18_uniform_Q8.json
@@ -1,0 +1,422 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.01388
+        },
+        {
+          "vocab_index": 31,
+          "token": "lap_e03_q07",
+          "mean_abs_shap": 0.008555
+        },
+        {
+          "vocab_index": 95,
+          "token": "lap_e11_q07",
+          "mean_abs_shap": 0.008474
+        },
+        {
+          "vocab_index": 47,
+          "token": "lap_e05_q07",
+          "mean_abs_shap": 0.007808
+        },
+        {
+          "vocab_index": 98,
+          "token": "lap_e12_q02",
+          "mean_abs_shap": 0.007124
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.006249
+        },
+        {
+          "vocab_index": 30,
+          "token": "lap_e03_q06",
+          "mean_abs_shap": 0.00609
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.005417
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 76,
+          "token": "lap_e09_q04",
+          "mean_abs_shap": 0.007114
+        },
+        {
+          "vocab_index": 117,
+          "token": "lap_e14_q05",
+          "mean_abs_shap": 0.005712
+        },
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.004796
+        },
+        {
+          "vocab_index": 110,
+          "token": "lap_e13_q06",
+          "mean_abs_shap": 0.003901
+        },
+        {
+          "vocab_index": 17,
+          "token": "lap_e02_q01",
+          "mean_abs_shap": 0.00294
+        },
+        {
+          "vocab_index": 55,
+          "token": "lap_e06_q07",
+          "mean_abs_shap": 0.002916
+        },
+        {
+          "vocab_index": 98,
+          "token": "lap_e12_q02",
+          "mean_abs_shap": 0.002835
+        },
+        {
+          "vocab_index": 109,
+          "token": "lap_e13_q05",
+          "mean_abs_shap": 0.002478
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 46,
+          "token": "lap_e05_q06",
+          "mean_abs_shap": 0.013039
+        },
+        {
+          "vocab_index": 77,
+          "token": "lap_e09_q05",
+          "mean_abs_shap": 0.011434
+        },
+        {
+          "vocab_index": 60,
+          "token": "lap_e07_q04",
+          "mean_abs_shap": 0.008117
+        },
+        {
+          "vocab_index": 111,
+          "token": "lap_e13_q07",
+          "mean_abs_shap": 0.007491
+        },
+        {
+          "vocab_index": 38,
+          "token": "lap_e04_q06",
+          "mean_abs_shap": 0.006236
+        },
+        {
+          "vocab_index": 116,
+          "token": "lap_e14_q04",
+          "mean_abs_shap": 0.005996
+        },
+        {
+          "vocab_index": 115,
+          "token": "lap_e14_q03",
+          "mean_abs_shap": 0.005819
+        },
+        {
+          "vocab_index": 47,
+          "token": "lap_e05_q07",
+          "mean_abs_shap": 0.005746
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.008522
+        },
+        {
+          "vocab_index": 67,
+          "token": "lap_e08_q03",
+          "mean_abs_shap": 0.006448
+        },
+        {
+          "vocab_index": 43,
+          "token": "lap_e05_q03",
+          "mean_abs_shap": 0.004785
+        },
+        {
+          "vocab_index": 85,
+          "token": "lap_e10_q05",
+          "mean_abs_shap": 0.004149
+        },
+        {
+          "vocab_index": 89,
+          "token": "lap_e11_q01",
+          "mean_abs_shap": 0.003929
+        },
+        {
+          "vocab_index": 33,
+          "token": "lap_e04_q01",
+          "mean_abs_shap": 0.003771
+        },
+        {
+          "vocab_index": 62,
+          "token": "lap_e07_q06",
+          "mean_abs_shap": 0.002525
+        },
+        {
+          "vocab_index": 75,
+          "token": "lap_e09_q03",
+          "mean_abs_shap": 0.002454
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 30,
+          "token": "lap_e03_q06",
+          "mean_abs_shap": 0.012202
+        },
+        {
+          "vocab_index": 98,
+          "token": "lap_e12_q02",
+          "mean_abs_shap": 0.011116
+        },
+        {
+          "vocab_index": 62,
+          "token": "lap_e07_q06",
+          "mean_abs_shap": 0.00947
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.009095
+        },
+        {
+          "vocab_index": 74,
+          "token": "lap_e09_q02",
+          "mean_abs_shap": 0.008121
+        },
+        {
+          "vocab_index": 78,
+          "token": "lap_e09_q06",
+          "mean_abs_shap": 0.007841
+        },
+        {
+          "vocab_index": 110,
+          "token": "lap_e13_q06",
+          "mean_abs_shap": 0.00721
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.006985
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 85,
+          "token": "lap_e10_q05",
+          "mean_abs_shap": 0.015818
+        },
+        {
+          "vocab_index": 92,
+          "token": "lap_e11_q04",
+          "mean_abs_shap": 0.015168
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.01483
+        },
+        {
+          "vocab_index": 60,
+          "token": "lap_e07_q04",
+          "mean_abs_shap": 0.013746
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.013355
+        },
+        {
+          "vocab_index": 99,
+          "token": "lap_e12_q03",
+          "mean_abs_shap": 0.011209
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.01097
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.010527
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 110,
+          "token": "lap_e13_q06",
+          "mean_abs_shap": 0.011712
+        },
+        {
+          "vocab_index": 89,
+          "token": "lap_e11_q01",
+          "mean_abs_shap": 0.010585
+        },
+        {
+          "vocab_index": 64,
+          "token": "lap_e08_q00",
+          "mean_abs_shap": 0.010209
+        },
+        {
+          "vocab_index": 66,
+          "token": "lap_e08_q02",
+          "mean_abs_shap": 0.008551
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.00821
+        },
+        {
+          "vocab_index": 41,
+          "token": "lap_e05_q01",
+          "mean_abs_shap": 0.007775
+        },
+        {
+          "vocab_index": 47,
+          "token": "lap_e05_q07",
+          "mean_abs_shap": 0.007216
+        },
+        {
+          "vocab_index": 97,
+          "token": "lap_e12_q01",
+          "mean_abs_shap": 0.006474
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.027331
+        },
+        {
+          "vocab_index": 8,
+          "token": "lap_e01_q00",
+          "mean_abs_shap": 0.020964
+        },
+        {
+          "vocab_index": 34,
+          "token": "lap_e04_q02",
+          "mean_abs_shap": 0.017668
+        },
+        {
+          "vocab_index": 30,
+          "token": "lap_e03_q06",
+          "mean_abs_shap": 0.015797
+        },
+        {
+          "vocab_index": 31,
+          "token": "lap_e03_q07",
+          "mean_abs_shap": 0.014251
+        },
+        {
+          "vocab_index": 64,
+          "token": "lap_e08_q00",
+          "mean_abs_shap": 0.012539
+        },
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.010434
+        },
+        {
+          "vocab_index": 98,
+          "token": "lap_e12_q02",
+          "mean_abs_shap": 0.009585
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 17,
+          "token": "lap_e02_q01",
+          "mean_abs_shap": 0.016588
+        },
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.01503
+        },
+        {
+          "vocab_index": 48,
+          "token": "lap_e06_q00",
+          "mean_abs_shap": 0.013722
+        },
+        {
+          "vocab_index": 64,
+          "token": "lap_e08_q00",
+          "mean_abs_shap": 0.011414
+        },
+        {
+          "vocab_index": 5,
+          "token": "lap_e00_q05",
+          "mean_abs_shap": 0.007433
+        },
+        {
+          "vocab_index": 67,
+          "token": "lap_e08_q03",
+          "mean_abs_shap": 0.006791
+        },
+        {
+          "vocab_index": 78,
+          "token": "lap_e09_q06",
+          "mean_abs_shap": 0.006431
+        },
+        {
+          "vocab_index": 123,
+          "token": "lap_e15_q03",
+          "mean_abs_shap": 0.006303
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:54Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.58
+}

--- a/data/derived/v_sweep/f13_shap/pavia-university_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/pavia-university_V19_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 24,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 15,
+          "token": "umap_d1_q07",
+          "mean_abs_shap": 0.053791
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.036865
+        },
+        {
+          "vocab_index": 23,
+          "token": "umap_d2_q07",
+          "mean_abs_shap": 0.036332
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.035989
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.032723
+        },
+        {
+          "vocab_index": 2,
+          "token": "umap_d0_q02",
+          "mean_abs_shap": 0.032096
+        },
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.031444
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.027763
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.037691
+        },
+        {
+          "vocab_index": 15,
+          "token": "umap_d1_q07",
+          "mean_abs_shap": 0.034881
+        },
+        {
+          "vocab_index": 10,
+          "token": "umap_d1_q02",
+          "mean_abs_shap": 0.032386
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.029215
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.027853
+        },
+        {
+          "vocab_index": 9,
+          "token": "umap_d1_q01",
+          "mean_abs_shap": 0.027399
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.0269
+        },
+        {
+          "vocab_index": 7,
+          "token": "umap_d0_q07",
+          "mean_abs_shap": 0.022714
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 15,
+          "token": "umap_d1_q07",
+          "mean_abs_shap": 0.088348
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.057408
+        },
+        {
+          "vocab_index": 7,
+          "token": "umap_d0_q07",
+          "mean_abs_shap": 0.03805
+        },
+        {
+          "vocab_index": 4,
+          "token": "umap_d0_q04",
+          "mean_abs_shap": 0.036659
+        },
+        {
+          "vocab_index": 2,
+          "token": "umap_d0_q02",
+          "mean_abs_shap": 0.030905
+        },
+        {
+          "vocab_index": 21,
+          "token": "umap_d2_q05",
+          "mean_abs_shap": 0.029467
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.025741
+        },
+        {
+          "vocab_index": 10,
+          "token": "umap_d1_q02",
+          "mean_abs_shap": 0.024618
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:55Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.49
+}

--- a/data/derived/v_sweep/f13_shap/pavia-university_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/pavia-university_V20_uniform_Q8.json
@@ -1,0 +1,422 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 9,
+  "V": 824,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 53,
+          "token": "miw_b006_q05",
+          "mean_abs_shap": 0.0148
+        },
+        {
+          "vocab_index": 61,
+          "token": "miw_b007_q05",
+          "mean_abs_shap": 0.007399
+        },
+        {
+          "vocab_index": 169,
+          "token": "miw_b021_q01",
+          "mean_abs_shap": 0.0064
+        },
+        {
+          "vocab_index": 77,
+          "token": "miw_b009_q05",
+          "mean_abs_shap": 0.0064
+        },
+        {
+          "vocab_index": 196,
+          "token": "miw_b024_q04",
+          "mean_abs_shap": 0.006045
+        },
+        {
+          "vocab_index": 177,
+          "token": "miw_b022_q01",
+          "mean_abs_shap": 0.006045
+        },
+        {
+          "vocab_index": 46,
+          "token": "miw_b005_q06",
+          "mean_abs_shap": 0.005799
+        },
+        {
+          "vocab_index": 2,
+          "token": "miw_b000_q02",
+          "mean_abs_shap": 0.0052
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.065129
+        },
+        {
+          "vocab_index": 46,
+          "token": "miw_b005_q06",
+          "mean_abs_shap": 0.058833
+        },
+        {
+          "vocab_index": 44,
+          "token": "miw_b005_q04",
+          "mean_abs_shap": 0.05584
+        },
+        {
+          "vocab_index": 45,
+          "token": "miw_b005_q05",
+          "mean_abs_shap": 0.046284
+        },
+        {
+          "vocab_index": 167,
+          "token": "miw_b020_q07",
+          "mean_abs_shap": 0.005636
+        },
+        {
+          "vocab_index": 2,
+          "token": "miw_b000_q02",
+          "mean_abs_shap": 0.005331
+        },
+        {
+          "vocab_index": 373,
+          "token": "miw_b046_q05",
+          "mean_abs_shap": 0.00461
+        },
+        {
+          "vocab_index": 64,
+          "token": "miw_b008_q00",
+          "mean_abs_shap": 0.004182
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 2,
+          "token": "miw_b000_q02",
+          "mean_abs_shap": 0.024313
+        },
+        {
+          "vocab_index": 9,
+          "token": "miw_b001_q01",
+          "mean_abs_shap": 0.0228
+        },
+        {
+          "vocab_index": 10,
+          "token": "miw_b001_q02",
+          "mean_abs_shap": 0.0112
+        },
+        {
+          "vocab_index": 34,
+          "token": "miw_b004_q02",
+          "mean_abs_shap": 0.008752
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.008736
+        },
+        {
+          "vocab_index": 35,
+          "token": "miw_b004_q03",
+          "mean_abs_shap": 0.008
+        },
+        {
+          "vocab_index": 28,
+          "token": "miw_b003_q04",
+          "mean_abs_shap": 0.0076
+        },
+        {
+          "vocab_index": 25,
+          "token": "miw_b003_q01",
+          "mean_abs_shap": 0.0072
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 9,
+          "token": "miw_b001_q01",
+          "mean_abs_shap": 0.017628
+        },
+        {
+          "vocab_index": 806,
+          "token": "miw_b100_q06",
+          "mean_abs_shap": 0.010801
+        },
+        {
+          "vocab_index": 112,
+          "token": "miw_b014_q00",
+          "mean_abs_shap": 0.010421
+        },
+        {
+          "vocab_index": 11,
+          "token": "miw_b001_q03",
+          "mean_abs_shap": 0.008971
+        },
+        {
+          "vocab_index": 366,
+          "token": "miw_b045_q06",
+          "mean_abs_shap": 0.0086
+        },
+        {
+          "vocab_index": 41,
+          "token": "miw_b005_q01",
+          "mean_abs_shap": 0.008171
+        },
+        {
+          "vocab_index": 136,
+          "token": "miw_b017_q00",
+          "mean_abs_shap": 0.008104
+        },
+        {
+          "vocab_index": 65,
+          "token": "miw_b008_q01",
+          "mean_abs_shap": 0.006326
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 34,
+          "token": "miw_b004_q02",
+          "mean_abs_shap": 0.009341
+        },
+        {
+          "vocab_index": 46,
+          "token": "miw_b005_q06",
+          "mean_abs_shap": 0.007264
+        },
+        {
+          "vocab_index": 50,
+          "token": "miw_b006_q02",
+          "mean_abs_shap": 0.006138
+        },
+        {
+          "vocab_index": 10,
+          "token": "miw_b001_q02",
+          "mean_abs_shap": 0.005689
+        },
+        {
+          "vocab_index": 72,
+          "token": "miw_b009_q00",
+          "mean_abs_shap": 0.005667
+        },
+        {
+          "vocab_index": 9,
+          "token": "miw_b001_q01",
+          "mean_abs_shap": 0.004712
+        },
+        {
+          "vocab_index": 2,
+          "token": "miw_b000_q02",
+          "mean_abs_shap": 0.00393
+        },
+        {
+          "vocab_index": 61,
+          "token": "miw_b007_q05",
+          "mean_abs_shap": 0.003443
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 42,
+          "token": "miw_b005_q02",
+          "mean_abs_shap": 0.013957
+        },
+        {
+          "vocab_index": 162,
+          "token": "miw_b020_q02",
+          "mean_abs_shap": 0.004357
+        },
+        {
+          "vocab_index": 4,
+          "token": "miw_b000_q04",
+          "mean_abs_shap": 0.0024
+        },
+        {
+          "vocab_index": 19,
+          "token": "miw_b002_q03",
+          "mean_abs_shap": 0.0024
+        },
+        {
+          "vocab_index": 391,
+          "token": "miw_b048_q07",
+          "mean_abs_shap": 0.0016
+        },
+        {
+          "vocab_index": 81,
+          "token": "miw_b010_q01",
+          "mean_abs_shap": 0.0014
+        },
+        {
+          "vocab_index": 231,
+          "token": "miw_b028_q07",
+          "mean_abs_shap": 0.0014
+        },
+        {
+          "vocab_index": 119,
+          "token": "miw_b014_q07",
+          "mean_abs_shap": 0.0012
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 10,
+          "token": "miw_b001_q02",
+          "mean_abs_shap": 0.0444
+        },
+        {
+          "vocab_index": 4,
+          "token": "miw_b000_q04",
+          "mean_abs_shap": 0.0192
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.01764
+        },
+        {
+          "vocab_index": 117,
+          "token": "miw_b014_q05",
+          "mean_abs_shap": 0.016378
+        },
+        {
+          "vocab_index": 15,
+          "token": "miw_b001_q07",
+          "mean_abs_shap": 0.0148
+        },
+        {
+          "vocab_index": 11,
+          "token": "miw_b001_q03",
+          "mean_abs_shap": 0.014
+        },
+        {
+          "vocab_index": 12,
+          "token": "miw_b001_q04",
+          "mean_abs_shap": 0.010571
+        },
+        {
+          "vocab_index": 9,
+          "token": "miw_b001_q01",
+          "mean_abs_shap": 0.009453
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 34,
+          "token": "miw_b004_q02",
+          "mean_abs_shap": 0.023594
+        },
+        {
+          "vocab_index": 10,
+          "token": "miw_b001_q02",
+          "mean_abs_shap": 0.019812
+        },
+        {
+          "vocab_index": 36,
+          "token": "miw_b004_q04",
+          "mean_abs_shap": 0.015919
+        },
+        {
+          "vocab_index": 2,
+          "token": "miw_b000_q02",
+          "mean_abs_shap": 0.015811
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.0143
+        },
+        {
+          "vocab_index": 32,
+          "token": "miw_b004_q00",
+          "mean_abs_shap": 0.012201
+        },
+        {
+          "vocab_index": 149,
+          "token": "miw_b018_q05",
+          "mean_abs_shap": 0.00872
+        },
+        {
+          "vocab_index": 44,
+          "token": "miw_b005_q04",
+          "mean_abs_shap": 0.008014
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 2,
+          "token": "miw_b000_q02",
+          "mean_abs_shap": 0.027533
+        },
+        {
+          "vocab_index": 24,
+          "token": "miw_b003_q00",
+          "mean_abs_shap": 0.0152
+        },
+        {
+          "vocab_index": 10,
+          "token": "miw_b001_q02",
+          "mean_abs_shap": 0.0144
+        },
+        {
+          "vocab_index": 61,
+          "token": "miw_b007_q05",
+          "mean_abs_shap": 0.014
+        },
+        {
+          "vocab_index": 9,
+          "token": "miw_b001_q01",
+          "mean_abs_shap": 0.012
+        },
+        {
+          "vocab_index": 16,
+          "token": "miw_b002_q00",
+          "mean_abs_shap": 0.0118
+        },
+        {
+          "vocab_index": 19,
+          "token": "miw_b002_q03",
+          "mean_abs_shap": 0.0084
+        },
+        {
+          "vocab_index": 56,
+          "token": "miw_b007_q00",
+          "mean_abs_shap": 0.008244
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:59Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 4.56
+}

--- a/data/derived/v_sweep/f13_shap/salinas-a-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-a-corrected_V13_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 53,
+          "token": "vq_m1_c21",
+          "mean_abs_shap": 0.074947
+        },
+        {
+          "vocab_index": 64,
+          "token": "vq_m2_c00",
+          "mean_abs_shap": 0.067219
+        },
+        {
+          "vocab_index": 5,
+          "token": "vq_m0_c05",
+          "mean_abs_shap": 0.067193
+        },
+        {
+          "vocab_index": 40,
+          "token": "vq_m1_c08",
+          "mean_abs_shap": 0.042962
+        },
+        {
+          "vocab_index": 48,
+          "token": "vq_m1_c16",
+          "mean_abs_shap": 0.042109
+        },
+        {
+          "vocab_index": 16,
+          "token": "vq_m0_c16",
+          "mean_abs_shap": 0.036681
+        },
+        {
+          "vocab_index": 88,
+          "token": "vq_m2_c24",
+          "mean_abs_shap": 0.035759
+        },
+        {
+          "vocab_index": 28,
+          "token": "vq_m0_c28",
+          "mean_abs_shap": 0.032516
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 48,
+          "token": "vq_m1_c16",
+          "mean_abs_shap": 0.068474
+        },
+        {
+          "vocab_index": 28,
+          "token": "vq_m0_c28",
+          "mean_abs_shap": 0.065018
+        },
+        {
+          "vocab_index": 53,
+          "token": "vq_m1_c21",
+          "mean_abs_shap": 0.05108
+        },
+        {
+          "vocab_index": 88,
+          "token": "vq_m2_c24",
+          "mean_abs_shap": 0.050697
+        },
+        {
+          "vocab_index": 5,
+          "token": "vq_m0_c05",
+          "mean_abs_shap": 0.047478
+        },
+        {
+          "vocab_index": 64,
+          "token": "vq_m2_c00",
+          "mean_abs_shap": 0.042231
+        },
+        {
+          "vocab_index": 40,
+          "token": "vq_m1_c08",
+          "mean_abs_shap": 0.040006
+        },
+        {
+          "vocab_index": 120,
+          "token": "vq_m3_c24",
+          "mean_abs_shap": 0.039446
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 40,
+          "token": "vq_m1_c08",
+          "mean_abs_shap": 0.066269
+        },
+        {
+          "vocab_index": 16,
+          "token": "vq_m0_c16",
+          "mean_abs_shap": 0.055133
+        },
+        {
+          "vocab_index": 53,
+          "token": "vq_m1_c21",
+          "mean_abs_shap": 0.048339
+        },
+        {
+          "vocab_index": 48,
+          "token": "vq_m1_c16",
+          "mean_abs_shap": 0.037962
+        },
+        {
+          "vocab_index": 28,
+          "token": "vq_m0_c28",
+          "mean_abs_shap": 0.035169
+        },
+        {
+          "vocab_index": 89,
+          "token": "vq_m2_c25",
+          "mean_abs_shap": 0.034661
+        },
+        {
+          "vocab_index": 64,
+          "token": "vq_m2_c00",
+          "mean_abs_shap": 0.032947
+        },
+        {
+          "vocab_index": 5,
+          "token": "vq_m0_c05",
+          "mean_abs_shap": 0.032637
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:39Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.35
+}

--- a/data/derived/v_sweep/f13_shap/salinas-a-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-a-corrected_V14_uniform_Q8.json
@@ -1,0 +1,287 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "V": 1024,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.01975
+        },
+        {
+          "vocab_index": 986,
+          "token": "cwt_s15_p3_q02",
+          "mean_abs_shap": 0.018265
+        },
+        {
+          "vocab_index": 1010,
+          "token": "cwt_s15_p6_q02",
+          "mean_abs_shap": 0.017955
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.017052
+        },
+        {
+          "vocab_index": 650,
+          "token": "cwt_s10_p1_q02",
+          "mean_abs_shap": 0.016906
+        },
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 0.016241
+        },
+        {
+          "vocab_index": 746,
+          "token": "cwt_s11_p5_q02",
+          "mean_abs_shap": 0.014396
+        },
+        {
+          "vocab_index": 930,
+          "token": "cwt_s14_p4_q02",
+          "mean_abs_shap": 0.014286
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 0.011643
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.011517
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.009945
+        },
+        {
+          "vocab_index": 746,
+          "token": "cwt_s11_p5_q02",
+          "mean_abs_shap": 0.009746
+        },
+        {
+          "vocab_index": 989,
+          "token": "cwt_s15_p3_q05",
+          "mean_abs_shap": 0.007992
+        },
+        {
+          "vocab_index": 962,
+          "token": "cwt_s15_p0_q02",
+          "mean_abs_shap": 0.007511
+        },
+        {
+          "vocab_index": 974,
+          "token": "cwt_s15_p1_q06",
+          "mean_abs_shap": 0.006527
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.006434
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 983,
+          "token": "cwt_s15_p2_q07",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 931,
+          "token": "cwt_s14_p4_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 975,
+          "token": "cwt_s15_p1_q07",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 917,
+          "token": "cwt_s14_p2_q05",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 850,
+          "token": "cwt_s13_p2_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 924,
+          "token": "cwt_s14_p3_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 835,
+          "token": "cwt_s13_p0_q03",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.025841
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.022939
+        },
+        {
+          "vocab_index": 911,
+          "token": "cwt_s14_p1_q07",
+          "mean_abs_shap": 0.020892
+        },
+        {
+          "vocab_index": 835,
+          "token": "cwt_s13_p0_q03",
+          "mean_abs_shap": 0.020604
+        },
+        {
+          "vocab_index": 986,
+          "token": "cwt_s15_p3_q02",
+          "mean_abs_shap": 0.020469
+        },
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 0.01645
+        },
+        {
+          "vocab_index": 650,
+          "token": "cwt_s10_p1_q02",
+          "mean_abs_shap": 0.016271
+        },
+        {
+          "vocab_index": 1010,
+          "token": "cwt_s15_p6_q02",
+          "mean_abs_shap": 0.012927
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 0.01819
+        },
+        {
+          "vocab_index": 779,
+          "token": "cwt_s12_p1_q03",
+          "mean_abs_shap": 0.012792
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.011677
+        },
+        {
+          "vocab_index": 974,
+          "token": "cwt_s15_p1_q06",
+          "mean_abs_shap": 0.010981
+        },
+        {
+          "vocab_index": 1002,
+          "token": "cwt_s15_p5_q02",
+          "mean_abs_shap": 0.010605
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.009789
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.008349
+        },
+        {
+          "vocab_index": 859,
+          "token": "cwt_s13_p3_q03",
+          "mean_abs_shap": 0.00827
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 983,
+          "token": "cwt_s15_p2_q07",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 917,
+          "token": "cwt_s14_p2_q05",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 975,
+          "token": "cwt_s15_p1_q07",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 964,
+          "token": "cwt_s15_p0_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 930,
+          "token": "cwt_s14_p4_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 842,
+          "token": "cwt_s13_p1_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 986,
+          "token": "cwt_s15_p3_q02",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:40Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.38
+}

--- a/data/derived/v_sweep/f13_shap/salinas-a-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-a-corrected_V15_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 48,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "NBR_q00",
+          "mean_abs_shap": 0.038068
+        },
+        {
+          "vocab_index": 40,
+          "token": "SAVI_q00",
+          "mean_abs_shap": 0.034733
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.030167
+        },
+        {
+          "vocab_index": 0,
+          "token": "EVI_q00",
+          "mean_abs_shap": 0.028078
+        },
+        {
+          "vocab_index": 43,
+          "token": "SAVI_q03",
+          "mean_abs_shap": 0.027843
+        },
+        {
+          "vocab_index": 19,
+          "token": "NBR_q03",
+          "mean_abs_shap": 0.026589
+        },
+        {
+          "vocab_index": 32,
+          "token": "NDVI_q00",
+          "mean_abs_shap": 0.024158
+        },
+        {
+          "vocab_index": 23,
+          "token": "NBR_q07",
+          "mean_abs_shap": 0.02353
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 23,
+          "token": "NBR_q07",
+          "mean_abs_shap": 0.029255
+        },
+        {
+          "vocab_index": 15,
+          "token": "MNDWI_q07",
+          "mean_abs_shap": 0.025935
+        },
+        {
+          "vocab_index": 7,
+          "token": "EVI_q07",
+          "mean_abs_shap": 0.022913
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.021897
+        },
+        {
+          "vocab_index": 9,
+          "token": "MNDWI_q01",
+          "mean_abs_shap": 0.019544
+        },
+        {
+          "vocab_index": 0,
+          "token": "EVI_q00",
+          "mean_abs_shap": 0.019038
+        },
+        {
+          "vocab_index": 43,
+          "token": "SAVI_q03",
+          "mean_abs_shap": 0.017734
+        },
+        {
+          "vocab_index": 32,
+          "token": "NDVI_q00",
+          "mean_abs_shap": 0.017103
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 19,
+          "token": "NBR_q03",
+          "mean_abs_shap": 0.034634
+        },
+        {
+          "vocab_index": 34,
+          "token": "NDVI_q02",
+          "mean_abs_shap": 0.028244
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.027843
+        },
+        {
+          "vocab_index": 40,
+          "token": "SAVI_q00",
+          "mean_abs_shap": 0.026953
+        },
+        {
+          "vocab_index": 25,
+          "token": "NDSI_q01",
+          "mean_abs_shap": 0.026685
+        },
+        {
+          "vocab_index": 42,
+          "token": "SAVI_q02",
+          "mean_abs_shap": 0.025581
+        },
+        {
+          "vocab_index": 16,
+          "token": "NBR_q00",
+          "mean_abs_shap": 0.024802
+        },
+        {
+          "vocab_index": 9,
+          "token": "MNDWI_q01",
+          "mean_abs_shap": 0.0232
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:40Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.31
+}

--- a/data/derived/v_sweep/f13_shap/salinas-a-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-a-corrected_V17_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 512,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 141,
+          "token": "atom_a017_q05",
+          "mean_abs_shap": 0.017421
+        },
+        {
+          "vocab_index": 48,
+          "token": "atom_a006_q00",
+          "mean_abs_shap": 0.013116
+        },
+        {
+          "vocab_index": 99,
+          "token": "atom_a012_q03",
+          "mean_abs_shap": 0.012014
+        },
+        {
+          "vocab_index": 104,
+          "token": "atom_a013_q00",
+          "mean_abs_shap": 0.011743
+        },
+        {
+          "vocab_index": 249,
+          "token": "atom_a031_q01",
+          "mean_abs_shap": 0.010282
+        },
+        {
+          "vocab_index": 134,
+          "token": "atom_a016_q06",
+          "mean_abs_shap": 0.009896
+        },
+        {
+          "vocab_index": 471,
+          "token": "atom_a058_q07",
+          "mean_abs_shap": 0.009598
+        },
+        {
+          "vocab_index": 253,
+          "token": "atom_a031_q05",
+          "mean_abs_shap": 0.0092
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 464,
+          "token": "atom_a058_q00",
+          "mean_abs_shap": 0.012003
+        },
+        {
+          "vocab_index": 82,
+          "token": "atom_a010_q02",
+          "mean_abs_shap": 0.011049
+        },
+        {
+          "vocab_index": 136,
+          "token": "atom_a017_q00",
+          "mean_abs_shap": 0.010943
+        },
+        {
+          "vocab_index": 71,
+          "token": "atom_a008_q07",
+          "mean_abs_shap": 0.010405
+        },
+        {
+          "vocab_index": 141,
+          "token": "atom_a017_q05",
+          "mean_abs_shap": 0.009742
+        },
+        {
+          "vocab_index": 104,
+          "token": "atom_a013_q00",
+          "mean_abs_shap": 0.009596
+        },
+        {
+          "vocab_index": 139,
+          "token": "atom_a017_q03",
+          "mean_abs_shap": 0.009388
+        },
+        {
+          "vocab_index": 449,
+          "token": "atom_a056_q01",
+          "mean_abs_shap": 0.007842
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 253,
+          "token": "atom_a031_q05",
+          "mean_abs_shap": 0.017233
+        },
+        {
+          "vocab_index": 104,
+          "token": "atom_a013_q00",
+          "mean_abs_shap": 0.01371
+        },
+        {
+          "vocab_index": 141,
+          "token": "atom_a017_q05",
+          "mean_abs_shap": 0.013549
+        },
+        {
+          "vocab_index": 136,
+          "token": "atom_a017_q00",
+          "mean_abs_shap": 0.013171
+        },
+        {
+          "vocab_index": 57,
+          "token": "atom_a007_q01",
+          "mean_abs_shap": 0.011468
+        },
+        {
+          "vocab_index": 71,
+          "token": "atom_a008_q07",
+          "mean_abs_shap": 0.011175
+        },
+        {
+          "vocab_index": 48,
+          "token": "atom_a006_q00",
+          "mean_abs_shap": 0.010624
+        },
+        {
+          "vocab_index": 454,
+          "token": "atom_a056_q06",
+          "mean_abs_shap": 0.010431
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:41Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.8
+}

--- a/data/derived/v_sweep/f13_shap/salinas-a-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-a-corrected_V18_uniform_Q8.json
@@ -1,0 +1,287 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.008686
+        },
+        {
+          "vocab_index": 71,
+          "token": "lap_e08_q07",
+          "mean_abs_shap": 0.007751
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.005145
+        },
+        {
+          "vocab_index": 18,
+          "token": "lap_e02_q02",
+          "mean_abs_shap": 0.005102
+        },
+        {
+          "vocab_index": 55,
+          "token": "lap_e06_q07",
+          "mean_abs_shap": 0.003941
+        },
+        {
+          "vocab_index": 27,
+          "token": "lap_e03_q03",
+          "mean_abs_shap": 0.003663
+        },
+        {
+          "vocab_index": 28,
+          "token": "lap_e03_q04",
+          "mean_abs_shap": 0.003642
+        },
+        {
+          "vocab_index": 109,
+          "token": "lap_e13_q05",
+          "mean_abs_shap": 0.003182
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 72,
+          "token": "lap_e09_q00",
+          "mean_abs_shap": 0.003106
+        },
+        {
+          "vocab_index": 78,
+          "token": "lap_e09_q06",
+          "mean_abs_shap": 0.002724
+        },
+        {
+          "vocab_index": 119,
+          "token": "lap_e14_q07",
+          "mean_abs_shap": 0.001912
+        },
+        {
+          "vocab_index": 63,
+          "token": "lap_e07_q07",
+          "mean_abs_shap": 0.001776
+        },
+        {
+          "vocab_index": 39,
+          "token": "lap_e04_q07",
+          "mean_abs_shap": 0.001573
+        },
+        {
+          "vocab_index": 10,
+          "token": "lap_e01_q02",
+          "mean_abs_shap": 0.00139
+        },
+        {
+          "vocab_index": 23,
+          "token": "lap_e02_q07",
+          "mean_abs_shap": 0.001389
+        },
+        {
+          "vocab_index": 88,
+          "token": "lap_e11_q00",
+          "mean_abs_shap": 0.001364
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 41,
+          "token": "lap_e05_q01",
+          "mean_abs_shap": 0.015764
+        },
+        {
+          "vocab_index": 1,
+          "token": "lap_e00_q01",
+          "mean_abs_shap": 0.015672
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.014164
+        },
+        {
+          "vocab_index": 22,
+          "token": "lap_e02_q06",
+          "mean_abs_shap": 0.013292
+        },
+        {
+          "vocab_index": 49,
+          "token": "lap_e06_q01",
+          "mean_abs_shap": 0.011673
+        },
+        {
+          "vocab_index": 44,
+          "token": "lap_e05_q04",
+          "mean_abs_shap": 0.011588
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.010647
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.009871
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 54,
+          "token": "lap_e06_q06",
+          "mean_abs_shap": 0.01945
+        },
+        {
+          "vocab_index": 1,
+          "token": "lap_e00_q01",
+          "mean_abs_shap": 0.016531
+        },
+        {
+          "vocab_index": 53,
+          "token": "lap_e06_q05",
+          "mean_abs_shap": 0.014939
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.011765
+        },
+        {
+          "vocab_index": 97,
+          "token": "lap_e12_q01",
+          "mean_abs_shap": 0.01004
+        },
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.008881
+        },
+        {
+          "vocab_index": 70,
+          "token": "lap_e08_q06",
+          "mean_abs_shap": 0.007889
+        },
+        {
+          "vocab_index": 43,
+          "token": "lap_e05_q03",
+          "mean_abs_shap": 0.006911
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 1,
+          "token": "lap_e00_q01",
+          "mean_abs_shap": 0.033815
+        },
+        {
+          "vocab_index": 53,
+          "token": "lap_e06_q05",
+          "mean_abs_shap": 0.016057
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.01542
+        },
+        {
+          "vocab_index": 51,
+          "token": "lap_e06_q03",
+          "mean_abs_shap": 0.015137
+        },
+        {
+          "vocab_index": 71,
+          "token": "lap_e08_q07",
+          "mean_abs_shap": 0.014822
+        },
+        {
+          "vocab_index": 0,
+          "token": "lap_e00_q00",
+          "mean_abs_shap": 0.014413
+        },
+        {
+          "vocab_index": 9,
+          "token": "lap_e01_q01",
+          "mean_abs_shap": 0.014118
+        },
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.013832
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 51,
+          "token": "lap_e06_q03",
+          "mean_abs_shap": 0.017167
+        },
+        {
+          "vocab_index": 7,
+          "token": "lap_e00_q07",
+          "mean_abs_shap": 0.009817
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.008202
+        },
+        {
+          "vocab_index": 65,
+          "token": "lap_e08_q01",
+          "mean_abs_shap": 0.004265
+        },
+        {
+          "vocab_index": 22,
+          "token": "lap_e02_q06",
+          "mean_abs_shap": 0.003949
+        },
+        {
+          "vocab_index": 70,
+          "token": "lap_e08_q06",
+          "mean_abs_shap": 0.003902
+        },
+        {
+          "vocab_index": 18,
+          "token": "lap_e02_q02",
+          "mean_abs_shap": 0.003293
+        },
+        {
+          "vocab_index": 24,
+          "token": "lap_e03_q00",
+          "mean_abs_shap": 0.003227
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:42Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.55
+}

--- a/data/derived/v_sweep/f13_shap/salinas-a-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-a-corrected_V19_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 24,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.066673
+        },
+        {
+          "vocab_index": 3,
+          "token": "umap_d0_q03",
+          "mean_abs_shap": 0.056745
+        },
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.052621
+        },
+        {
+          "vocab_index": 11,
+          "token": "umap_d1_q03",
+          "mean_abs_shap": 0.049386
+        },
+        {
+          "vocab_index": 21,
+          "token": "umap_d2_q05",
+          "mean_abs_shap": 0.046914
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.034293
+        },
+        {
+          "vocab_index": 9,
+          "token": "umap_d1_q01",
+          "mean_abs_shap": 0.029996
+        },
+        {
+          "vocab_index": 23,
+          "token": "umap_d2_q07",
+          "mean_abs_shap": 0.026675
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 3,
+          "token": "umap_d0_q03",
+          "mean_abs_shap": 0.069389
+        },
+        {
+          "vocab_index": 12,
+          "token": "umap_d1_q04",
+          "mean_abs_shap": 0.062139
+        },
+        {
+          "vocab_index": 11,
+          "token": "umap_d1_q03",
+          "mean_abs_shap": 0.061457
+        },
+        {
+          "vocab_index": 9,
+          "token": "umap_d1_q01",
+          "mean_abs_shap": 0.038571
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.036474
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.030678
+        },
+        {
+          "vocab_index": 23,
+          "token": "umap_d2_q07",
+          "mean_abs_shap": 0.030427
+        },
+        {
+          "vocab_index": 10,
+          "token": "umap_d1_q02",
+          "mean_abs_shap": 0.027277
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 21,
+          "token": "umap_d2_q05",
+          "mean_abs_shap": 0.068937
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.035539
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.034859
+        },
+        {
+          "vocab_index": 7,
+          "token": "umap_d0_q07",
+          "mean_abs_shap": 0.030898
+        },
+        {
+          "vocab_index": 1,
+          "token": "umap_d0_q01",
+          "mean_abs_shap": 0.030192
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.019007
+        },
+        {
+          "vocab_index": 9,
+          "token": "umap_d1_q01",
+          "mean_abs_shap": 0.01859
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.017859
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:42Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.37
+}

--- a/data/derived/v_sweep/f13_shap/salinas-a-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-a-corrected_V20_uniform_Q8.json
@@ -1,0 +1,287 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 6,
+  "V": 1632,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 193,
+          "token": "miw_b024_q01",
+          "mean_abs_shap": 0.0516
+        },
+        {
+          "vocab_index": 234,
+          "token": "miw_b029_q02",
+          "mean_abs_shap": 0.046971
+        },
+        {
+          "vocab_index": 82,
+          "token": "miw_b010_q02",
+          "mean_abs_shap": 0.0464
+        },
+        {
+          "vocab_index": 179,
+          "token": "miw_b022_q03",
+          "mean_abs_shap": 0.0456
+        },
+        {
+          "vocab_index": 126,
+          "token": "miw_b015_q06",
+          "mean_abs_shap": 0.04
+        },
+        {
+          "vocab_index": 185,
+          "token": "miw_b023_q01",
+          "mean_abs_shap": 0.0388
+        },
+        {
+          "vocab_index": 255,
+          "token": "miw_b031_q07",
+          "mean_abs_shap": 0.020001
+        },
+        {
+          "vocab_index": 27,
+          "token": "miw_b003_q03",
+          "mean_abs_shap": 0.019256
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 809,
+          "token": "miw_b101_q01",
+          "mean_abs_shap": 5996944036790.21
+        },
+        {
+          "vocab_index": 1448,
+          "token": "miw_b181_q00",
+          "mean_abs_shap": 5996944036790.207
+        },
+        {
+          "vocab_index": 641,
+          "token": "miw_b080_q01",
+          "mean_abs_shap": 5996944036790.202
+        },
+        {
+          "vocab_index": 124,
+          "token": "miw_b015_q04",
+          "mean_abs_shap": 5996944036790.202
+        },
+        {
+          "vocab_index": 49,
+          "token": "miw_b006_q01",
+          "mean_abs_shap": 0.026187
+        },
+        {
+          "vocab_index": 1073,
+          "token": "miw_b134_q01",
+          "mean_abs_shap": 0.021397
+        },
+        {
+          "vocab_index": 57,
+          "token": "miw_b007_q01",
+          "mean_abs_shap": 0.016422
+        },
+        {
+          "vocab_index": 65,
+          "token": "miw_b008_q01",
+          "mean_abs_shap": 0.016013
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 1082,
+          "token": "miw_b135_q02",
+          "mean_abs_shap": 0.003902
+        },
+        {
+          "vocab_index": 970,
+          "token": "miw_b121_q02",
+          "mean_abs_shap": 0.00376
+        },
+        {
+          "vocab_index": 469,
+          "token": "miw_b058_q05",
+          "mean_abs_shap": 0.003615
+        },
+        {
+          "vocab_index": 41,
+          "token": "miw_b005_q01",
+          "mean_abs_shap": 0.00322
+        },
+        {
+          "vocab_index": 961,
+          "token": "miw_b120_q01",
+          "mean_abs_shap": 0.002914
+        },
+        {
+          "vocab_index": 302,
+          "token": "miw_b037_q06",
+          "mean_abs_shap": 0.002095
+        },
+        {
+          "vocab_index": 499,
+          "token": "miw_b062_q03",
+          "mean_abs_shap": 0.001818
+        },
+        {
+          "vocab_index": 673,
+          "token": "miw_b084_q01",
+          "mean_abs_shap": 0.001114
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 748,
+          "token": "miw_b093_q04",
+          "mean_abs_shap": 0.0236
+        },
+        {
+          "vocab_index": 1488,
+          "token": "miw_b186_q00",
+          "mean_abs_shap": 0.018488
+        },
+        {
+          "vocab_index": 34,
+          "token": "miw_b004_q02",
+          "mean_abs_shap": 0.013562
+        },
+        {
+          "vocab_index": 0,
+          "token": "miw_b000_q00",
+          "mean_abs_shap": 0.013508
+        },
+        {
+          "vocab_index": 51,
+          "token": "miw_b006_q03",
+          "mean_abs_shap": 0.013311
+        },
+        {
+          "vocab_index": 27,
+          "token": "miw_b003_q03",
+          "mean_abs_shap": 0.011971
+        },
+        {
+          "vocab_index": 89,
+          "token": "miw_b011_q01",
+          "mean_abs_shap": 0.010803
+        },
+        {
+          "vocab_index": 25,
+          "token": "miw_b003_q01",
+          "mean_abs_shap": 0.010104
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "miw_b002_q00",
+          "mean_abs_shap": 0.013238
+        },
+        {
+          "vocab_index": 57,
+          "token": "miw_b007_q01",
+          "mean_abs_shap": 0.013029
+        },
+        {
+          "vocab_index": 109,
+          "token": "miw_b013_q05",
+          "mean_abs_shap": 0.012018
+        },
+        {
+          "vocab_index": 177,
+          "token": "miw_b022_q01",
+          "mean_abs_shap": 0.011985
+        },
+        {
+          "vocab_index": 292,
+          "token": "miw_b036_q04",
+          "mean_abs_shap": 0.004854
+        },
+        {
+          "vocab_index": 1353,
+          "token": "miw_b169_q01",
+          "mean_abs_shap": 0.004591
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.004586
+        },
+        {
+          "vocab_index": 1448,
+          "token": "miw_b181_q00",
+          "mean_abs_shap": 0.004106
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 232,
+          "token": "miw_b029_q00",
+          "mean_abs_shap": 0.035095
+        },
+        {
+          "vocab_index": 1441,
+          "token": "miw_b180_q01",
+          "mean_abs_shap": 0.0298
+        },
+        {
+          "vocab_index": 516,
+          "token": "miw_b064_q04",
+          "mean_abs_shap": 0.028001
+        },
+        {
+          "vocab_index": 105,
+          "token": "miw_b013_q01",
+          "mean_abs_shap": 0.0172
+        },
+        {
+          "vocab_index": 8,
+          "token": "miw_b001_q00",
+          "mean_abs_shap": 0.015201
+        },
+        {
+          "vocab_index": 254,
+          "token": "miw_b031_q06",
+          "mean_abs_shap": 0.014933
+        },
+        {
+          "vocab_index": 150,
+          "token": "miw_b018_q06",
+          "mean_abs_shap": 0.014293
+        },
+        {
+          "vocab_index": 295,
+          "token": "miw_b036_q07",
+          "mean_abs_shap": 0.014001
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:47Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 4.69
+}

--- a/data/derived/v_sweep/f13_shap/salinas-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-corrected_V13_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V13",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 5,
+          "token": "vq_m0_c05",
+          "mean_abs_shap": 0.073618
+        },
+        {
+          "vocab_index": 75,
+          "token": "vq_m2_c11",
+          "mean_abs_shap": 0.060042
+        },
+        {
+          "vocab_index": 28,
+          "token": "vq_m0_c28",
+          "mean_abs_shap": 0.050599
+        },
+        {
+          "vocab_index": 1,
+          "token": "vq_m0_c01",
+          "mean_abs_shap": 0.03076
+        },
+        {
+          "vocab_index": 120,
+          "token": "vq_m3_c24",
+          "mean_abs_shap": 0.029139
+        },
+        {
+          "vocab_index": 48,
+          "token": "vq_m1_c16",
+          "mean_abs_shap": 0.02492
+        },
+        {
+          "vocab_index": 88,
+          "token": "vq_m2_c24",
+          "mean_abs_shap": 0.024643
+        },
+        {
+          "vocab_index": 97,
+          "token": "vq_m3_c01",
+          "mean_abs_shap": 0.02381
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 1,
+          "token": "vq_m0_c01",
+          "mean_abs_shap": 0.066002
+        },
+        {
+          "vocab_index": 5,
+          "token": "vq_m0_c05",
+          "mean_abs_shap": 0.03437
+        },
+        {
+          "vocab_index": 116,
+          "token": "vq_m3_c20",
+          "mean_abs_shap": 0.030917
+        },
+        {
+          "vocab_index": 72,
+          "token": "vq_m2_c08",
+          "mean_abs_shap": 0.028477
+        },
+        {
+          "vocab_index": 28,
+          "token": "vq_m0_c28",
+          "mean_abs_shap": 0.028237
+        },
+        {
+          "vocab_index": 86,
+          "token": "vq_m2_c22",
+          "mean_abs_shap": 0.026056
+        },
+        {
+          "vocab_index": 69,
+          "token": "vq_m2_c05",
+          "mean_abs_shap": 0.025062
+        },
+        {
+          "vocab_index": 89,
+          "token": "vq_m2_c25",
+          "mean_abs_shap": 0.024809
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 28,
+          "token": "vq_m0_c28",
+          "mean_abs_shap": 0.076314
+        },
+        {
+          "vocab_index": 5,
+          "token": "vq_m0_c05",
+          "mean_abs_shap": 0.050344
+        },
+        {
+          "vocab_index": 75,
+          "token": "vq_m2_c11",
+          "mean_abs_shap": 0.045637
+        },
+        {
+          "vocab_index": 1,
+          "token": "vq_m0_c01",
+          "mean_abs_shap": 0.038912
+        },
+        {
+          "vocab_index": 72,
+          "token": "vq_m2_c08",
+          "mean_abs_shap": 0.037118
+        },
+        {
+          "vocab_index": 97,
+          "token": "vq_m3_c01",
+          "mean_abs_shap": 0.0369
+        },
+        {
+          "vocab_index": 106,
+          "token": "vq_m3_c10",
+          "mean_abs_shap": 0.03037
+        },
+        {
+          "vocab_index": 89,
+          "token": "vq_m2_c25",
+          "mean_abs_shap": 0.02573
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:25Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.73
+}

--- a/data/derived/v_sweep/f13_shap/salinas-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-corrected_V14_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1024,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 998,
+          "token": "cwt_s15_p4_q06",
+          "mean_abs_shap": 0.009382
+        },
+        {
+          "vocab_index": 916,
+          "token": "cwt_s14_p2_q04",
+          "mean_abs_shap": 0.008272
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.0081
+        },
+        {
+          "vocab_index": 962,
+          "token": "cwt_s15_p0_q02",
+          "mean_abs_shap": 0.007832
+        },
+        {
+          "vocab_index": 898,
+          "token": "cwt_s14_p0_q02",
+          "mean_abs_shap": 0.006963
+        },
+        {
+          "vocab_index": 594,
+          "token": "cwt_s09_p2_q02",
+          "mean_abs_shap": 0.006851
+        },
+        {
+          "vocab_index": 983,
+          "token": "cwt_s15_p2_q07",
+          "mean_abs_shap": 0.006473
+        },
+        {
+          "vocab_index": 658,
+          "token": "cwt_s10_p2_q02",
+          "mean_abs_shap": 0.006414
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 914,
+          "token": "cwt_s14_p2_q02",
+          "mean_abs_shap": 0.000267
+        },
+        {
+          "vocab_index": 1004,
+          "token": "cwt_s15_p5_q04",
+          "mean_abs_shap": 0.000148
+        },
+        {
+          "vocab_index": 932,
+          "token": "cwt_s14_p4_q04",
+          "mean_abs_shap": 8.5e-05
+        },
+        {
+          "vocab_index": 990,
+          "token": "cwt_s15_p3_q06",
+          "mean_abs_shap": 8.1e-05
+        },
+        {
+          "vocab_index": 1002,
+          "token": "cwt_s15_p5_q02",
+          "mean_abs_shap": 7e-05
+        },
+        {
+          "vocab_index": 835,
+          "token": "cwt_s13_p0_q03",
+          "mean_abs_shap": 6.9e-05
+        },
+        {
+          "vocab_index": 666,
+          "token": "cwt_s10_p3_q02",
+          "mean_abs_shap": 6.5e-05
+        },
+        {
+          "vocab_index": 898,
+          "token": "cwt_s14_p0_q02",
+          "mean_abs_shap": 6.2e-05
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 1004,
+          "token": "cwt_s15_p5_q04",
+          "mean_abs_shap": 0.000479
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.000407
+        },
+        {
+          "vocab_index": 850,
+          "token": "cwt_s13_p2_q02",
+          "mean_abs_shap": 0.000345
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.000331
+        },
+        {
+          "vocab_index": 746,
+          "token": "cwt_s11_p5_q02",
+          "mean_abs_shap": 0.000282
+        },
+        {
+          "vocab_index": 999,
+          "token": "cwt_s15_p4_q07",
+          "mean_abs_shap": 0.000246
+        },
+        {
+          "vocab_index": 924,
+          "token": "cwt_s14_p3_q04",
+          "mean_abs_shap": 0.000238
+        },
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 0.000226
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 964,
+          "token": "cwt_s15_p0_q04",
+          "mean_abs_shap": 0.016824
+        },
+        {
+          "vocab_index": 899,
+          "token": "cwt_s14_p0_q03",
+          "mean_abs_shap": 0.013449
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.012965
+        },
+        {
+          "vocab_index": 1018,
+          "token": "cwt_s15_p7_q02",
+          "mean_abs_shap": 0.0113
+        },
+        {
+          "vocab_index": 900,
+          "token": "cwt_s14_p0_q04",
+          "mean_abs_shap": 0.010026
+        },
+        {
+          "vocab_index": 973,
+          "token": "cwt_s15_p1_q05",
+          "mean_abs_shap": 0.010011
+        },
+        {
+          "vocab_index": 1013,
+          "token": "cwt_s15_p6_q05",
+          "mean_abs_shap": 0.009209
+        },
+        {
+          "vocab_index": 658,
+          "token": "cwt_s10_p2_q02",
+          "mean_abs_shap": 0.008878
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 658,
+          "token": "cwt_s10_p2_q02",
+          "mean_abs_shap": 0.017231
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.015158
+        },
+        {
+          "vocab_index": 650,
+          "token": "cwt_s10_p1_q02",
+          "mean_abs_shap": 0.012178
+        },
+        {
+          "vocab_index": 715,
+          "token": "cwt_s11_p1_q03",
+          "mean_abs_shap": 0.012086
+        },
+        {
+          "vocab_index": 836,
+          "token": "cwt_s13_p0_q04",
+          "mean_abs_shap": 0.009445
+        },
+        {
+          "vocab_index": 1004,
+          "token": "cwt_s15_p5_q04",
+          "mean_abs_shap": 0.009274
+        },
+        {
+          "vocab_index": 666,
+          "token": "cwt_s10_p3_q02",
+          "mean_abs_shap": 0.00927
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.009191
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 0.000569
+        },
+        {
+          "vocab_index": 981,
+          "token": "cwt_s15_p2_q05",
+          "mean_abs_shap": 0.000424
+        },
+        {
+          "vocab_index": 987,
+          "token": "cwt_s15_p3_q03",
+          "mean_abs_shap": 0.000393
+        },
+        {
+          "vocab_index": 963,
+          "token": "cwt_s15_p0_q03",
+          "mean_abs_shap": 0.000372
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.00037
+        },
+        {
+          "vocab_index": 1010,
+          "token": "cwt_s15_p6_q02",
+          "mean_abs_shap": 0.000348
+        },
+        {
+          "vocab_index": 975,
+          "token": "cwt_s15_p1_q07",
+          "mean_abs_shap": 0.000332
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.000302
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 0.018313
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.013162
+        },
+        {
+          "vocab_index": 658,
+          "token": "cwt_s10_p2_q02",
+          "mean_abs_shap": 0.010916
+        },
+        {
+          "vocab_index": 962,
+          "token": "cwt_s15_p0_q02",
+          "mean_abs_shap": 0.010801
+        },
+        {
+          "vocab_index": 650,
+          "token": "cwt_s10_p1_q02",
+          "mean_abs_shap": 0.010522
+        },
+        {
+          "vocab_index": 1003,
+          "token": "cwt_s15_p5_q03",
+          "mean_abs_shap": 0.008856
+        },
+        {
+          "vocab_index": 931,
+          "token": "cwt_s14_p4_q03",
+          "mean_abs_shap": 0.008098
+        },
+        {
+          "vocab_index": 900,
+          "token": "cwt_s14_p0_q04",
+          "mean_abs_shap": 0.00788
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 973,
+          "token": "cwt_s15_p1_q05",
+          "mean_abs_shap": 1e-05
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 9e-06
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 9e-06
+        },
+        {
+          "vocab_index": 901,
+          "token": "cwt_s14_p0_q05",
+          "mean_abs_shap": 9e-06
+        },
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 8e-06
+        },
+        {
+          "vocab_index": 990,
+          "token": "cwt_s15_p3_q06",
+          "mean_abs_shap": 6e-06
+        },
+        {
+          "vocab_index": 850,
+          "token": "cwt_s13_p2_q02",
+          "mean_abs_shap": 6e-06
+        },
+        {
+          "vocab_index": 666,
+          "token": "cwt_s10_p3_q02",
+          "mean_abs_shap": 5e-06
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 907,
+          "token": "cwt_s14_p1_q03",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 990,
+          "token": "cwt_s15_p3_q06",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 915,
+          "token": "cwt_s14_p2_q03",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 973,
+          "token": "cwt_s15_p1_q05",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 914,
+          "token": "cwt_s14_p2_q02",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 1e-06
+        },
+        {
+          "vocab_index": 931,
+          "token": "cwt_s14_p4_q03",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 859,
+          "token": "cwt_s13_p3_q03",
+          "mean_abs_shap": 0.01834
+        },
+        {
+          "vocab_index": 900,
+          "token": "cwt_s14_p0_q04",
+          "mean_abs_shap": 0.015196
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.013922
+        },
+        {
+          "vocab_index": 965,
+          "token": "cwt_s15_p0_q05",
+          "mean_abs_shap": 0.013799
+        },
+        {
+          "vocab_index": 980,
+          "token": "cwt_s15_p2_q04",
+          "mean_abs_shap": 0.011686
+        },
+        {
+          "vocab_index": 651,
+          "token": "cwt_s10_p1_q03",
+          "mean_abs_shap": 0.010996
+        },
+        {
+          "vocab_index": 658,
+          "token": "cwt_s10_p2_q02",
+          "mean_abs_shap": 0.01028
+        },
+        {
+          "vocab_index": 974,
+          "token": "cwt_s15_p1_q06",
+          "mean_abs_shap": 0.010006
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 908,
+          "token": "cwt_s14_p1_q04",
+          "mean_abs_shap": 0.000185
+        },
+        {
+          "vocab_index": 930,
+          "token": "cwt_s14_p4_q02",
+          "mean_abs_shap": 0.000154
+        },
+        {
+          "vocab_index": 931,
+          "token": "cwt_s14_p4_q03",
+          "mean_abs_shap": 0.000153
+        },
+        {
+          "vocab_index": 746,
+          "token": "cwt_s11_p5_q02",
+          "mean_abs_shap": 0.000134
+        },
+        {
+          "vocab_index": 909,
+          "token": "cwt_s14_p1_q05",
+          "mean_abs_shap": 0.000128
+        },
+        {
+          "vocab_index": 1003,
+          "token": "cwt_s15_p5_q03",
+          "mean_abs_shap": 9.4e-05
+        },
+        {
+          "vocab_index": 990,
+          "token": "cwt_s15_p3_q06",
+          "mean_abs_shap": 8.8e-05
+        },
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 8.7e-05
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 771,
+          "token": "cwt_s12_p0_q03",
+          "mean_abs_shap": 0.020929
+        },
+        {
+          "vocab_index": 973,
+          "token": "cwt_s15_p1_q05",
+          "mean_abs_shap": 0.013291
+        },
+        {
+          "vocab_index": 1011,
+          "token": "cwt_s15_p6_q03",
+          "mean_abs_shap": 0.010491
+        },
+        {
+          "vocab_index": 980,
+          "token": "cwt_s15_p2_q04",
+          "mean_abs_shap": 0.009973
+        },
+        {
+          "vocab_index": 911,
+          "token": "cwt_s14_p1_q07",
+          "mean_abs_shap": 0.009387
+        },
+        {
+          "vocab_index": 1012,
+          "token": "cwt_s15_p6_q04",
+          "mean_abs_shap": 0.009102
+        },
+        {
+          "vocab_index": 922,
+          "token": "cwt_s14_p3_q02",
+          "mean_abs_shap": 0.008082
+        },
+        {
+          "vocab_index": 658,
+          "token": "cwt_s10_p2_q02",
+          "mean_abs_shap": 0.008071
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:29Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 3.48
+}

--- a/data/derived/v_sweep/f13_shap/salinas-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-corrected_V15_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 48,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 19,
+          "token": "NBR_q03",
+          "mean_abs_shap": 0.02464
+        },
+        {
+          "vocab_index": 43,
+          "token": "SAVI_q03",
+          "mean_abs_shap": 0.024189
+        },
+        {
+          "vocab_index": 3,
+          "token": "EVI_q03",
+          "mean_abs_shap": 0.023769
+        },
+        {
+          "vocab_index": 4,
+          "token": "EVI_q04",
+          "mean_abs_shap": 0.023266
+        },
+        {
+          "vocab_index": 25,
+          "token": "NDSI_q01",
+          "mean_abs_shap": 0.020843
+        },
+        {
+          "vocab_index": 40,
+          "token": "SAVI_q00",
+          "mean_abs_shap": 0.017604
+        },
+        {
+          "vocab_index": 24,
+          "token": "NDSI_q00",
+          "mean_abs_shap": 0.016787
+        },
+        {
+          "vocab_index": 8,
+          "token": "MNDWI_q00",
+          "mean_abs_shap": 0.016543
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 39,
+          "token": "NDVI_q07",
+          "mean_abs_shap": 0.032189
+        },
+        {
+          "vocab_index": 47,
+          "token": "SAVI_q07",
+          "mean_abs_shap": 0.023134
+        },
+        {
+          "vocab_index": 7,
+          "token": "EVI_q07",
+          "mean_abs_shap": 0.018472
+        },
+        {
+          "vocab_index": 23,
+          "token": "NBR_q07",
+          "mean_abs_shap": 0.017412
+        },
+        {
+          "vocab_index": 31,
+          "token": "NDSI_q07",
+          "mean_abs_shap": 0.013035
+        },
+        {
+          "vocab_index": 44,
+          "token": "SAVI_q04",
+          "mean_abs_shap": 0.01262
+        },
+        {
+          "vocab_index": 40,
+          "token": "SAVI_q00",
+          "mean_abs_shap": 0.009618
+        },
+        {
+          "vocab_index": 36,
+          "token": "NDVI_q04",
+          "mean_abs_shap": 0.009283
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 19,
+          "token": "NBR_q03",
+          "mean_abs_shap": 0.032209
+        },
+        {
+          "vocab_index": 39,
+          "token": "NDVI_q07",
+          "mean_abs_shap": 0.029933
+        },
+        {
+          "vocab_index": 16,
+          "token": "NBR_q00",
+          "mean_abs_shap": 0.02623
+        },
+        {
+          "vocab_index": 3,
+          "token": "EVI_q03",
+          "mean_abs_shap": 0.026227
+        },
+        {
+          "vocab_index": 40,
+          "token": "SAVI_q00",
+          "mean_abs_shap": 0.024263
+        },
+        {
+          "vocab_index": 32,
+          "token": "NDVI_q00",
+          "mean_abs_shap": 0.02178
+        },
+        {
+          "vocab_index": 43,
+          "token": "SAVI_q03",
+          "mean_abs_shap": 0.021342
+        },
+        {
+          "vocab_index": 7,
+          "token": "EVI_q07",
+          "mean_abs_shap": 0.02095
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:29Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.59
+}

--- a/data/derived/v_sweep/f13_shap/salinas-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-corrected_V17_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 512,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 208,
+          "token": "atom_a026_q00",
+          "mean_abs_shap": 0.020179
+        },
+        {
+          "vocab_index": 73,
+          "token": "atom_a009_q01",
+          "mean_abs_shap": 0.015547
+        },
+        {
+          "vocab_index": 384,
+          "token": "atom_a048_q00",
+          "mean_abs_shap": 0.01501
+        },
+        {
+          "vocab_index": 457,
+          "token": "atom_a057_q01",
+          "mean_abs_shap": 0.013254
+        },
+        {
+          "vocab_index": 255,
+          "token": "atom_a031_q07",
+          "mean_abs_shap": 0.012289
+        },
+        {
+          "vocab_index": 116,
+          "token": "atom_a014_q04",
+          "mean_abs_shap": 0.011923
+        },
+        {
+          "vocab_index": 71,
+          "token": "atom_a008_q07",
+          "mean_abs_shap": 0.010751
+        },
+        {
+          "vocab_index": 79,
+          "token": "atom_a009_q07",
+          "mean_abs_shap": 0.008634
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 71,
+          "token": "atom_a008_q07",
+          "mean_abs_shap": 0.027201
+        },
+        {
+          "vocab_index": 255,
+          "token": "atom_a031_q07",
+          "mean_abs_shap": 0.02058
+        },
+        {
+          "vocab_index": 135,
+          "token": "atom_a016_q07",
+          "mean_abs_shap": 0.014772
+        },
+        {
+          "vocab_index": 208,
+          "token": "atom_a026_q00",
+          "mean_abs_shap": 0.013783
+        },
+        {
+          "vocab_index": 321,
+          "token": "atom_a040_q01",
+          "mean_abs_shap": 0.012845
+        },
+        {
+          "vocab_index": 457,
+          "token": "atom_a057_q01",
+          "mean_abs_shap": 0.012328
+        },
+        {
+          "vocab_index": 73,
+          "token": "atom_a009_q01",
+          "mean_abs_shap": 0.011569
+        },
+        {
+          "vocab_index": 144,
+          "token": "atom_a018_q00",
+          "mean_abs_shap": 0.010944
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 255,
+          "token": "atom_a031_q07",
+          "mean_abs_shap": 0.031797
+        },
+        {
+          "vocab_index": 71,
+          "token": "atom_a008_q07",
+          "mean_abs_shap": 0.015928
+        },
+        {
+          "vocab_index": 304,
+          "token": "atom_a038_q00",
+          "mean_abs_shap": 0.012679
+        },
+        {
+          "vocab_index": 375,
+          "token": "atom_a046_q07",
+          "mean_abs_shap": 0.012555
+        },
+        {
+          "vocab_index": 321,
+          "token": "atom_a040_q01",
+          "mean_abs_shap": 0.011267
+        },
+        {
+          "vocab_index": 381,
+          "token": "atom_a047_q05",
+          "mean_abs_shap": 0.010486
+        },
+        {
+          "vocab_index": 63,
+          "token": "atom_a007_q07",
+          "mean_abs_shap": 0.00965
+        },
+        {
+          "vocab_index": 73,
+          "token": "atom_a009_q01",
+          "mean_abs_shap": 0.009282
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:31Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.54
+}

--- a/data/derived/v_sweep/f13_shap/salinas-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-corrected_V18_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 128,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 39,
+          "token": "lap_e04_q07",
+          "mean_abs_shap": 0.026133
+        },
+        {
+          "vocab_index": 59,
+          "token": "lap_e07_q03",
+          "mean_abs_shap": 0.019742
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.019061
+        },
+        {
+          "vocab_index": 89,
+          "token": "lap_e11_q01",
+          "mean_abs_shap": 0.018375
+        },
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.014753
+        },
+        {
+          "vocab_index": 54,
+          "token": "lap_e06_q06",
+          "mean_abs_shap": 0.014517
+        },
+        {
+          "vocab_index": 41,
+          "token": "lap_e05_q01",
+          "mean_abs_shap": 0.013993
+        },
+        {
+          "vocab_index": 58,
+          "token": "lap_e07_q02",
+          "mean_abs_shap": 0.013742
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.017299
+        },
+        {
+          "vocab_index": 15,
+          "token": "lap_e01_q07",
+          "mean_abs_shap": 0.006929
+        },
+        {
+          "vocab_index": 32,
+          "token": "lap_e04_q00",
+          "mean_abs_shap": 0.005292
+        },
+        {
+          "vocab_index": 37,
+          "token": "lap_e04_q05",
+          "mean_abs_shap": 0.004809
+        },
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.004243
+        },
+        {
+          "vocab_index": 88,
+          "token": "lap_e11_q00",
+          "mean_abs_shap": 0.004138
+        },
+        {
+          "vocab_index": 60,
+          "token": "lap_e07_q04",
+          "mean_abs_shap": 0.00268
+        },
+        {
+          "vocab_index": 26,
+          "token": "lap_e03_q02",
+          "mean_abs_shap": 0.002382
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 22,
+          "token": "lap_e02_q06",
+          "mean_abs_shap": 0.005697
+        },
+        {
+          "vocab_index": 72,
+          "token": "lap_e09_q00",
+          "mean_abs_shap": 0.004172
+        },
+        {
+          "vocab_index": 15,
+          "token": "lap_e01_q07",
+          "mean_abs_shap": 0.001894
+        },
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.001876
+        },
+        {
+          "vocab_index": 79,
+          "token": "lap_e09_q07",
+          "mean_abs_shap": 0.001789
+        },
+        {
+          "vocab_index": 90,
+          "token": "lap_e11_q02",
+          "mean_abs_shap": 0.001477
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.000953
+        },
+        {
+          "vocab_index": 57,
+          "token": "lap_e07_q01",
+          "mean_abs_shap": 0.000826
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.017808
+        },
+        {
+          "vocab_index": 104,
+          "token": "lap_e13_q00",
+          "mean_abs_shap": 0.006414
+        },
+        {
+          "vocab_index": 32,
+          "token": "lap_e04_q00",
+          "mean_abs_shap": 0.006192
+        },
+        {
+          "vocab_index": 109,
+          "token": "lap_e13_q05",
+          "mean_abs_shap": 0.005898
+        },
+        {
+          "vocab_index": 37,
+          "token": "lap_e04_q05",
+          "mean_abs_shap": 0.005587
+        },
+        {
+          "vocab_index": 90,
+          "token": "lap_e11_q02",
+          "mean_abs_shap": 0.005172
+        },
+        {
+          "vocab_index": 12,
+          "token": "lap_e01_q04",
+          "mean_abs_shap": 0.004375
+        },
+        {
+          "vocab_index": 93,
+          "token": "lap_e11_q05",
+          "mean_abs_shap": 0.004121
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 17,
+          "token": "lap_e02_q01",
+          "mean_abs_shap": 0.015686
+        },
+        {
+          "vocab_index": 26,
+          "token": "lap_e03_q02",
+          "mean_abs_shap": 0.011787
+        },
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.011749
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.011365
+        },
+        {
+          "vocab_index": 15,
+          "token": "lap_e01_q07",
+          "mean_abs_shap": 0.010999
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.009697
+        },
+        {
+          "vocab_index": 94,
+          "token": "lap_e11_q06",
+          "mean_abs_shap": 0.006497
+        },
+        {
+          "vocab_index": 112,
+          "token": "lap_e14_q00",
+          "mean_abs_shap": 0.00631
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.01568
+        },
+        {
+          "vocab_index": 55,
+          "token": "lap_e06_q07",
+          "mean_abs_shap": 0.014035
+        },
+        {
+          "vocab_index": 39,
+          "token": "lap_e04_q07",
+          "mean_abs_shap": 0.012814
+        },
+        {
+          "vocab_index": 44,
+          "token": "lap_e05_q04",
+          "mean_abs_shap": 0.011861
+        },
+        {
+          "vocab_index": 41,
+          "token": "lap_e05_q01",
+          "mean_abs_shap": 0.011628
+        },
+        {
+          "vocab_index": 119,
+          "token": "lap_e14_q07",
+          "mean_abs_shap": 0.011586
+        },
+        {
+          "vocab_index": 19,
+          "token": "lap_e02_q03",
+          "mean_abs_shap": 0.01023
+        },
+        {
+          "vocab_index": 7,
+          "token": "lap_e00_q07",
+          "mean_abs_shap": 0.009739
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 90,
+          "token": "lap_e11_q02",
+          "mean_abs_shap": 0.0094
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.00879
+        },
+        {
+          "vocab_index": 47,
+          "token": "lap_e05_q07",
+          "mean_abs_shap": 0.007423
+        },
+        {
+          "vocab_index": 59,
+          "token": "lap_e07_q03",
+          "mean_abs_shap": 0.006907
+        },
+        {
+          "vocab_index": 74,
+          "token": "lap_e09_q02",
+          "mean_abs_shap": 0.00652
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.006499
+        },
+        {
+          "vocab_index": 43,
+          "token": "lap_e05_q03",
+          "mean_abs_shap": 0.006312
+        },
+        {
+          "vocab_index": 38,
+          "token": "lap_e04_q06",
+          "mean_abs_shap": 0.006031
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "lap_e02_q00",
+          "mean_abs_shap": 0.019354
+        },
+        {
+          "vocab_index": 40,
+          "token": "lap_e05_q00",
+          "mean_abs_shap": 0.011945
+        },
+        {
+          "vocab_index": 90,
+          "token": "lap_e11_q02",
+          "mean_abs_shap": 0.009442
+        },
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.008244
+        },
+        {
+          "vocab_index": 104,
+          "token": "lap_e13_q00",
+          "mean_abs_shap": 0.006886
+        },
+        {
+          "vocab_index": 26,
+          "token": "lap_e03_q02",
+          "mean_abs_shap": 0.006043
+        },
+        {
+          "vocab_index": 17,
+          "token": "lap_e02_q01",
+          "mean_abs_shap": 0.005939
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.005789
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 58,
+          "token": "lap_e07_q02",
+          "mean_abs_shap": 0.018694
+        },
+        {
+          "vocab_index": 38,
+          "token": "lap_e04_q06",
+          "mean_abs_shap": 0.015693
+        },
+        {
+          "vocab_index": 44,
+          "token": "lap_e05_q04",
+          "mean_abs_shap": 0.015177
+        },
+        {
+          "vocab_index": 90,
+          "token": "lap_e11_q02",
+          "mean_abs_shap": 0.014732
+        },
+        {
+          "vocab_index": 39,
+          "token": "lap_e04_q07",
+          "mean_abs_shap": 0.008261
+        },
+        {
+          "vocab_index": 42,
+          "token": "lap_e05_q02",
+          "mean_abs_shap": 0.007396
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.006965
+        },
+        {
+          "vocab_index": 47,
+          "token": "lap_e05_q07",
+          "mean_abs_shap": 0.006712
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 7,
+          "token": "lap_e00_q07",
+          "mean_abs_shap": 0.010046
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.009212
+        },
+        {
+          "vocab_index": 79,
+          "token": "lap_e09_q07",
+          "mean_abs_shap": 0.008601
+        },
+        {
+          "vocab_index": 57,
+          "token": "lap_e07_q01",
+          "mean_abs_shap": 0.008067
+        },
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.007856
+        },
+        {
+          "vocab_index": 104,
+          "token": "lap_e13_q00",
+          "mean_abs_shap": 0.007189
+        },
+        {
+          "vocab_index": 111,
+          "token": "lap_e13_q07",
+          "mean_abs_shap": 0.007154
+        },
+        {
+          "vocab_index": 13,
+          "token": "lap_e01_q05",
+          "mean_abs_shap": 0.005934
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 56,
+          "token": "lap_e07_q00",
+          "mean_abs_shap": 0.013321
+        },
+        {
+          "vocab_index": 57,
+          "token": "lap_e07_q01",
+          "mean_abs_shap": 0.011742
+        },
+        {
+          "vocab_index": 14,
+          "token": "lap_e01_q06",
+          "mean_abs_shap": 0.007042
+        },
+        {
+          "vocab_index": 104,
+          "token": "lap_e13_q00",
+          "mean_abs_shap": 0.006305
+        },
+        {
+          "vocab_index": 20,
+          "token": "lap_e02_q04",
+          "mean_abs_shap": 0.0047
+        },
+        {
+          "vocab_index": 74,
+          "token": "lap_e09_q02",
+          "mean_abs_shap": 0.00432
+        },
+        {
+          "vocab_index": 36,
+          "token": "lap_e04_q04",
+          "mean_abs_shap": 0.004211
+        },
+        {
+          "vocab_index": 43,
+          "token": "lap_e05_q03",
+          "mean_abs_shap": 0.004166
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 71,
+          "token": "lap_e08_q07",
+          "mean_abs_shap": 0.005395
+        },
+        {
+          "vocab_index": 91,
+          "token": "lap_e11_q03",
+          "mean_abs_shap": 0.004313
+        },
+        {
+          "vocab_index": 45,
+          "token": "lap_e05_q05",
+          "mean_abs_shap": 0.002247
+        },
+        {
+          "vocab_index": 124,
+          "token": "lap_e15_q04",
+          "mean_abs_shap": 0.001909
+        },
+        {
+          "vocab_index": 116,
+          "token": "lap_e14_q04",
+          "mean_abs_shap": 0.001555
+        },
+        {
+          "vocab_index": 93,
+          "token": "lap_e11_q05",
+          "mean_abs_shap": 0.001414
+        },
+        {
+          "vocab_index": 104,
+          "token": "lap_e13_q00",
+          "mean_abs_shap": 0.001078
+        },
+        {
+          "vocab_index": 109,
+          "token": "lap_e13_q05",
+          "mean_abs_shap": 0.000956
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:32Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 1.62
+}

--- a/data/derived/v_sweep/f13_shap/salinas-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-corrected_V19_uniform_Q8.json
@@ -1,0 +1,152 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 3,
+  "V": 24,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.059934
+        },
+        {
+          "vocab_index": 14,
+          "token": "umap_d1_q06",
+          "mean_abs_shap": 0.04408
+        },
+        {
+          "vocab_index": 2,
+          "token": "umap_d0_q02",
+          "mean_abs_shap": 0.041112
+        },
+        {
+          "vocab_index": 11,
+          "token": "umap_d1_q03",
+          "mean_abs_shap": 0.038809
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.034337
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.031624
+        },
+        {
+          "vocab_index": 7,
+          "token": "umap_d0_q07",
+          "mean_abs_shap": 0.029554
+        },
+        {
+          "vocab_index": 23,
+          "token": "umap_d2_q07",
+          "mean_abs_shap": 0.029365
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.071335
+        },
+        {
+          "vocab_index": 18,
+          "token": "umap_d2_q02",
+          "mean_abs_shap": 0.068413
+        },
+        {
+          "vocab_index": 13,
+          "token": "umap_d1_q05",
+          "mean_abs_shap": 0.049171
+        },
+        {
+          "vocab_index": 9,
+          "token": "umap_d1_q01",
+          "mean_abs_shap": 0.045387
+        },
+        {
+          "vocab_index": 3,
+          "token": "umap_d0_q03",
+          "mean_abs_shap": 0.035607
+        },
+        {
+          "vocab_index": 2,
+          "token": "umap_d0_q02",
+          "mean_abs_shap": 0.024329
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.023589
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.01966
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 2,
+          "token": "umap_d0_q02",
+          "mean_abs_shap": 0.070952
+        },
+        {
+          "vocab_index": 8,
+          "token": "umap_d1_q00",
+          "mean_abs_shap": 0.047395
+        },
+        {
+          "vocab_index": 11,
+          "token": "umap_d1_q03",
+          "mean_abs_shap": 0.04713
+        },
+        {
+          "vocab_index": 0,
+          "token": "umap_d0_q00",
+          "mean_abs_shap": 0.044804
+        },
+        {
+          "vocab_index": 20,
+          "token": "umap_d2_q04",
+          "mean_abs_shap": 0.038421
+        },
+        {
+          "vocab_index": 18,
+          "token": "umap_d2_q02",
+          "mean_abs_shap": 0.038016
+        },
+        {
+          "vocab_index": 19,
+          "token": "umap_d2_q03",
+          "mean_abs_shap": 0.035101
+        },
+        {
+          "vocab_index": 5,
+          "token": "umap_d0_q05",
+          "mean_abs_shap": 0.034814
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:33Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 0.53
+}

--- a/data/derived/v_sweep/f13_shap/salinas-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f13_shap/salinas-corrected_V20_uniform_Q8.json
@@ -1,0 +1,557 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 8,
+  "K": 12,
+  "V": 1632,
+  "n_samples_explained": 50,
+  "n_background": 25,
+  "top_m": 8,
+  "top_features_per_topic": [
+    {
+      "topic": 0,
+      "features": [
+        {
+          "vocab_index": 0,
+          "token": "miw_b000_q00",
+          "mean_abs_shap": 0.031834
+        },
+        {
+          "vocab_index": 811,
+          "token": "miw_b101_q03",
+          "mean_abs_shap": 0.024433
+        },
+        {
+          "vocab_index": 154,
+          "token": "miw_b019_q02",
+          "mean_abs_shap": 0.0191
+        },
+        {
+          "vocab_index": 1,
+          "token": "miw_b000_q01",
+          "mean_abs_shap": 0.018694
+        },
+        {
+          "vocab_index": 27,
+          "token": "miw_b003_q03",
+          "mean_abs_shap": 0.01496
+        },
+        {
+          "vocab_index": 1256,
+          "token": "miw_b157_q00",
+          "mean_abs_shap": 0.014827
+        },
+        {
+          "vocab_index": 1384,
+          "token": "miw_b173_q00",
+          "mean_abs_shap": 0.014818
+        },
+        {
+          "vocab_index": 282,
+          "token": "miw_b035_q02",
+          "mean_abs_shap": 0.014525
+        }
+      ]
+    },
+    {
+      "topic": 1,
+      "features": [
+        {
+          "vocab_index": 292,
+          "token": "miw_b036_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 700,
+          "token": "miw_b087_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 803,
+          "token": "miw_b100_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 98,
+          "token": "miw_b012_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 430,
+          "token": "miw_b053_q06",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 299,
+          "token": "miw_b037_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 188,
+          "token": "miw_b023_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 557,
+          "token": "miw_b069_q05",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 2,
+      "features": [
+        {
+          "vocab_index": 106,
+          "token": "miw_b013_q02",
+          "mean_abs_shap": 33364245117137.273
+        },
+        {
+          "vocab_index": 126,
+          "token": "miw_b015_q06",
+          "mean_abs_shap": 33364245117137.273
+        },
+        {
+          "vocab_index": 122,
+          "token": "miw_b015_q02",
+          "mean_abs_shap": 0.011514
+        },
+        {
+          "vocab_index": 1336,
+          "token": "miw_b167_q00",
+          "mean_abs_shap": 0.0087
+        },
+        {
+          "vocab_index": 282,
+          "token": "miw_b035_q02",
+          "mean_abs_shap": 0.006694
+        },
+        {
+          "vocab_index": 1312,
+          "token": "miw_b164_q00",
+          "mean_abs_shap": 0.006616
+        },
+        {
+          "vocab_index": 1002,
+          "token": "miw_b125_q02",
+          "mean_abs_shap": 0.006514
+        },
+        {
+          "vocab_index": 188,
+          "token": "miw_b023_q04",
+          "mean_abs_shap": 0.00641
+        }
+      ]
+    },
+    {
+      "topic": 3,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "miw_b002_q00",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 18,
+          "token": "miw_b002_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 19,
+          "token": "miw_b002_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 20,
+          "token": "miw_b002_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 21,
+          "token": "miw_b002_q05",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 22,
+          "token": "miw_b002_q06",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 23,
+          "token": "miw_b002_q07",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 4,
+      "features": [
+        {
+          "vocab_index": 132,
+          "token": "miw_b016_q04",
+          "mean_abs_shap": 0.027468
+        },
+        {
+          "vocab_index": 175,
+          "token": "miw_b021_q07",
+          "mean_abs_shap": 0.024054
+        },
+        {
+          "vocab_index": 722,
+          "token": "miw_b090_q02",
+          "mean_abs_shap": 0.020519
+        },
+        {
+          "vocab_index": 523,
+          "token": "miw_b065_q03",
+          "mean_abs_shap": 0.02
+        },
+        {
+          "vocab_index": 922,
+          "token": "miw_b115_q02",
+          "mean_abs_shap": 0.019627
+        },
+        {
+          "vocab_index": 303,
+          "token": "miw_b037_q07",
+          "mean_abs_shap": 0.019525
+        },
+        {
+          "vocab_index": 326,
+          "token": "miw_b040_q06",
+          "mean_abs_shap": 0.014143
+        },
+        {
+          "vocab_index": 319,
+          "token": "miw_b039_q07",
+          "mean_abs_shap": 0.012
+        }
+      ]
+    },
+    {
+      "topic": 5,
+      "features": [
+        {
+          "vocab_index": 16,
+          "token": "miw_b002_q00",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 17,
+          "token": "miw_b002_q01",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 18,
+          "token": "miw_b002_q02",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 19,
+          "token": "miw_b002_q03",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 20,
+          "token": "miw_b002_q04",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 21,
+          "token": "miw_b002_q05",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 22,
+          "token": "miw_b002_q06",
+          "mean_abs_shap": 0.0
+        },
+        {
+          "vocab_index": 23,
+          "token": "miw_b002_q07",
+          "mean_abs_shap": 0.0
+        }
+      ]
+    },
+    {
+      "topic": 6,
+      "features": [
+        {
+          "vocab_index": 234,
+          "token": "miw_b029_q02",
+          "mean_abs_shap": 900719925474.0989
+        },
+        {
+          "vocab_index": 73,
+          "token": "miw_b009_q01",
+          "mean_abs_shap": 900719925474.0988
+        },
+        {
+          "vocab_index": 53,
+          "token": "miw_b006_q05",
+          "mean_abs_shap": 0.001941
+        },
+        {
+          "vocab_index": 61,
+          "token": "miw_b007_q05",
+          "mean_abs_shap": 0.001645
+        },
+        {
+          "vocab_index": 28,
+          "token": "miw_b003_q04",
+          "mean_abs_shap": 0.001608
+        },
+        {
+          "vocab_index": 102,
+          "token": "miw_b012_q06",
+          "mean_abs_shap": 0.0016
+        },
+        {
+          "vocab_index": 43,
+          "token": "miw_b005_q03",
+          "mean_abs_shap": 0.001589
+        },
+        {
+          "vocab_index": 134,
+          "token": "miw_b016_q06",
+          "mean_abs_shap": 0.001509
+        }
+      ]
+    },
+    {
+      "topic": 7,
+      "features": [
+        {
+          "vocab_index": 724,
+          "token": "miw_b090_q04",
+          "mean_abs_shap": 585329379261937.5
+        },
+        {
+          "vocab_index": 656,
+          "token": "miw_b082_q00",
+          "mean_abs_shap": 585329379261937.5
+        },
+        {
+          "vocab_index": 1393,
+          "token": "miw_b174_q01",
+          "mean_abs_shap": 585329379261937.5
+        },
+        {
+          "vocab_index": 415,
+          "token": "miw_b051_q07",
+          "mean_abs_shap": 585329379261937.5
+        },
+        {
+          "vocab_index": 57,
+          "token": "miw_b007_q01",
+          "mean_abs_shap": 0.026031
+        },
+        {
+          "vocab_index": 1472,
+          "token": "miw_b184_q00",
+          "mean_abs_shap": 0.022266
+        },
+        {
+          "vocab_index": 130,
+          "token": "miw_b016_q02",
+          "mean_abs_shap": 0.0187
+        },
+        {
+          "vocab_index": 1320,
+          "token": "miw_b165_q00",
+          "mean_abs_shap": 0.018023
+        }
+      ]
+    },
+    {
+      "topic": 8,
+      "features": [
+        {
+          "vocab_index": 231,
+          "token": "miw_b028_q07",
+          "mean_abs_shap": 0.0612
+        },
+        {
+          "vocab_index": 300,
+          "token": "miw_b037_q04",
+          "mean_abs_shap": 0.056064
+        },
+        {
+          "vocab_index": 241,
+          "token": "miw_b030_q01",
+          "mean_abs_shap": 0.053314
+        },
+        {
+          "vocab_index": 753,
+          "token": "miw_b094_q01",
+          "mean_abs_shap": 0.048594
+        },
+        {
+          "vocab_index": 203,
+          "token": "miw_b025_q03",
+          "mean_abs_shap": 0.045164
+        },
+        {
+          "vocab_index": 34,
+          "token": "miw_b004_q02",
+          "mean_abs_shap": 0.04196
+        },
+        {
+          "vocab_index": 506,
+          "token": "miw_b063_q02",
+          "mean_abs_shap": 0.0382
+        },
+        {
+          "vocab_index": 187,
+          "token": "miw_b023_q03",
+          "mean_abs_shap": 0.0292
+        }
+      ]
+    },
+    {
+      "topic": 9,
+      "features": [
+        {
+          "vocab_index": 582,
+          "token": "miw_b072_q06",
+          "mean_abs_shap": 14344324469328.01
+        },
+        {
+          "vocab_index": 140,
+          "token": "miw_b017_q04",
+          "mean_abs_shap": 14344324469328.01
+        },
+        {
+          "vocab_index": 779,
+          "token": "miw_b097_q03",
+          "mean_abs_shap": 0.014363
+        },
+        {
+          "vocab_index": 153,
+          "token": "miw_b019_q01",
+          "mean_abs_shap": 0.011963
+        },
+        {
+          "vocab_index": 26,
+          "token": "miw_b003_q02",
+          "mean_abs_shap": 0.0104
+        },
+        {
+          "vocab_index": 71,
+          "token": "miw_b008_q07",
+          "mean_abs_shap": 0.0092
+        },
+        {
+          "vocab_index": 95,
+          "token": "miw_b011_q07",
+          "mean_abs_shap": 0.0052
+        },
+        {
+          "vocab_index": 46,
+          "token": "miw_b005_q06",
+          "mean_abs_shap": 0.001563
+        }
+      ]
+    },
+    {
+      "topic": 10,
+      "features": [
+        {
+          "vocab_index": 216,
+          "token": "miw_b027_q00",
+          "mean_abs_shap": 0.020643
+        },
+        {
+          "vocab_index": 1088,
+          "token": "miw_b136_q00",
+          "mean_abs_shap": 0.018345
+        },
+        {
+          "vocab_index": 151,
+          "token": "miw_b018_q07",
+          "mean_abs_shap": 0.015849
+        },
+        {
+          "vocab_index": 28,
+          "token": "miw_b003_q04",
+          "mean_abs_shap": 0.014243
+        },
+        {
+          "vocab_index": 292,
+          "token": "miw_b036_q04",
+          "mean_abs_shap": 0.010053
+        },
+        {
+          "vocab_index": 94,
+          "token": "miw_b011_q06",
+          "mean_abs_shap": 0.009897
+        },
+        {
+          "vocab_index": 787,
+          "token": "miw_b098_q03",
+          "mean_abs_shap": 0.009361
+        },
+        {
+          "vocab_index": 73,
+          "token": "miw_b009_q01",
+          "mean_abs_shap": 0.009325
+        }
+      ]
+    },
+    {
+      "topic": 11,
+      "features": [
+        {
+          "vocab_index": 8,
+          "token": "miw_b001_q00",
+          "mean_abs_shap": 0.0136
+        },
+        {
+          "vocab_index": 129,
+          "token": "miw_b016_q01",
+          "mean_abs_shap": 0.0136
+        },
+        {
+          "vocab_index": 119,
+          "token": "miw_b014_q07",
+          "mean_abs_shap": 0.00965
+        },
+        {
+          "vocab_index": 227,
+          "token": "miw_b028_q03",
+          "mean_abs_shap": 0.007582
+        },
+        {
+          "vocab_index": 156,
+          "token": "miw_b019_q04",
+          "mean_abs_shap": 0.006707
+        },
+        {
+          "vocab_index": 105,
+          "token": "miw_b013_q01",
+          "mean_abs_shap": 0.005834
+        },
+        {
+          "vocab_index": 944,
+          "token": "miw_b118_q00",
+          "mean_abs_shap": 0.005375
+        },
+        {
+          "vocab_index": 87,
+          "token": "miw_b010_q07",
+          "mean_abs_shap": 0.005056
+        }
+      ]
+    }
+  ],
+  "status": "ok",
+  "generated_at": "2026-05-30T05:03:38Z",
+  "builder": "build_v_sweep_f13_shap v0.1",
+  "elapsed_seconds": 5.46
+}


### PR DESCRIPTION
42 new SHAP attribution cells for V13/V14/V15/V17/V18/V19/V20. F-13 now covers all 19 recipes × 6 scenes = 114 cells.