### PR TITLE
audit 2026-05-30: number consistency fixes + per-scene win corrections + i18n update

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -879,7 +879,7 @@
         "tag": "MI-weighted bands",
         "title": "Mutual-info weighted band tokens (V20)",
         "summary": "V1 (band, q-bin) tokens but with copies weighted by per-band mutual information with labels. Up to 8 copies per band per pixel.",
-        "theory": "V20 takes V1's vocabulary and re-weights each band by its discriminative power (sklearn mutual_info_classif). Bands with high MI emit more copies; near-zero MI bands emit ~none. F-2 c_v 0.74-0.95 — competitive with V12. **V20 wins F-7 NMI on 3 of 5 scenes (indian-pines, salinas-A, kennedy-SC) at Q=8 and overtakes V12 on the LDA mean as Q refines (Q=8 to Q=32: F-2 +0.060, F-7 +0.043)**. Most robust counterfactual topic basis at Q=8 (F-22 mean median L1 = 26.3), with a non-monotonic Q=16 peak (41.8, +59%). Trade-off: V20 falls in the informative-but-seed-sensitive F-18 regime (~0.45)."
+        "theory": "V20 takes V1's vocabulary and re-weights each band by its discriminative power (sklearn mutual_info_classif). Bands with high MI emit more copies; near-zero MI bands emit ~none. F-2 c_v 0.85-0.91 — competitive with V12. **V20 dominance scales sharply with Q (cross-19-recipe LDA F-7 winner on 1/6 scenes at Q=8 to 4/6 at Q=32) and overtakes V12 on the LDA mean (Q=8 to Q=32: F-2 +0.060, F-7 +0.043)**. Most robust counterfactual topic basis at Q=8 (F-22 mean median L1 = 26.3), with a non-monotonic Q=16 peak (41.8, +59%). Trade-off: V20 falls in the informative-but-seed-sensitive F-18 regime (~0.45)."
       },
       "V18": {
         "tag": "graph-Laplacian",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -879,7 +879,7 @@
         "tag": "bandas ponderadas por MI",
         "title": "Tokens bandas MI-ponderadas (V20)",
         "summary": "Tokens V1 (banda, q-bin) pero con copias ponderadas por la información mutua por banda con las etiquetas. Hasta 8 copias por banda por píxel.",
-        "theory": "V20 toma el vocabulario de V1 y re-pondera cada banda por su poder discriminativo (sklearn mutual_info_classif). Bandas con MI alta emiten más copias; bandas con MI ~0 emiten ~ninguna. F-2 c_v 0.74-0.95 — competitivo con V12. **V20 gana F-7 NMI en 3 de 5 escenas (indian-pines, salinas-A, kennedy-SC) a Q=8 y supera a V12 en la media LDA al refinar Q (Q=8→Q=32: F-2 +0.060, F-7 +0.043)**. Base de tópicos más robusta contrafactualmente a Q=8 (F-22 media mediana L1 = 26.3), con pico no monotónico a Q=16 (41.8, +59%). Trade-off: V20 cae en el régimen informativa-pero-seed-sensitive en F-18 (~0.45)."
+        "theory": "V20 toma el vocabulario de V1 y re-pondera cada banda por su poder discriminativo (sklearn mutual_info_classif). Bandas con MI alta emiten más copias; bandas con MI ~0 emiten ~ninguna. F-2 c_v 0.85-0.91 — competitivo con V12. **La dominancia de V20 escala fuertemente con Q (de ganadora LDA F-7 en 1/6 escenas a Q=8 a 4/6 a Q=32, cross-19-recetas) y supera a V12 en la media LDA al refinar Q (Q=8→Q=32: F-2 +0.060, F-7 +0.043)**. Base de tópicos más robusta contrafactualmente a Q=8 (F-22 media mediana L1 = 26.3), con pico no monotónico a Q=16 (41.8, +59%). Trade-off: V20 cae en el régimen informativa-pero-seed-sensitive en F-18 (~0.45)."
       },
       "V18": {
         "tag": "Laplaciano grafo",


### PR DESCRIPTION
## Summary

Deep audit findings applied to docs and i18n:

- **F-14 V20 'min' qualifier** added (V9/V11/V17 hit 0.000 trivially due to small vocab; V20's 0.009 is min among informative-vocab recipes only)
- **V20 per-scene win count corrected** in i18n EN+ES: was "3 of 5 scenes" (stale V20-vs-V12 framing), now "cross-19-recipe LDA F-7 winner on 1/6 scenes at Q=8 to 4/6 at Q=32"
- Audit query reproducible per issue #760 (now closed)

## Test plan

- [ ] Frontend renders updated V20 theory string in both locales
- [ ] No regression on other i18n keys (708 each, parity preserved)

## Related

- Closes #760
- Audit also raised: #755, #756, #757, #758, #759 (open enhancements)