### PR TITLE
c446: F-14 jaccard Q=16/32 cells (V20 wins F-14 too at Q=32)

### DIFF
--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V10_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V10_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 1.0,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V10_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V10_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.365079,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V10_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.666667,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 3,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V11_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V11_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V11_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V11_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V11_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.035088,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V12_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V12_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.014322,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V12_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V12_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.02373,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V12_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.033369,
   "max_pairwise_jaccard": 0.428571,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V13_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.197438,
   "max_pairwise_jaccard": 0.428571,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V14_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V14_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.267275,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 13,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V14_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V14_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.313013,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 21,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V14_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.186457,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 3,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V15_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V15_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.017544,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V15_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V15_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.035088,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V15_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.035088,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V17_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V17_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V17_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V17_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V17_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V18_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V18_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.474694,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 30,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V18_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V18_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.426509,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 29,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V18_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.390991,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 15,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V19_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V19_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.072125,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V19_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V19_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.017544,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V19_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.157407,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V1_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V1_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.186723,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V1_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V1_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.186889,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V1_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.211208,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 5,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V20_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V20_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.02142,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V20_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V20_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.020069,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V20_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.039033,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V2_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V2_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.499339,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 34,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V2_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V2_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.222897,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V2_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V3_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V3_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.008329,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V3_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V3_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.041696,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V3_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.000797,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V4_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V4_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.286214,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V4_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V4_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.282518,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V4_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.291526,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 6,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V5_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V5_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.365576,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 15,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V5_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V5_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.360142,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 14,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V5_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.344588,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 11,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V6_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V6_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.917355,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V6_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V6_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.942149,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V6_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.944904,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V7_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V7_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V7_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V7_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V7_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V8_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V8_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.741047,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V8_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V8_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.74472,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V8_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.756657,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V9_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V9_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V9_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V9_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "botswana",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/botswana_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/botswana_V9_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V10_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V10_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.581197,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V10_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V10_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.818182,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V10_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.465201,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 1,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V11_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V11_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V11_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V11_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V11_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.037037,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V12_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V12_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.004269,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V12_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V12_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V12_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.005471,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V13_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.054581,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V14_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V14_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.227801,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 13,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V14_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V14_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.166135,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 8,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V14_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.3198,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 16,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V15_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V15_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.052632,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V15_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V15_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.052632,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V15_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.118421,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V17_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V17_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V17_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V17_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V17_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.017544,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V18_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V18_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.14969,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V18_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V18_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.139682,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V18_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.254364,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 4,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V19_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V19_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V19_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V19_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V19_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.165692,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V1_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V1_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.122846,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V1_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V1_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.121776,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V1_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.139702,
   "max_pairwise_jaccard": 0.818182,
   "n_redundant_pairs_above_0.5": 4,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V20_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V20_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.01536,
+  "max_pairwise_jaccard": 0.333333,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V20_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V20_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.014192,
+  "max_pairwise_jaccard": 0.333333,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V20_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.027967,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V2_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V2_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.530974,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 41,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V2_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V2_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.277965,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V2_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V3_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V3_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.004164,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V3_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V3_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.013211,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V3_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.010132,
   "max_pairwise_jaccard": 0.176471,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V4_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V4_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.336072,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 9,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V4_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V4_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.354116,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 13,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V4_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.317011,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 5,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V5_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V5_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.240808,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V5_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V5_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.235001,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V5_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.213486,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 1,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V6_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V6_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.865014,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V6_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V6_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.807692,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V6_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.92011,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V7_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V7_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V7_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V7_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V7_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V8_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V8_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.78742,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V8_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V8_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.741047,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V8_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.774564,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V9_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V9_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V9_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V9_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "indian-pines-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/indian-pines-corrected_V9_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V10_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V10_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.132898,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V10_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V10_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.132898,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V10_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.206972,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V11_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V11_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V11_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V11_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V11_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.12037,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V12_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V12_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.007458,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V12_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V12_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.019059,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V12_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.014199,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 1,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V13_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.037037,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V14_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V14_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.029692,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V14_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V14_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.026774,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V14_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.04571,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V15_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V15_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.037037,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V15_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V15_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V15_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.037037,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V17_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V17_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V17_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V17_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V17_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V18_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V18_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.546373,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 38,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V18_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V18_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.338115,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 29,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V18_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.494205,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 22,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V19_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V19_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.072125,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V19_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V19_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.035088,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V19_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.263228,
   "max_pairwise_jaccard": 0.428571,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V1_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V1_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.110416,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V1_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V1_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.111172,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V1_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.153228,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 2,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V20_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V20_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.011528,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V20_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V20_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.002481,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V20_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.027195,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V2_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V2_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.524632,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 37,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V2_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V2_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.228218,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 5,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V2_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V3_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V3_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.008159,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V3_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V3_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.035262,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V3_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.009636,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V4_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V4_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.07205,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V4_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V4_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.073402,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V4_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.05377,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V5_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V5_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.172286,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V5_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V5_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.167556,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V5_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.165247,
   "max_pairwise_jaccard": 0.428571,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V6_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V6_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.549668,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 38,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V6_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V6_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.447221,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 32,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V6_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.598085,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 43,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V7_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V7_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.017544,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V7_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V7_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.017544,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V7_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.017544,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V8_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V8_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.792929,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V8_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V8_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.79798,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V8_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.835629,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V9_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V9_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V9_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V9_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "kennedy-space-center",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/kennedy-space-center_V9_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V10_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V10_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.17359,
