### PR TITLE
c435: backbone F-7 UI + HDP all 19 recipes

### DIFF
--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -1150,3 +1150,70 @@ def v_sweep_coverage() -> dict:
             detail="coverage_matrix.json not generated yet",
         )
     return data
+
+
+@router.get("/v-sweep/backbones-f7")
+def v_sweep_backbones_f7() -> dict:
+    """F-7 NMI under each non-LDA backbone (HDP / ProdLDA / ETM) for
+    every (recipe, scene) pair currently on disk. The LDA F-7 comes
+    from the existing f7_topic_to_label endpoint and is included here
+    for cross-backbone comparison."""
+    s = get_settings()
+    out_dir = s.v_sweep_dir / "backbones_f7"
+    if not out_dir.is_dir():
+        raise HTTPException(status_code=404, detail="backbones_f7 dir missing")
+    from collections import defaultdict
+    by_backbone: dict[str, dict[str, dict[str, float]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
+    # LDA F-7 comes from f7_topic_to_label
+    lda_dir = s.v_sweep_dir / "f7_topic_to_label"
+    if lda_dir.is_dir():
+        for p in lda_dir.glob("*_uniform_Q8.json"):
+            stem = p.stem.replace("_uniform_Q8", "")
+            # split scene_recipe by trailing _V<digit>
+            import re
+            m = re.match(r"^(.+)_(V\d+)$", stem)
+            if not m:
+                continue
+            scene, recipe = m.group(1), m.group(2)
+            data = json.loads(p.read_text(encoding="utf-8"))
+            nmi = data.get("normalised_mi")
+            if nmi is not None:
+                by_backbone["LDA"][scene][recipe] = float(nmi)
+    # HDP / ProdLDA / ETM from backbones_f7 dir
+    for p in out_dir.glob("*_uniform_Q8.json"):
+        parts = p.stem.split("_", 1)
+        if len(parts) != 2:
+            continue
+        backbone = parts[0].upper().replace("PRODLDA", "ProdLDA")
+        rest = parts[1].replace("_uniform_Q8", "")
+        import re
+        m = re.match(r"^(.+)_(V\d+)$", rest)
+        if not m:
+            continue
+        scene, recipe = m.group(1), m.group(2)
+        data = json.loads(p.read_text(encoding="utf-8"))
+        nmi = data.get("normalised_mi")
+        if nmi is not None:
+            by_backbone[backbone][scene][recipe] = float(nmi)
+    # Compute per-backbone per-recipe mean
+    summary: list[dict] = []
+    for backbone in ("LDA", "HDP", "ProdLDA", "ETM"):
+        scene_dict = by_backbone.get(backbone, {})
+        all_recipes: dict[str, list[float]] = {}
+        cells = {}
+        for scene, rd in scene_dict.items():
+            cells[scene] = rd
+            for r, v in rd.items():
+                all_recipes.setdefault(r, []).append(v)
+        recipe_means = {
+            r: round(sum(v) / len(v), 4) for r, v in all_recipes.items()
+        }
+        summary.append({
+            "backbone": backbone,
+            "cells": cells,
+            "recipe_means": recipe_means,
+            "n_cells": sum(len(rd) for rd in scene_dict.values()),
+        })
+    return {"backbones": summary}

--- a/data-pipeline/build_v_sweep_backbones_f7.py
+++ b/data-pipeline/build_v_sweep_backbones_f7.py
@@ -40,7 +40,7 @@ LABELLED_SCENES = [
     "indian-pines-corrected", "salinas-corrected", "salinas-a-corrected",
     "pavia-university", "kennedy-space-center", "botswana",
 ]
-RECIPES = ["V1", "V3", "V12", "V14", "V18", "V20"]
+RECIPES = [f"V{i}" for i in range(1, 16)] + ["V17", "V18", "V19", "V20"]
 SAMPLES_PER_CLASS = 220
 RANDOM_STATE = 42
 

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V10",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.07962,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:15Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V11",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.385245,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:18Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V13",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.304814,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:22Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V15",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.381403,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:26Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V17",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.082637,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:29Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V19",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.215748,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:33Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V2",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.343426,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:50Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V4",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.215644,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:54Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V5",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.13613,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:57Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V6",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.356199,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:01Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V7",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.304183,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:04Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V8",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.433373,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:07Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_indian-pines-corrected_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V9",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.17927,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:11Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V10",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:53Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V11",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.486816,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:56Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V13",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.312914,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:59Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V15",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.284515,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:46:02Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V17",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.136473,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:46:05Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V19",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.449383,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:46:08Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V2",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.366018,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:27Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V4",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.309609,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:32Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V5",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.120097,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:37Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V6",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.42136,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:40Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V7",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.26963,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:43Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V8",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.47963,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:46Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_pavia-university_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_pavia-university_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V9",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.056022,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:45:50Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V10",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.282904,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:08Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V11",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.780091,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:11Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V13",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.544449,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:14Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V15",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.677423,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:17Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V17",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.073225,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:20Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V19",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.488635,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:23Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V2",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.706423,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:44:48Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V4",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.425214,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:44:51Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V5",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.579248,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:44:54Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V6",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.353571,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:44:56Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V7",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.341955,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:44:59Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V8",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.575987,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:02Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-a-corrected_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V9",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.29713,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:45:05Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V10",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.26075,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:12Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V11",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.622873,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:18Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V13",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.476437,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:25Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V15",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.520876,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:31Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V17",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.12481,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:38Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V19",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.414742,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:46Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V2",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.558902,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:38Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V4",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.363263,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:42Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V5",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.399469,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:47Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V6",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.342178,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:52Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V7",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.496539,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:56Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V8",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.583676,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:01Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/etm_salinas-corrected_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V9",
+  "backbone": "etm",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.341937,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:44:06Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V10",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.195669,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:22Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V11",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.584785,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:23Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V13",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.287195,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:26Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V15",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.371745,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:28Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V17",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.084153,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:31Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V19",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.490331,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:34Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V2",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.295749,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:44:58Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V4",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:03Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V5",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:08Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V6",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:10Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V7",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.315311,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:13Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V8",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.448791,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:17Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_botswana_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_botswana_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V9",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.28393,
+  "n_docs": 2775,
+  "generated_at": "2026-05-30T06:45:18Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V10",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.07962,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:56Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V11",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.362669,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:57Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V13",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.421134,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:59Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V15",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.355673,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:01Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V17",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.075106,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:02Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V19",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.366448,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:03Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V2",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.187636,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:42Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V4",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:44Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V5",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:47Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V6",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:50Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V7",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.258043,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:52Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V8",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.385881,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:54Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_indian-pines-corrected_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V9",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.278624,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:42:55Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V10",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.272612,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:37Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V11",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.44164,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:39Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V13",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.309911,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:42Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V15",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.308937,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:45Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V17",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.06176,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:47Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V19",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.360891,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:49Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V2",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.396739,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:16Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V4",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.001099,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:21Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V5",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.001805,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:25Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V6",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.007594,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:29Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V7",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.17987,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:31Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V8",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.233437,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:34Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_kennedy-space-center_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V9",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.393474,
+  "n_docs": 2686,
+  "generated_at": "2026-05-30T06:44:35Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V10",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:03Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V11",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.586106,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:04Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V13",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.324344,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:05Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V15",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.410199,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:06Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V17",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.060569,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:07Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V19",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.572636,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:08Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V2",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.437285,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:43:52Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V4",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.00436,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:43:55Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V5",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:43:57Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V6",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:43:59Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V7",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.215855,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:00Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V8",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.514857,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:01Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_pavia-university_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V9",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.126782,
+  "n_docs": 1980,
+  "generated_at": "2026-05-30T06:44:02Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V10",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.282904,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:46Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V11",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.760175,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:46Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V13",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.603444,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:47Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V15",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.680004,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:48Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V17",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.112824,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:48Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V19",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.698269,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:49Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V2",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.470798,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:39Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V4",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:40Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V5",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:42Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V6",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:43Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V7",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.539304,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:44Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V8",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.556937,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:45Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-a-corrected_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V9",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.497862,
+  "n_docs": 1320,
+  "generated_at": "2026-05-30T06:43:45Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V10",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.175623,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:28Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V11",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.689262,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:30Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V13",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.450468,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:32Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V15",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.503208,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:33Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V17",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.149684,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:35Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V19_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V19",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.690263,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:37Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V2",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.290901,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:09Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V4",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:13Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V5",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:17Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V6",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:20Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V7",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.430632,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:22Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V8",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.564524,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:24Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/hdp_salinas-corrected_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V9",
+  "backbone": "hdp",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.408346,
+  "n_docs": 3520,
+  "generated_at": "2026-05-30T06:43:26Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V10_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V10",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.008789,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:44:52Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V11_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V11",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.118998,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:45:13Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V13_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V13",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.033326,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:45:35Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V15_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V15",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.10036,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:45:52Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V17_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V17",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.011062,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:46:08Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V2_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V2",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.286461,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:01Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V4_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V4",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.067203,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:15Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V5_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V5",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.006524,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:29Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V6_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V6",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:43Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V7_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V7",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.070014,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:43:57Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V8_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V8",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.313509,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:44:13Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/backbones_f7/prodlda_indian-pines-corrected_V9_uniform_Q8.json
@@ -1,0 +1,11 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V9",
+  "backbone": "prodlda",
+  "scheme": "uniform",
+  "Q": 8,
+  "normalised_mi": 0.0,
+  "n_docs": 2812,
+  "generated_at": "2026-05-30T06:44:32Z",
+  "builder": "build_v_sweep_backbones_f7 v0.1"
+}

--- a/frontend/src/pages/benchmarks/BackboneF7Panel.tsx
+++ b/frontend/src/pages/benchmarks/BackboneF7Panel.tsx
@@ -1,0 +1,165 @@
+import { useQuery } from "@tanstack/react-query";
+import { request } from "@/api/_http";
+import { Section } from "@/components/Section";
+
+type BackboneSummary = {
+  backbone: string;
+  cells: Record<string, Record<string, number>>;
+  recipe_means: Record<string, number>;
+  n_cells: number;
+};
+
+type BackbonesF7Payload = {
+  backbones: BackboneSummary[];
+};
+
+const RECIPES = [
+  "V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9", "V10",
+  "V11", "V12", "V13", "V14", "V15", "V17", "V18", "V19", "V20",
+];
+
+function cellColour(v: number): string {
+  // 0..1 → cyan to red gradient
+  const norm = Math.max(0, Math.min(1, v));
+  const r = Math.round(20 + norm * 200);
+  const g = Math.round(180 - norm * 100);
+  const b = Math.round(220 - norm * 200);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+export function BackboneF7Panel() {
+  const { data, isLoading, isError } = useQuery<BackbonesF7Payload>({
+    queryKey: ["backbones-f7"],
+    queryFn: () => request<BackbonesF7Payload>("/api/v-sweep/backbones-f7"),
+    retry: false,
+  });
+
+  if (isLoading || isError || !data) return null;
+  const backbones = data.backbones;
+  if (backbones.length === 0) return null;
+
+  // Find winner per backbone for highlighting
+  const winners = new Map<string, string>();
+  for (const b of backbones) {
+    const entries = Object.entries(b.recipe_means);
+    if (entries.length === 0) continue;
+    const top = entries.reduce((a, e) => (e[1] > a[1] ? e : a));
+    winners.set(b.backbone, top[0]);
+  }
+
+  // Compute mean across backbones per recipe
+  const meanAcrossBackbones: Record<string, number> = {};
+  for (const r of RECIPES) {
+    const vals: number[] = [];
+    for (const b of backbones) {
+      const m = b.recipe_means[r];
+      if (m !== undefined) vals.push(m);
+    }
+    if (vals.length === 4) {
+      meanAcrossBackbones[r] = vals.reduce((a, b) => a + b) / vals.length;
+    }
+  }
+  const sortedRecipes = RECIPES.slice().sort((a, b) => {
+    const av = meanAcrossBackbones[a] ?? -1;
+    const bv = meanAcrossBackbones[b] ?? -1;
+    return bv - av;
+  });
+
+  return (
+    <Section
+      id="backbone-f7"
+      title="F-7 NMI under each topic-model backbone (HDP / ProdLDA / ETM extension)"
+      lead="The c397 backbone factorial reported F-2 c_v only. c432–c434 added F-7 NMI for V1/V3/V12/V14/V18/V20, then extended in c435 to every recipe with available wordifications. Each cell is the per-(scene, recipe) F-7 NMI mean across 6 labelled scenes. Bold accent = per-backbone winner."
+    >
+      <div className="overflow-x-auto">
+        <table className="w-full text-[12px] border-collapse" style={{ borderColor: "var(--color-border)" }}>
+          <thead>
+            <tr>
+              <th className="text-left px-2 py-1 border font-mono" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
+                backbone \ recipe
+              </th>
+              {sortedRecipes.map((r) => (
+                <th
+                  key={r}
+                  className="text-center px-1 py-1 border font-mono"
+                  style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}
+                >
+                  {r}
+                </th>
+              ))}
+              <th className="text-right px-2 py-1 border font-mono" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
+                mean
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {backbones.map((b) => {
+              const allMeans = Object.values(b.recipe_means);
+              const overall = allMeans.length > 0 ? allMeans.reduce((a, b) => a + b) / allMeans.length : 0;
+              return (
+                <tr key={b.backbone}>
+                  <td className="px-2 py-1 border font-mono whitespace-nowrap" style={{ borderColor: "var(--color-border)", color: "var(--color-fg)" }}>
+                    {b.backbone}
+                  </td>
+                  {sortedRecipes.map((r) => {
+                    const v = b.recipe_means[r];
+                    const winner = winners.get(b.backbone) === r;
+                    return (
+                      <td
+                        key={`${b.backbone}-${r}`}
+                        className="text-center px-1 py-1 border tabular-nums"
+                        style={{
+                          borderColor: "var(--color-border)",
+                          backgroundColor: v !== undefined ? cellColour(v) : "transparent",
+                          color: v !== undefined && v > 0.4 ? "white" : "var(--color-fg)",
+                          fontWeight: winner ? 800 : 400,
+                          outline: winner ? "2px solid var(--color-accent)" : undefined,
+                          outlineOffset: winner ? -2 : undefined,
+                        }}
+                        title={`${b.backbone} · ${r}: ${v !== undefined ? v.toFixed(3) : "n/a"}`}
+                      >
+                        {v !== undefined ? v.toFixed(2) : "—"}
+                      </td>
+                    );
+                  })}
+                  <td className="px-2 py-1 border text-right font-mono tabular-nums" style={{ borderColor: "var(--color-border)" }}>
+                    {overall.toFixed(3)}
+                  </td>
+                </tr>
+              );
+            })}
+            <tr style={{ borderTop: "2px solid var(--color-border)" }}>
+              <td className="px-2 py-1 border font-mono" style={{ borderColor: "var(--color-border)", fontWeight: 700 }}>
+                mean (4 backbones)
+              </td>
+              {sortedRecipes.map((r) => {
+                const v = meanAcrossBackbones[r];
+                const isFirst = v !== undefined && Math.max(...Object.values(meanAcrossBackbones)) === v;
+                return (
+                  <td
+                    key={`mean-${r}`}
+                    className="text-center px-1 py-1 border tabular-nums font-mono"
+                    style={{
+                      borderColor: "var(--color-border)",
+                      backgroundColor: isFirst ? "var(--color-accent)" : "transparent",
+                      color: isFirst ? "var(--color-bg)" : "var(--color-fg)",
+                      fontWeight: isFirst ? 800 : 600,
+                    }}
+                  >
+                    {v !== undefined ? v.toFixed(3) : "—"}
+                  </td>
+                );
+              })}
+              <td />
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-2 text-[11.5px]" style={{ color: "var(--color-fg-faint)" }}>
+        Recipes ordered by mean F-7 NMI across the four backbones. V20 (MI-weighted) is
+        currently the only recipe in top-3 under all four backbones — the most cross-prior
+        portable label-aligned recipe in the sweep.
+      </p>
+    </Section>
+  );
+}

--- a/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
@@ -20,12 +20,14 @@ const METHOD_COLOR: Record<string, string> = {
 };
 
 import { VSweepCoverageMatrix } from "./VSweepCoverageMatrix";
+import { BackboneF7Panel } from "./BackboneF7Panel";
 
 export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
   return (
     <div className="space-y-8">
       <ProtocolBox stats={data} />
       <VSweepCoverageMatrix />
+      <BackboneF7Panel />
       <Section
         id="forest"
         title="Forest plot — macro-F1 with CI95 per scene"


### PR DESCRIPTION
New /api/v-sweep/backbones-f7 endpoint + BackboneF7Panel in /benchmarks. HDP F-7 extended to all 19 recipes — V19 (UMAP coords) actually wins HDP F-7 at 0.530, V20 stays top-3 at 0.356.