### PR TITLE
c434: ProdLDA F-7 — V20 top-2

### DIFF
--- a/data/derived/v_sweep/backbones_f7/prodlda_botswana_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_botswana_V12_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V12",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.241398,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:29:29Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_botswana_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_botswana_V14_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V14",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.060235,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:29:39Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_botswana_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_botswana_V18_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V18",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.096963,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:29:51Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_botswana_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_botswana_V1_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V1",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:29:09Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_botswana_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_botswana_V20_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V20",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.137881,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:30:04Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_botswana_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_botswana_V3_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V3",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.127013,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:29:19Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V12_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V12",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:23:49Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V14_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V14",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.081621,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:24:03Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V18_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V18",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.058546,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:24:19Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V1_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V1",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:23:22Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V20_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V20",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:24:36Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V3_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V3",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:23:36Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V12_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V12",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.344768,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:28:27Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V14_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V14",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.066057,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:28:38Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V18_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V18",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.064406,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:28:48Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V1_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V1",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.205923,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:28:08Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V20_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V20",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.334985,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:28:57Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_kennedy-space-center_V3_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V3",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.320498,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:28:18Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V12_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V12",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.411929,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:27:29Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V14_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V14",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.002265,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:27:38Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V18_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V18",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.000506,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:27:47Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V1_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V1",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.341909,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:27:11Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V20_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V20",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.328643,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:27:55Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_pavia-university_V3_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V3",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.401184,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:27:19Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V12_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V12",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.251463,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:26:43Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V14_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V14",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.231677,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:26:49Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V18_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V18",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.167878,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:26:56Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V1_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V1",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.000758,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:26:30Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V20_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V20",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.341723,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:27:01Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-a-corrected_V3_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V3",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.000758,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:26:37Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V12_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V12",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.179473,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:25:36Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V14_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V14",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.244648,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:25:52Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V18_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V18",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.094356,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:26:08Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V1_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V1",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:24:58Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V20_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V20",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.185367,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:26:24Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_salinas-corrected_V3_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V3",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.167076,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:25:20Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}


### PR DESCRIPTION
V20 mean F-7 NMI under ProdLDA = 0.221, V12 0.238 (V20 2nd). V20 is now top-3 across all 4 topic-model backbones (1st HDP+ETM, 2nd ProdLDA, 3rd LDA). The most cross-backbone-portable recipe for label-aligned topics.