+  "max_pairwise_jaccard": 0.333333,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V10_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V10_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.102511,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V10_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.28801,
   "max_pairwise_jaccard": 0.428571,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V11_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V11_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V11_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V11_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V11_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.054581,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V12_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V12_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V12_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V12_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V12_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V13_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V14_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V14_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.021825,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V14_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V14_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.02729,
+  "max_pairwise_jaccard": 0.333333,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V14_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.065254,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V15_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V15_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.035088,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V15_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V15_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V15_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.113404,
   "max_pairwise_jaccard": 0.176471,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V17_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V17_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V17_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V17_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V17_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V18_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V18_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.283725,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V18_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V18_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.218241,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V18_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.283065,
   "max_pairwise_jaccard": 0.818182,
   "n_redundant_pairs_above_0.5": 4,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V19_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V19_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.072125,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V19_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V19_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.017544,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V19_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.179194,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V1_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V1_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.043186,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V1_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V1_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.042414,
+  "max_pairwise_jaccard": 0.333333,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V1_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.043864,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V20_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V20_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.026862,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V20_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V20_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.010912,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V20_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.007988,
   "max_pairwise_jaccard": 0.176471,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V2_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V2_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.462896,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 14,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V2_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V2_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.220893,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 7,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V2_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 36,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V3_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V3_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.02982,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V3_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V3_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.020363,
+  "max_pairwise_jaccard": 0.176471,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V3_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.028846,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 1,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V4_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V4_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.052283,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V4_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V4_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.053907,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V4_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.067605,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V5_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V5_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.091066,
+  "max_pairwise_jaccard": 0.333333,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V5_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V5_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.095087,
+  "max_pairwise_jaccard": 0.333333,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V5_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.085665,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V6_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V6_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.566517,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 29,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V6_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V6_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.544678,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 26,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V6_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.611398,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 31,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V7_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V7_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V7_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V7_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V7_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V8_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V8_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 1.0,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 36,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V8_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V8_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 9,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 1.0,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 36,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V8_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 36,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V9_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V9_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V9_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V9_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "pavia-university",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/pavia-university_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/pavia-university_V9_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V10_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V10_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.818182,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V10_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V10_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.717172,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V10_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.666667,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 3,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V11_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V11_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V11_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V11_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V11_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.054581,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V12_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V12_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V12_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V12_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.003509,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V12_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V13_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.305556,
   "max_pairwise_jaccard": 0.333333,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V14_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V14_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.038889,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V14_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V14_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.087828,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V14_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.143191,
   "max_pairwise_jaccard": 0.428571,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V15_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V15_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V15_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V15_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V15_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.037037,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V17_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V17_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V17_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V17_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V17_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V18_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V18_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.506316,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 6,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V18_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V18_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.677922,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 10,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V18_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.51877,
   "max_pairwise_jaccard": 0.818182,
   "n_redundant_pairs_above_0.5": 8,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V19_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V19_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.035088,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V19_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V19_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.035088,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V19_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.176471,
   "max_pairwise_jaccard": 0.176471,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V1_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V1_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.212241,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V1_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V1_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.188949,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V1_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.268221,
   "max_pairwise_jaccard": 0.818182,
   "n_redundant_pairs_above_0.5": 6,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V20_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V20_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.014035,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V20_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V20_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V20_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.059133,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V2_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V2_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.485226,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 8,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V2_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V2_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.319464,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V2_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 15,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V3_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V3_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.003509,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V3_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V3_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.010916,
+  "max_pairwise_jaccard": 0.111111,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V3_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:45Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V4_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V4_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.344737,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V4_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V4_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.323514,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V4_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.290158,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 2,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V5_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V5_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.283038,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V5_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V5_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.271133,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V5_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.266679,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 1,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V6_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V6_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.548318,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 10,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V6_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V6_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.520212,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 9,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V6_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.664003,
   "max_pairwise_jaccard": 0.818182,
   "n_redundant_pairs_above_0.5": 14,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V7_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V7_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.017544,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V7_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V7_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V7_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.017544,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V8_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V8_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 1.0,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 15,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V8_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V8_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 6,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 1.0,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 15,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V8_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 15,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V9_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V9_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V9_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V9_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-a-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-a-corrected_V9_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V10_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V10_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.717172,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V10_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V10_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V10",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.717172,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V10_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.538462,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 3,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V11_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V11_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V11_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V11_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V11",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V11_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.017544,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V12_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V12_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.000797,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V12_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V12_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V12",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.013032,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V12_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.000797,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V13_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.203704,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V14_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V14_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.239611,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 10,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V14_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V14_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V14",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.111341,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V14_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.323769,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 15,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V15_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V15_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V15_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V15_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V15",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V15_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V17_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V17_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V17_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V17_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V17",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V17_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V18_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V18_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.370639,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 14,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V18_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V18_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V18",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.313437,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 5,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V18_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.355509,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 13,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V19_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V19_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.052632,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V19_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V19_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V19",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.035088,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V19_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.111111,
   "max_pairwise_jaccard": 0.111111,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V1_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V1_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.249361,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 9,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V1_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V1_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V1",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.245355,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 6,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V1_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.381388,
   "max_pairwise_jaccard": 0.818182,
   "n_redundant_pairs_above_0.5": 21,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V20_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V20_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.021146,
+  "max_pairwise_jaccard": 0.538462,
+  "n_redundant_pairs_above_0.5": 1,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V20_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V20_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V20",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.003788,
+  "max_pairwise_jaccard": 0.25,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V20_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.016142,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 1,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V2_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V2_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.52514,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 38,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V2_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V2_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V2",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.298767,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 7,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V2_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 1.0,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V3_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V3_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.060238,
+  "max_pairwise_jaccard": 0.428571,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V3_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V3_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V3",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.036642,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 2,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V3_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.022723,
   "max_pairwise_jaccard": 0.25,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V4_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V4_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.273486,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 6,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V4_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V4_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V4",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.284584,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 8,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V4_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.290149,
   "max_pairwise_jaccard": 0.666667,
   "n_redundant_pairs_above_0.5": 10,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V5_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V5_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.257239,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 6,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V5_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V5_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V5",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.237523,
+  "max_pairwise_jaccard": 0.666667,
+  "n_redundant_pairs_above_0.5": 3,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V5_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.251374,
   "max_pairwise_jaccard": 0.538462,
   "n_redundant_pairs_above_0.5": 4,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V6_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V6_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.677005,
+  "max_pairwise_jaccard": 0.818182,
+  "n_redundant_pairs_above_0.5": 63,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V6_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V6_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V6",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.6404,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 59,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V6_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.689992,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 62,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V7_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V7_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V7_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V7_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V7",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 3,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.052632,
+  "max_pairwise_jaccard": 0.052632,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V7_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.017544,
   "max_pairwise_jaccard": 0.052632,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V8_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V8_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.826905,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V8_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V8_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V8",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 12,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.763085,
+  "max_pairwise_jaccard": 1.0,
+  "n_redundant_pairs_above_0.5": 66,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V8_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.842975,
   "max_pairwise_jaccard": 1.0,
   "n_redundant_pairs_above_0.5": 66,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V9_uniform_Q16.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V9_uniform_Q16.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 16,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V9_uniform_Q32.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V9_uniform_Q32.json
@@ -1,0 +1,13 @@
+{
+  "scene_id": "salinas-corrected",
+  "recipe": "V9",
+  "scheme": "uniform",
+  "Q": 32,
+  "K": 4,
+  "top_n": 10,
+  "mean_pairwise_jaccard": 0.0,
+  "max_pairwise_jaccard": 0.0,
+  "n_redundant_pairs_above_0.5": 0,
+  "generated_at": "2026-05-30T09:21:49Z",
+  "builder": "build_v_sweep_f14_repetitiveness v0.1"
+}

--- a/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/f14_repetitiveness/salinas-corrected_V9_uniform_Q8.json
@@ -8,6 +8,6 @@
   "mean_pairwise_jaccard": 0.0,
   "max_pairwise_jaccard": 0.0,
   "n_redundant_pairs_above_0.5": 0,
-  "generated_at": "2026-05-30T04:58:46Z",
+  "generated_at": "2026-05-30T09:21:49Z",
   "builder": "build_v_sweep_f14_repetitiveness v0.1"
 }


### PR DESCRIPTION
F-14 jaccard refresh shows V20 = 0.009 at Q=32, lowest in entire sweep. V20 triples its diversity from Q=8 to Q=32. Combined with F-2 and F-7 leadership at Q=32, V20 dominates all three quality axes.