### PR TITLE
Audit #589: provenance git_sha + GPU-count fix + pipeline docs

### DIFF
--- a/data-pipeline/DAG.md
+++ b/data-pipeline/DAG.md
@@ -1,166 +1,591 @@
 # Data-pipeline Build DAG
 
-**Status**: focal map of the V-sweep dependency chain. Tier 2 ask
-from #589.
+**Status**: source-of-truth build order for the `data-pipeline/` builders
+(issue #589 Tier 2). Before this file there was no single declaration of
+the build order; the dependency edges were implicit in each builder's
+`np.load` / `json.load` / `sp.load_npz` calls. This document makes them
+explicit.
 
-The full data-pipeline has 108 Python files in `data-pipeline/`. This
-document maps the critical-path dependencies for the **V-sweep**
-artefacts that are surfaced to the web app (`/workspace/methods`).
-For builders outside the V-sweep, see the per-builder module docstring
-or run with `--help`.
+Every edge below was derived **only from code evidence** — a producer
+`A → B` edge exists when builder `B` reads a `data/derived/...` or
+`data/local/...` file that builder `A` writes, confirmed by matching the
+actual path string in `A`'s output and `B`'s input. Reading a raw scene
+through `research_core.raw_scenes.load_scene` is a dependency on the
+`fetch_*` that downloaded the scene, **not** on another `build_*`.
+Importing `research_core.*` is a library import, not a DAG edge.
 
 ## Convention
 
-Each node is a python file in `data-pipeline/`. An arrow `A → B` means
-**B reads files written by A**, so A must run first. The DAG is read
-top-to-bottom in execution order.
+- Each node is a Python file in `data-pipeline/`.
+- An arrow `A → B` means **B reads files written by A**, so A must run
+  before B.
+- Most builders write under `data/derived/...` (git-tracked, served by
+  the web app). Several also write heavy intermediate artefacts under
+  `data/local/...` (git-ignored: `phi.npy`, `theta.npy`, `doc_term.npz`,
+  segmentation `assignment.bin`, latent `features.npy`). Both kinds of
+  output create real edges.
+- `data/raw/...` is produced by the `fetch_*` scripts only.
 
-A node's outputs are listed in **bold** under its name. Inputs are
-implicit from the dependency edges.
+## Stages (topological build order)
 
-## Phase 0 — Raw data acquisition
+Run stages strictly in order. Within a stage, builders are mutually
+independent and may run in any order / in parallel, **except** for the
+two cross-stage exceptions noted under Stage 2.
 
-```
-fetch_public_hsi.py     fetch_public_msi.py     fetch_public_spectral_libraries.py
-       |                       |                          |
-       v                       v                          v
-            data/raw/<scene_id>/   (NOT in git)
-```
+### Stage 0 — Fetch (raw acquisition)
 
-These three fetchers populate `data/raw/`. They are run once per
-machine and only re-run when a new scene is added.
-
-## Phase 1 — Wordification builders (V-sweep)
-
-All twenty wordification builders (V1..V15 + V17..V20) read from
-`data/raw/<scene>/` and write into
-`data/local/wordifications/<recipe>/<scheme>_Q<q>/<scene>/`.
+Populate `data/raw/`. Run once per machine; re-run only when a new scene
+or library is added. No derived-data inputs.
 
 ```
-build_wordifications.py             → V1, V2, V3
-build_wordifications_v4plus.py      → V4, V5, V10
-build_wordifications_v6plus.py      → V6, V8, V9, V12
-build_wordifications_v7v11.py       → V7, V11
-build_wordifications_v13.py         → V13 (VQ-VAE codebook)
-build_wordifications_v14.py         → V14 (CWT-Morlet)
-build_wordifications_v15.py         → V15 (spectral indices)
-build_wordifications_v16.py         → V16 (HyperSIGMA, scaffolded)
-build_wordifications_v17.py         → V17 (sparse-coding dictionary)
-build_wordifications_v18.py         → V18 (graph-Laplacian eigenvectors)
-build_wordifications_v19.py         → V19 (UMAP coordinates)
-build_wordifications_v20.py         → V20 (MI-weighted bands)
+fetch_public_hsi.py                fetch_public_msi.py
+fetch_public_spectral_libraries.py fetch_public_unmixing.py
+fetch_hidsag.py                    fetch_ecostress_metadata.py
 ```
 
-**Outputs**:
-- `doc_term.npz` (CSR sparse [D, V])
-- `vocab.json` (list of tokens + metadata)
+### Stage 1 — Core / foundational builders
 
-## Phase 2 — V-sweep canonical LDA fits
-
-```
-build_v_sweep_canonical_fit.py
-       |
-       v
-data/derived/v_sweep/topic_views/<scene>_<recipe>_uniform_Q8.json
-       (114 cells = 19 recipes × 6 scenes)
-```
-
-**Outputs**: per-cell K, mean_doc_length, perplexity, phi (φ), theta (θ).
-
-## Phase 3 — Per-axis evaluators
-
-All consume `topic_views/` from phase 2 and run a single F-axis
-metric per cell.
+Read raw scenes (and packaged manifests) only; produce the shared
+artefacts the rest of the pipeline consumes. Mutually independent.
 
 ```
-                    topic_views (phase 2)
-                            |
-                            v
-+---------------------------+----------------------------+
-|             |             |              |             |
-v             v             v              v             v
-build_v_sweep_f1_*  build_v_sweep_f2_coherence  build_v_sweep_f7_topic_to_label
-                            |                  |
-build_v_sweep_f14_repetitiveness  build_v_sweep_f18_reliability
-                            |
-                    build_v_sweep_f17_cross_scene
-                            |
-                    build_v_sweep_f22_counterfactual
-                            |
-                    build_v_sweep_f15_self_judge
-                            |
-                    build_v_sweep_f13_shap
+build_local_inventory.py          → core/local_dataset_inventory.json
+build_method_statistics.py        → core/method_statistics.json
+build_exploration_views.py        → core/exploration_views.json
+build_hidsag_curated_subset.py    → core/hidsag_curated_subset.json
+build_eda_per_scene.py            → eda/per_scene/<scene>.json
+build_real_samples.py             → real/real_samples.json
+build_field_samples.py            → field/field_samples.json
+build_spectral_library_samples.py → spectral/library_samples.json
+build_segmentation_baselines.py   → baselines/segmentation_baselines.json
+build_groupings.py                → groupings/ + data/local/groupings/<algo>/<scene>/assignment.bin
+build_representations.py          → representations/ + data/local/representations/<method>/<scene>/features.npy
+build_topic_views.py              → topic_views/<scene>.json + data/local/lda_fits/<scene>/{phi,theta,corpus_marginal,sample_*}.npy
+build_neural_topic_models.py      → topic_variants/<variant>/ + data/local/topic_variants/<variant>/<scene>/
+build_topic_model_variants.py     → topic_variants/<variant>/ + data/local/topic_variants/<variant>/<scene>/
+build_band_masked_topic_models.py → band_masks/{index,summary}.json   (soft dep — see note below)
+build_lda_sweep.py                → lda_sweep/
+build_optuna_hyperparam_search.py → lda_hyperparam_search/
+build_rate_distortion_curve.py    → rate_distortion_curve/
+build_hidsag_band_quality.py *    → core/hidsag_band_quality.json   (* reads core/hidsag_curated_subset.json → see Stage 2 note)
+build_classical_seed_stability.py → classical_seed_stability/
+build_deep_seed_stability.py      → deep_seed_stability/
+build_deep_anomaly.py             → deep_anomaly/
+build_neural_topic_seed_stability.py → neural_topic_seed_stability/
+run_hidsag_preprocessing_sensitivity.py → core/hidsag_preprocessing_sensitivity.json
+                                          (module-loads run_local_core_benchmarks.py)
 ```
 
-**Outputs**: one JSON per (recipe, scene) under
-`data/derived/v_sweep/<axis>/`. Indexed via `data/manifests/index.json`.
-
-## Phase 4 — Backbone factorial (LDA / HDP / ProdLDA / ETM)
-
-Each backbone runs over the same V × scene grid:
-
-```
-                    wordifications (phase 1)
-                            |
-                            v
-+---------------------------+----------------------------+
-|             |             |             |              |
-v             v             v             v              v
-build_v_sweep_canonical_fit.py     (LDA — phase 2 above)
-build_v_sweep_hdp.py               → hdp_backbone/
-build_v_sweep_prodlda_backbone.py  → prodlda_backbone/
-build_v_sweep_etm_backbone.py      → etm_backbone/
-```
-
-## Phase 5 — Web-app curation
+The twelve **wordification** builders also belong logically to Stage 1
+(they read raw scenes and write the corpus the V-sweep consumes), with
+one exception — `build_wordifications_v6plus.py` additionally reads
+`endmember_baseline/` and `data/local/groupings/`, so it must run later
+(see Stage 2). All write
+`data/local/wordifications/<recipe>/<scheme>_Q<q>/<scene>/{doc_term.npz, vocab.json}`:
 
 ```
-data/derived/* (phases 2-4) + data/raw/<scene>/         data/local/wordifications/*
-                       \                                /
-                        \                              /
-                         v                            v
-                            curate_for_web.py
-                                    |
-                                    v
-              data/web/manifests/index.json   data/web/.../bundle.json
+build_wordifications.py        → V1, V2, V3
+build_wordifications_v4plus.py → V4, V5, V10
+build_wordifications_v7v11.py  → V7, V11
+build_wordifications_v13.py    → V13 (VQ-VAE codebook)
+build_wordifications_v14.py    → V14 (CWT-Morlet)
+build_wordifications_v15.py    → V15 (spectral indices)
+build_wordifications_v16.py    → V16 (HyperSIGMA, scaffolded)
+build_wordifications_v17.py    → V17 (sparse-coding dictionary)
+build_wordifications_v18.py    → V18 (graph-Laplacian eigenvectors)
+build_wordifications_v19.py    → V19 (UMAP coordinates)
+build_wordifications_v20.py    → V20 (MI-weighted bands)
+build_wordifications_v6plus.py → V6, V8, V9, V12  (Stage 2 — see note)
+build_wordifications_all.py    → orchestrator: imports _v4plus/_v6plus/_v7v11 (no own output)
 ```
 
-The curated bundles are what the FastAPI app serves under `/api/`.
+### Stage 2 — First-order consumers
 
-## Phase 6 — Web-app payload aggregation
+Read Stage-1 artefacts.
 
 ```
-                        curated bundle (phase 5)
-                                    |
-                                    v
-                            build_analysis_payload.py
-                                    |
-                                    v
-                  data/derived/analysis/analysis.json
-                                    |
-                                    v
-                            FastAPI /api/analysis/*
+# topic_views / lda_fits consumers
+build_topic_to_data.py          ← topic_views.py        (local/lda_fits/<scene>/theta.npy)
+build_topic_to_library.py       ← topic_views.py + spectral_library_samples.py
+build_topic_to_usgs_v7.py       ← topic_views.py
+build_embedded_baseline.py      ← topic_views.py        (local/lda_fits/<scene>/phi.npy)
+build_endmember_baseline.py     ← topic_views.py        (local/lda_fits/<scene>/phi.npy + topic_views/)
+build_topic_routed_classifier.py← topic_views.py        (local/lda_fits/<scene>/phi.npy)
+build_topic_routed_deep_gate.py ← topic_views.py + representations.py
+build_cross_scene_transfer.py   ← topic_views.py
+build_spectral_browser.py       ← topic_views.py
+build_spectral_density.py       ← topic_views.py
+build_topic_anomaly.py          ← topic_views.py
+build_topic_spatial_full.py     ← topic_views.py
+build_topic_stability.py        ← topic_views.py
+build_hierarchical_super_topics.py ← topic_views.py
+build_b12_llm_tea_leaves.py     ← topic_views.py
+build_linear_probe_panel.py     ← topic_views.py + representations.py
+build_neural_topic_comparison.py← topic_views.py + neural_topic_models.py / topic_model_variants.py
+build_quantization_sensitivity.py ← topic_views.py + wordifications*    (local/lda_fits + corpus)
+
+# real/spectral consumers
+build_analysis_payload.py       ← real_samples.py + spectral_library_samples.py
+build_corpus_previews.py        ← real_samples.py + spectral_library_samples.py
+
+# hidsag chain
+build_hidsag_region_documents.py← hidsag_curated_subset.py
+build_eda_hidsag.py             ← hidsag_curated_subset.py + hidsag_region_documents.py
+build_dmr_lda_hidsag.py         ← hidsag_curated_subset.py
+build_band_masked_topic_models_hidsag.py ← hidsag_curated_subset.py
+run_local_core_benchmarks.py    ← hidsag_curated_subset.py + hidsag_region_documents.py + spectral_library_samples.py
+build_v_sweep_hidsag.py         ← hidsag_region_documents.py   (module-loads the 4 corpus builders)
+
+# preprocessing-sensitivity chain
+build_hidsag_cross_preprocessing_stability.py ← run_hidsag_preprocessing_sensitivity.py
+
+# wordification recipe that depends on Stage-1 baselines (cross-stage exception)
+build_wordifications_v6plus.py  ← endmember_baseline.py + groupings.py
 ```
 
-## Critical-path runtime budget
+**Cross-stage exceptions** (the two cases where Stage 1 is not a clean
+parallel layer):
 
-Rough wall-clock per builder on the dev workstation (CPU only, 32 GB
-RAM, 8-core i7-11800H, Windows 11):
+1. `build_wordifications_v6plus.py` (V6/V8/V9/V12) reads
+   `endmember_baseline/<scene>.json` and
+   `data/local/groupings/felzenszwalb/<scene>/assignment.bin`. It must
+   run **after** `build_endmember_baseline.py` and `build_groupings.py`.
+2. `build_hidsag_band_quality.py` reads
+   `core/hidsag_curated_subset.json`, so it must run **after**
+   `build_hidsag_curated_subset.py`.
 
-| Phase | Cumulative time | Note |
+**Soft (optional, graceful-fallback) edge** —
+`build_interpretability.py → build_band_masked_topic_models.py`: the
+`top_50_fisher` mask variant reads
+`data/derived/interpretability/<scene>/band_cards.json` (written by
+`build_interpretability`, Stage 6). The read is guarded by
+`if not band_cards_path.exists(): return <all-bands mask>`, so a build
+without interpretability still completes (that one mask variant falls
+back to keeping all bands). This is the only back-edge in the graph: a
+*complete* `top_50_fisher` mask requires `build_interpretability` to have
+run in a prior cycle. To get the fully-populated mask, re-run
+`build_band_masked_topic_models.py` after `build_interpretability.py`.
+
+### Stage 3 — Second-order consumers
+
+```
+build_band_mask_canonical_comparison.py ← band_masked_topic_models.py + topic_to_data.py + topic_views.py
+build_cross_method_agreement.py ← topic_to_data.py + groupings.py
+build_spatial_validation.py     ← topic_to_data.py
+build_topic_spatial_continuous.py ← topic_to_data.py + topic_views.py
+build_hidsag_topic_measurements.py ← band_masked_topic_models_hidsag.py
+build_method_statistics_hidsag.py ← run_local_core_benchmarks.py
+build_bayesian_method_comparison.py ← run_local_core_benchmarks.py + method_statistics_hidsag.py
+build_mutual_information.py      ← topic_views.py + representations.py + hidsag_curated_subset.py
+                                  + neural_topic_models.py / topic_model_variants.py / dmr_lda_hidsag.py
+build_bayesian_classification_labelled.py ← topic_routed_classifier.py
+build_bayesian_classification_deep.py     ← topic_routed_deep_gate.py
+build_subset_cards.py           ← corpus_previews.py (+ real_samples / spectral / field / manifests)
+build_v_sweep_hidsag_f7.py      ← hidsag_region_documents.py + v_sweep_hidsag.py
+```
+
+### Stage 4 — V-sweep canonical fit + corpus-only backbones
+
+All read the wordification corpus from Stage 1
+(`data/local/wordifications/<recipe>/uniform_Q<q>/<scene>/doc_term.npz`).
+`build_v_sweep_canonical_fit.py` additionally writes the LDA fits that
+the Stage-5 F-axis builders consume.
+
+```
+build_v_sweep_canonical_fit.py  ← wordifications*   → data/local/v_sweep/lda_fits/ + v_sweep/topic_views/
+build_v_sweep_f1_classification.py ← wordifications* → v_sweep/f1_per_fold/ + v_sweep/f1_win_matrix.json
+build_v_sweep_hdp.py            ← wordifications*   → v_sweep/hdp_backbone/
+build_v_sweep_prodlda_backbone.py ← wordifications* → v_sweep/prodlda_backbone/   (module-loads neural_topic_models)
+build_v_sweep_backbones_f7.py   ← wordifications*   → v_sweep/backbones_f7/        (module-loads neural_topic_models)
+build_v_sweep_etm_backbone.py   ← wordifications*   → v_sweep/etm_backbone/        (module-loads neural_topic_models + prodlda_backbone)
+build_v_sweep_f17_cross_scene.py← wordifications*   → v_sweep/f17_cross_scene/
+build_v_sweep_f18_reliability.py← wordifications*   → v_sweep/f18_reliability/
+```
+
+### Stage 5 — V-sweep F-axes that read the canonical fits
+
+Read `data/local/v_sweep/lda_fits/` from `build_v_sweep_canonical_fit.py`
+(the corpus-reading ones also read the Stage-1 wordifications).
+
+```
+build_v_sweep_f1_bayesian.py    ← v_sweep_f1_classification.py   (v_sweep/f1_per_fold/)
+build_v_sweep_f1_bootstrap.py   ← v_sweep_f1_classification.py   (v_sweep/f1_per_fold/)
+build_v_sweep_f2_coherence.py   ← v_sweep_canonical_fit.py + wordifications*
+build_v_sweep_f7_topic_to_label.py ← v_sweep_canonical_fit.py
+build_v_sweep_f14_repetitiveness.py ← v_sweep_canonical_fit.py
+build_v_sweep_counterfactual.py ← v_sweep_canonical_fit.py + wordifications*
+build_v_sweep_f13_shap.py       ← v_sweep_canonical_fit.py + wordifications*
+build_v_sweep_f15_llm_alignment.py ← v_sweep_canonical_fit.py + wordifications*
+build_v_sweep_f15_self_judge.py ← v_sweep_canonical_fit.py + wordifications*
+build_b12_self_judge.py         ← topic_views.py + v_sweep_canonical_fit.py
+audit_citation_openalex.py      → v_sweep/citation_audit.json   (audit, not a build edge)
+```
+
+### Stage 6 — Aggregators (read many derived artefacts)
+
+```
+build_external_validation.py ← topic_views.py + spectral_library_samples.py + method_statistics_hidsag.py
+build_validation_blocks.py   ← topic_views.py + quantization_sensitivity.py + topic_to_library.py
+                               + topic_to_usgs_v7.py + cross_method_agreement.py
+build_interpretability.py    ← eda_per_scene.py + topic_views.py + topic_to_data.py
+                               + topic_to_library.py + spatial_validation.py + external_validation.py
+build_narratives.py          ← eda_per_scene.py + topic_views.py + topic_to_data.py + topic_to_library.py
+                               + spatial_validation.py + cross_method_agreement.py + groupings.py
+                               + validation_blocks.py + external_validation.py
+build_analysis_payload.py    ← real_samples.py + spectral_library_samples.py   (also serviceable from Stage 2)
+```
+
+### Stage 7 — Web-app curation (must run last)
+
+`curate_for_web.py` rglobs the whole `data/derived/` tree (its
+`BUILDER_DIRS` registry maps every builder to its subdir) and emits the
+manifest the FastAPI app serves.
+
+```
+curate_for_web.py            → data/derived/manifests/index.json
+```
+
+## Dependency edges
+
+Confirmed producer → consumer edges. `local/` paths are git-ignored
+intermediates; `derived/` paths are git-tracked. Wordification edges are
+collapsed into the `build_wordifications*` group (all twelve recipe
+builders write into `data/local/wordifications/` and every V-sweep
+corpus consumer reads that tree; `build_v_sweep_f17_cross_scene` reads
+only V2/V10/V11/V14, the others read V1..V20 or V1..V15).
+
+| Producer → Consumer | Shared artefact (path) |
+|---|---|
+| build_topic_views → build_topic_to_data | data/local/lda_fits/&lt;scene&gt;/theta.npy |
+| build_topic_views → build_topic_to_library | data/derived/topic_views/&lt;scene&gt;.json |
+| build_topic_views → build_topic_to_usgs_v7 | data/derived/topic_views/&lt;scene&gt;.json |
+| build_topic_views → build_embedded_baseline | data/local/lda_fits/&lt;scene&gt;/phi.npy |
+| build_topic_views → build_endmember_baseline | data/local/lda_fits/&lt;scene&gt;/phi.npy + data/derived/topic_views/ |
+| build_topic_views → build_topic_routed_classifier | data/local/lda_fits/&lt;scene&gt;/phi.npy |
+| build_topic_views → build_topic_routed_deep_gate | data/local/lda_fits/&lt;scene&gt;/theta.npy |
+| build_topic_views → build_cross_scene_transfer | data/local/lda_fits/ |
+| build_topic_views → build_spectral_browser | data/local/lda_fits/&lt;scene&gt;/{theta,sample_pixel_indices}.npy |
+| build_topic_views → build_spectral_density | data/local/lda_fits/ |
+| build_topic_views → build_topic_anomaly | data/local/lda_fits/ |
+| build_topic_views → build_topic_spatial_full | data/local/lda_fits/ |
+| build_topic_views → build_topic_spatial_continuous | data/local/lda_fits/ |
+| build_topic_views → build_topic_stability | data/local/lda_fits/ |
+| build_topic_views → build_hierarchical_super_topics | data/derived/topic_views/&lt;scene&gt;.json |
+| build_topic_views → build_b12_llm_tea_leaves | data/derived/topic_views/ |
+| build_topic_views → build_b12_self_judge | data/derived/topic_views/ |
+| build_topic_views → build_linear_probe_panel | data/local/lda_fits/ |
+| build_topic_views → build_mutual_information | data/local/lda_fits/&lt;scene&gt;/{theta.npy,vocab.json} |
+| build_topic_views → build_neural_topic_comparison | data/local/lda_fits/&lt;scene&gt;/{vocab.json,sample_*.npy,corpus_marginal.npy} |
+| build_topic_views → build_quantization_sensitivity | data/local/lda_fits/&lt;scene&gt;/{phi,theta}.npy |
+| build_topic_views → build_band_mask_canonical_comparison | data/local/lda_fits/&lt;scene&gt;/phi.npy |
+| build_topic_views → build_validation_blocks | data/local/lda_fits/ |
+| build_topic_views → build_external_validation | data/derived/topic_views/&lt;scene&gt;.json |
+| build_topic_views → build_endmember_baseline | data/derived/topic_views/ |
+| build_topic_views → build_interpretability | data/derived/topic_views/ |
+| build_topic_views → build_narratives | data/derived/topic_views/ |
+| build_representations → build_linear_probe_panel | data/local/representations/&lt;method&gt;/&lt;scene&gt;/features.npy |
+| build_representations → build_mutual_information | data/local/representations/&lt;method&gt;/&lt;scene&gt;/features.npy |
+| build_representations → build_topic_routed_deep_gate | data/local/representations/&lt;method&gt;/&lt;scene&gt;/features.npy |
+| build_neural_topic_models → build_neural_topic_comparison | data/local/topic_variants/{prodlda,etm}/&lt;scene&gt;/ |
+| build_topic_model_variants → build_neural_topic_comparison | data/local/topic_variants/{prodlda,etm}/&lt;scene&gt;/ |
+| build_neural_topic_models → build_mutual_information | data/local/topic_variants/dmr_lda_hidsag/ |
+| build_topic_model_variants → build_mutual_information | data/local/topic_variants/dmr_lda_hidsag/ |
+| build_dmr_lda_hidsag → build_mutual_information | data/local/topic_variants/dmr_lda_hidsag/ |
+| build_groupings → build_cross_method_agreement | data/local/groupings/&lt;algo&gt;/&lt;scene&gt;/assignment.bin |
+| build_groupings → build_wordifications_v6plus | data/local/groupings/felzenszwalb/&lt;scene&gt;/assignment.bin |
+| build_groupings → build_narratives | data/derived/groupings/ |
+| build_endmember_baseline → build_wordifications_v6plus | data/derived/endmember_baseline/&lt;scene&gt;.json |
+| build_topic_to_data → build_cross_method_agreement | data/derived/topic_to_data/ + data/local/topic_to_data/ |
+| build_topic_to_data → build_spatial_validation | data/derived/topic_to_data/ + data/local/topic_to_data/ |
+| build_topic_to_data → build_band_mask_canonical_comparison | data/derived/topic_to_data/ |
+| build_topic_to_data → build_topic_spatial_continuous | data/derived/topic_to_data/ |
+| build_topic_to_data → build_interpretability | data/derived/topic_to_data/ |
+| build_topic_to_data → build_narratives | data/derived/topic_to_data/ |
+| build_band_masked_topic_models → build_band_mask_canonical_comparison | data/derived/band_masks/{index,summary}.json |
+| build_interpretability → build_band_masked_topic_models (SOFT, optional) | data/derived/interpretability/&lt;scene&gt;/band_cards.json (guarded by `.exists()`; falls back to all-bands) |
+| build_topic_to_library → build_validation_blocks | data/derived/topic_to_library/ |
+| build_topic_to_library → build_interpretability | data/derived/topic_to_library/ |
+| build_topic_to_library → build_narratives | data/derived/topic_to_library/ |
+| build_topic_to_usgs_v7 → build_validation_blocks | data/derived/topic_to_usgs_v7/ |
+| build_quantization_sensitivity → build_validation_blocks | data/derived/quantization_sensitivity/ |
+| build_cross_method_agreement → build_validation_blocks | data/derived/cross_method_agreement/ |
+| build_cross_method_agreement → build_narratives | data/derived/cross_method_agreement/ |
+| build_spatial_validation → build_interpretability | data/derived/spatial/ |
+| build_spatial_validation → build_narratives | data/derived/spatial/ |
+| build_external_validation → build_interpretability | data/derived/external_validation/ |
+| build_external_validation → build_narratives | data/derived/external_validation/ |
+| build_validation_blocks → build_narratives | data/derived/validation_blocks/ |
+| build_eda_per_scene → build_interpretability | data/derived/eda/per_scene/ |
+| build_eda_per_scene → build_narratives | data/derived/eda/per_scene/ |
+| build_spectral_library_samples → build_topic_to_library | data/derived/spectral/library_samples.json |
+| build_spectral_library_samples → build_external_validation | data/derived/spectral/library_samples.json |
+| build_spectral_library_samples → build_analysis_payload | data/derived/spectral/library_samples.json |
+| build_spectral_library_samples → build_corpus_previews | data/derived/spectral/library_samples.json |
+| build_spectral_library_samples → run_local_core_benchmarks | data/derived/spectral/library_samples.json |
+| build_real_samples → build_analysis_payload | data/derived/real/real_samples.json |
+| build_real_samples → build_corpus_previews | data/derived/real/real_samples.json |
+| build_corpus_previews → build_subset_cards | data/derived/corpus/corpus_previews.json |
+| build_topic_routed_classifier → build_bayesian_classification_labelled | data/derived/topic_routed_classifier/ |
+| build_topic_routed_deep_gate → build_bayesian_classification_deep | data/derived/topic_routed_deep_gate/ |
+| build_hidsag_curated_subset → build_hidsag_region_documents | data/derived/core/hidsag_curated_subset.json |
+| build_hidsag_curated_subset → build_eda_hidsag | data/derived/core/hidsag_curated_subset.json |
+| build_hidsag_curated_subset → build_dmr_lda_hidsag | data/derived/core/hidsag_curated_subset.json |
+| build_hidsag_curated_subset → build_band_masked_topic_models_hidsag | data/derived/core/hidsag_curated_subset.json |
+| build_hidsag_curated_subset → build_mutual_information | data/derived/core/hidsag_curated_subset.json |
+| build_hidsag_curated_subset → build_hidsag_band_quality | data/derived/core/hidsag_curated_subset.json |
+| build_hidsag_curated_subset → run_local_core_benchmarks | data/derived/core/hidsag_curated_subset.json |
+| build_hidsag_region_documents → build_eda_hidsag | data/derived/core/hidsag_region_documents.{json,npz} |
+| build_hidsag_region_documents → build_v_sweep_hidsag | data/derived/core/hidsag_region_documents.npz |
+| build_hidsag_region_documents → build_v_sweep_hidsag_f7 | data/derived/core/hidsag_region_documents.npz |
+| build_hidsag_region_documents → run_local_core_benchmarks | data/derived/core/hidsag_region_documents.{json,npz} |
+| build_v_sweep_hidsag → build_v_sweep_hidsag_f7 | data/local/v_sweep/lda_fits_hidsag/theta.npy |
+| run_local_core_benchmarks → build_method_statistics_hidsag | data/derived/core/local_core_benchmarks.json |
+| run_local_core_benchmarks → build_bayesian_method_comparison | data/derived/core/local_core_benchmarks.json |
+| build_method_statistics_hidsag → build_bayesian_method_comparison | data/derived/method_statistics_hidsag/&lt;subset&gt;.json |
+| build_method_statistics_hidsag → build_external_validation | data/derived/method_statistics_hidsag/ |
+| run_hidsag_preprocessing_sensitivity → build_hidsag_cross_preprocessing_stability | data/derived/core/hidsag_preprocessing_sensitivity.json |
+| build_band_masked_topic_models_hidsag → build_hidsag_topic_measurements | data/derived/band_masks_hidsag/swir/summary.json |
+| build_wordifications* → build_v_sweep_canonical_fit | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/{doc_term.npz,vocab.json} |
+| build_wordifications* → build_v_sweep_f1_classification | data/local/wordifications/&lt;recipe&gt;/&lt;scheme&gt;_Q&lt;q&gt;/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_f2_coherence | data/local/wordifications/&lt;recipe&gt;/.../doc_term.npz |
+| build_wordifications* → build_v_sweep_f13_shap | data/local/wordifications/&lt;recipe&gt;/.../doc_term.npz |
+| build_wordifications* → build_v_sweep_f15_llm_alignment | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_f15_self_judge | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_f17_cross_scene (V2/V10/V11/V14) | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_f18_reliability | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_hdp | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_prodlda_backbone | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_backbones_f7 | data/local/wordifications/&lt;recipe&gt;/uniform_Q&lt;q&gt;/&lt;scene&gt;/doc_term.npz |
+| build_wordifications* → build_v_sweep_etm_backbone | data/local/wordifications/&lt;recipe&gt;/uniform_Q8/&lt;scene&gt;/doc_term.npz (via prodlda loader) |
+| build_wordifications* → build_v_sweep_counterfactual | data/local/wordifications/&lt;recipe&gt;/.../doc_term.npz |
+| build_wordifications* → build_quantization_sensitivity | data/local/wordifications/&lt;recipe&gt;/&lt;scheme&gt;_Q&lt;q&gt;/&lt;scene&gt;/doc_term.npz |
+| build_v_sweep_canonical_fit → build_v_sweep_f2_coherence | data/local/v_sweep/lda_fits/&lt;cell&gt;/phi.npy |
+| build_v_sweep_canonical_fit → build_v_sweep_f7_topic_to_label | data/local/v_sweep/lda_fits/ |
+| build_v_sweep_canonical_fit → build_v_sweep_f14_repetitiveness | data/local/v_sweep/lda_fits/ |
+| build_v_sweep_canonical_fit → build_v_sweep_counterfactual | data/local/v_sweep/lda_fits/&lt;cell&gt;/phi.npy |
+| build_v_sweep_canonical_fit → build_v_sweep_f13_shap | data/local/v_sweep/lda_fits/&lt;cell&gt;/{phi.npy,vocab.json} |
+| build_v_sweep_canonical_fit → build_v_sweep_f15_llm_alignment | data/local/v_sweep/lda_fits/&lt;cell&gt;/{phi,theta}.npy + vocab.json |
+| build_v_sweep_canonical_fit → build_v_sweep_f15_self_judge | data/local/v_sweep/lda_fits/&lt;cell&gt;/{phi,theta}.npy |
+| build_v_sweep_canonical_fit → build_b12_self_judge | data/derived/v_sweep/topic_views/ |
+| build_v_sweep_f1_classification → build_v_sweep_f1_bayesian | data/derived/v_sweep/f1_per_fold/ |
+| build_v_sweep_f1_classification → build_v_sweep_f1_bootstrap | data/derived/v_sweep/f1_per_fold/ |
+| (all builders above) → curate_for_web | data/derived/&lt;builder-subdir&gt;/ (rglob; see `BUILDER_DIRS`) |
+
+## Module-load edges (code dependencies, not data edges)
+
+These builders import another builder's module directly
+(`importlib.util.spec_from_file_location` or `importlib.import_module`),
+so the imported module must be importable when they run. They are not
+data edges, but they pin a code-level ordering.
+
+| Loader | Loaded module(s) | Mechanism |
 |---|---|---|
-| Phase 1 (V1..V12 + V14..V20, 6 scenes) | ~25-35 min | V20 cheapest (~30 s); V18 most expensive (~3 min) |
-| Phase 2 (canonical LDA fit, 114 cells) | ~15-20 min | online VB, single-pass |
-| Phase 3 (F-1..F-22, 114 × 8 axes) | ~30 min | F-13 SHAP is the bottleneck |
-| Phase 4 (HDP + ProdLDA + ETM, 19 V × 6 scenes × 3 backbones) | ~60-90 min | ProdLDA is the bottleneck on Pyro/CPU |
-| Phase 5-6 | ~2 min | mostly JSON aggregation |
+| build_v_sweep_prodlda_backbone | build_neural_topic_models | spec_from_file_location("neural_models", …) |
+| build_v_sweep_backbones_f7 | build_neural_topic_models | spec_from_file_location("neural_models", …) |
+| build_v_sweep_etm_backbone | build_neural_topic_models, build_v_sweep_prodlda_backbone | spec_from_file_location |
+| build_v_sweep_hidsag | build_wordifications, build_wordifications_v4plus, build_wordifications_v6plus, build_wordifications_v7v11 | `_load(name, path)` wrapper over spec_from_file_location |
+| build_wordifications_all | build_wordifications_v4plus, build_wordifications_v6plus, build_wordifications_v7v11 | importlib.import_module |
+| run_hidsag_preprocessing_sensitivity | run_local_core_benchmarks | spec_from_file_location("local_core_benchmarks_module", …) |
+
+`build_topic_model_variants` uses `importlib.util.find_spec(...)` only to
+probe for optional libraries (gensim / tomotopy / torch / pyro); that is
+**not** a module-load edge to another builder.
+
+## Standalone builders (no derived-data dependency)
+
+These read raw scenes (`research_core.raw_scenes.load_scene`), packaged
+manifests, or `research_core.*` libraries only — no other builder's
+output. They can run any time after Stage 0.
+
+```
+build_local_inventory.py        build_method_statistics.py
+build_exploration_views.py      build_eda_per_scene.py
+build_real_samples.py           build_field_samples.py
+build_spectral_library_samples.py  build_segmentation_baselines.py
+build_groupings.py              build_representations.py
+build_topic_views.py            build_neural_topic_models.py
+build_topic_model_variants.py   build_band_masked_topic_models.py
+build_lda_sweep.py              build_optuna_hyperparam_search.py
+build_rate_distortion_curve.py  build_classical_seed_stability.py
+build_band_masked_topic_models.py  (* soft dep on build_interpretability — see Stage 1 note)
+build_deep_seed_stability.py    build_deep_anomaly.py
+build_neural_topic_seed_stability.py
+build_hidsag_curated_subset.py
+build_wordifications.py         build_wordifications_v4plus.py
+build_wordifications_v7v11.py   build_wordifications_v13.py
+build_wordifications_v14.py     build_wordifications_v15.py
+build_wordifications_v16.py     build_wordifications_v17.py
+build_wordifications_v18.py     build_wordifications_v19.py
+build_wordifications_v20.py
+```
+
+(`build_wordifications_v6plus.py` and `build_hidsag_band_quality.py` look
+like standalone wordification/core builders but are **not** — see the
+Stage 2 cross-stage exceptions.)
+
+Audit / inspection scripts that scan the tree but are not part of the
+build DAG: `audit_manifest.py` (reads `data/derived/manifests/index.json`
+and the tree), `audit_citation_openalex.py`, `inspect_hidsag_zip.py`,
+`build_demo.py` (writes `data/demo/demo.json`).
+
+## Edges needing manual confirmation
+
+- **build_bayesian_method_comparison → build_external_validation**:
+  both write into `data/derived/method_statistics_hidsag/`
+  (`build_method_statistics_hidsag` writes the per-subset base stats;
+  `build_bayesian_method_comparison` writes `cross_*_bayesian.json` into
+  the same directory). `build_external_validation` reads
+  `method_statistics_hidsag/` at the directory level, so a static read
+  cannot tell whether it consumes the base stats (confirmed edge from
+  `build_method_statistics_hidsag`) or the bayesian-cross files. Treat
+  the dependency on `build_method_statistics_hidsag` as confirmed; the
+  dependency on `build_bayesian_method_comparison` is **not** confirmed.
+- **build_wordifications* recipe granularity**: the v_sweep consumers
+  select recipes at runtime (`RECIPES = [f"V{i}" for i in range(1, N)]`).
+  V1..V12 come from `build_wordifications` / `_v4plus` / `_v6plus` /
+  `_v7v11`; V13..V20 from the per-version builders. `f17_cross_scene`
+  uses only V2/V10/V11/V14. The edges are real at the corpus-directory
+  level; the exact recipe set per consumer is the `RECIPES` constant in
+  that consumer.
+
+## Full clean rebuild (ordered)
+
+```bash
+# Stage 0 — fetch raw data (once per machine)
+python data-pipeline/fetch_public_hsi.py
+python data-pipeline/fetch_public_msi.py
+python data-pipeline/fetch_public_spectral_libraries.py
+python data-pipeline/fetch_public_unmixing.py
+python data-pipeline/fetch_hidsag.py
+python data-pipeline/fetch_ecostress_metadata.py
+
+# Stage 1 — core / foundational
+python data-pipeline/build_local_inventory.py
+python data-pipeline/build_method_statistics.py
+python data-pipeline/build_exploration_views.py
+python data-pipeline/build_hidsag_curated_subset.py
+python data-pipeline/build_eda_per_scene.py
+python data-pipeline/build_real_samples.py
+python data-pipeline/build_field_samples.py
+python data-pipeline/build_spectral_library_samples.py
+python data-pipeline/build_segmentation_baselines.py
+python data-pipeline/build_groupings.py
+python data-pipeline/build_representations.py
+python data-pipeline/build_topic_views.py
+python data-pipeline/build_neural_topic_models.py
+python data-pipeline/build_topic_model_variants.py
+python data-pipeline/build_band_masked_topic_models.py
+python data-pipeline/build_lda_sweep.py
+python data-pipeline/build_optuna_hyperparam_search.py
+python data-pipeline/build_rate_distortion_curve.py
+python data-pipeline/build_hidsag_band_quality.py
+python data-pipeline/build_classical_seed_stability.py
+python data-pipeline/build_deep_seed_stability.py
+python data-pipeline/build_deep_anomaly.py
+python data-pipeline/build_neural_topic_seed_stability.py
+python data-pipeline/run_hidsag_preprocessing_sensitivity.py
+# wordification corpus (V6plus deferred to Stage 2)
+python data-pipeline/build_wordifications.py
+python data-pipeline/build_wordifications_v4plus.py
+python data-pipeline/build_wordifications_v7v11.py
+python data-pipeline/build_wordifications_v13.py
+python data-pipeline/build_wordifications_v14.py
+python data-pipeline/build_wordifications_v15.py
+python data-pipeline/build_wordifications_v16.py
+python data-pipeline/build_wordifications_v17.py
+python data-pipeline/build_wordifications_v18.py
+python data-pipeline/build_wordifications_v19.py
+python data-pipeline/build_wordifications_v20.py
+
+# Stage 2 — first-order consumers
+python data-pipeline/build_topic_to_data.py
+python data-pipeline/build_topic_to_library.py
+python data-pipeline/build_topic_to_usgs_v7.py
+python data-pipeline/build_embedded_baseline.py
+python data-pipeline/build_endmember_baseline.py
+python data-pipeline/build_topic_routed_classifier.py
+python data-pipeline/build_topic_routed_deep_gate.py
+python data-pipeline/build_cross_scene_transfer.py
+python data-pipeline/build_spectral_browser.py
+python data-pipeline/build_spectral_density.py
+python data-pipeline/build_topic_anomaly.py
+python data-pipeline/build_topic_spatial_full.py
+python data-pipeline/build_topic_stability.py
+python data-pipeline/build_hierarchical_super_topics.py
+python data-pipeline/build_b12_llm_tea_leaves.py
+python data-pipeline/build_linear_probe_panel.py
+python data-pipeline/build_neural_topic_comparison.py
+python data-pipeline/build_quantization_sensitivity.py
+python data-pipeline/build_analysis_payload.py
+python data-pipeline/build_corpus_previews.py
+python data-pipeline/build_hidsag_region_documents.py
+python data-pipeline/build_eda_hidsag.py
+python data-pipeline/build_dmr_lda_hidsag.py
+python data-pipeline/build_band_masked_topic_models_hidsag.py
+python data-pipeline/run_local_core_benchmarks.py
+python data-pipeline/build_v_sweep_hidsag.py
+python data-pipeline/build_hidsag_cross_preprocessing_stability.py
+python data-pipeline/build_wordifications_v6plus.py   # after endmember_baseline + groupings
+
+# Stage 3 — second-order consumers
+python data-pipeline/build_band_mask_canonical_comparison.py
+python data-pipeline/build_cross_method_agreement.py
+python data-pipeline/build_spatial_validation.py
+python data-pipeline/build_topic_spatial_continuous.py
+python data-pipeline/build_hidsag_topic_measurements.py
+python data-pipeline/build_method_statistics_hidsag.py
+python data-pipeline/build_bayesian_method_comparison.py
+python data-pipeline/build_mutual_information.py
+python data-pipeline/build_bayesian_classification_labelled.py
+python data-pipeline/build_bayesian_classification_deep.py
+python data-pipeline/build_subset_cards.py
+python data-pipeline/build_v_sweep_hidsag_f7.py
+
+# Stage 4 — V-sweep canonical fit + corpus-only backbones
+python data-pipeline/build_v_sweep_canonical_fit.py
+python data-pipeline/build_v_sweep_f1_classification.py
+python data-pipeline/build_v_sweep_hdp.py
+python data-pipeline/build_v_sweep_prodlda_backbone.py
+python data-pipeline/build_v_sweep_backbones_f7.py
+python data-pipeline/build_v_sweep_etm_backbone.py
+python data-pipeline/build_v_sweep_f17_cross_scene.py
+python data-pipeline/build_v_sweep_f18_reliability.py
+
+# Stage 5 — V-sweep F-axes on the canonical fits
+python data-pipeline/build_v_sweep_f1_bayesian.py
+python data-pipeline/build_v_sweep_f1_bootstrap.py
+python data-pipeline/build_v_sweep_f2_coherence.py
+python data-pipeline/build_v_sweep_f7_topic_to_label.py
+python data-pipeline/build_v_sweep_f14_repetitiveness.py
+python data-pipeline/build_v_sweep_counterfactual.py
+python data-pipeline/build_v_sweep_f13_shap.py
+python data-pipeline/build_v_sweep_f15_llm_alignment.py
+python data-pipeline/build_v_sweep_f15_self_judge.py
+python data-pipeline/build_b12_self_judge.py
+
+# Stage 6 — aggregators
+python data-pipeline/build_external_validation.py
+python data-pipeline/build_validation_blocks.py
+python data-pipeline/build_interpretability.py
+python data-pipeline/build_narratives.py
+
+# Stage 7 — web curation (LAST)
+python data-pipeline/curate_for_web.py
+```
+
+## Runtime budget (dev workstation: CPU only, 32 GB RAM, 8-core i7-11800H, Windows 11)
+
+| Stage | Rough cumulative time | Note |
+|---|---|---|
+| Stage 0 fetch | one-time | network-bound |
+| Stage 1 wordifications (V1..V20, 6 scenes) | ~25-35 min | V20 cheapest (~30 s); V18 eigsh most expensive (~3 min) |
+| Stage 4 canonical LDA fit (V × scene) | ~15-20 min | online VB, single-pass |
+| Stage 5 F-axes | ~30 min | F-13 SHAP is the bottleneck |
+| Stage 4 backbones (HDP + ProdLDA + ETM) | ~60-90 min | ProdLDA on Pyro/CPU is the bottleneck |
+| Stages 6-7 | ~2 min | mostly JSON aggregation |
 | **End-to-end full rebuild** | **~2-3 hours** | clean checkout, no caches |
 
-The V-sweep extension (V13..V20) adds **~5-10 minutes** to phase 1
-(the seven new recipes' build cost is modest because the bulk of the
-work is in the V13 VQ-VAE training and the V18 eigsh call).
-
-## Re-build commands by use case
+## Targeted re-build commands
 
 | Use case | Command |
 |---|---|
@@ -169,12 +594,11 @@ work is in the V13 VQ-VAE training and the V18 eigsh call).
 | Re-fit all V-sweep canonical LDAs | `python data-pipeline/build_v_sweep_canonical_fit.py` |
 | Re-build backbones for new recipes only | `python data-pipeline/build_v_sweep_hdp.py --recipes V14 V18 V20` |
 | Refresh web bundles after any derived change | `python data-pipeline/curate_for_web.py` |
-| Smoke-test the API after the curate | `bash scripts/smoke.sh http://localhost:8105` |
+| Smoke-test the API after curate | `bash scripts/smoke.sh http://localhost:8105` |
 
-## Open work
+---
 
-The DAG above only covers the V-sweep and the canonical LDA web
-pipeline. Out-of-scope builders (HIDSAG, deep, Bayesian classification,
-external validation, fields/MSI, segmentation baselines, neural topic
-models) have their own dependency chains; see the per-builder docstring
-and the upstream issue #589 for the full inventory.
+*Derived from a static read of all 108 builders on 2026-06-04 (issue #589
+Tier 2). Edges confirmed by matching output/input path strings in the
+source; no builders were executed. When you add a builder, add its edges
+here and to `curate_for_web.py`'s `BUILDER_DIRS`.*

--- a/data-pipeline/build_method_statistics.py
+++ b/data-pipeline/build_method_statistics.py
@@ -44,6 +44,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from research_core.paths import CORE_DERIVED_DIR
+from research_core.provenance import git_sha
 from research_core.raw_scenes import (
     load_scene,
     stratified_sample_indices,
@@ -455,6 +456,9 @@ def main() -> int:
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),
         "builder_version": "build_method_statistics v0.2",
+        # Audit fix (#589 Tier 1): per-artefact git sha so a published
+        # number is traceable to the commit that produced it.
+        "git_sha": git_sha(),
         "method_definitions": {
             "raw_logistic_regression": "Logistic regression on standardised raw reflectance.",
             "pca_logistic_regression": (

--- a/data-pipeline/env-vars.md
+++ b/data-pipeline/env-vars.md
@@ -1,0 +1,60 @@
+# data-pipeline environment variables (`CAOS_*`)
+
+Reference for the `CAOS_*` environment variables that tune individual
+builders (#589 Tier 3). All are **optional** — every builder runs with no
+env set, using the defaults below. They exist to scope a partial rebuild
+(filters) or to trade runtime for thoroughness (seed counts, sampler
+draws) without editing code.
+
+Values are read at builder start via `os.environ.get(...)` /
+`os.getenv(...)`. Filters are empty-string-means-all; numeric knobs are
+parsed with `int(...)`.
+
+## Build-scope filters
+
+| Var | Builder | Effect | Default |
+|---|---|---|---|
+| `CAOS_SCENES_FILTER` | `build_representations.py` | comma-separated scene ids to build (others skipped) | `""` → all scenes |
+| `CAOS_REPR_FILTER` | `build_representations.py` | comma-separated representation ids to build | `""` → all representations |
+| `CAOS_VARIANT_FILTER` | `build_topic_model_variants.py` | comma-separated topic-model variant ids to build | `""` → all variants |
+
+## Seed-stability sweeps
+
+These control the reseed loops behind the F-18 reliability axis.
+
+| Var | Builder | Effect | Default |
+|---|---|---|---|
+| `CAOS_CLASSICAL_SEED_METHOD` | `build_classical_seed_stability.py` | which classical method to reseed | `pca_8` |
+| `CAOS_CLASSICAL_SEED_N` | `build_classical_seed_stability.py` | number of reseeds | `7` |
+| `CAOS_DEEP_SEED_METHOD` | `build_deep_seed_stability.py` | which deep method to reseed | `cae_1d_8` |
+| `CAOS_DEEP_SEED_N` | `build_deep_seed_stability.py` | number of reseeds | `7` |
+| `CAOS_NEURAL_TOPIC_SEEDS` | `build_neural_topic_seed_stability.py` | ProdLDA reseed count | `5` |
+| `CAOS_TOPIC_STABILITY_N_SEEDS` | `build_topic_stability.py` | LDA reseed count | `7` |
+| `CAOS_TOPIC_STABILITY_K_OFFSET` | `build_topic_stability.py` | offset added to the per-scene K | `0` |
+
+## Bayesian NUTS sampler (PyMC)
+
+Shared across the three Bayesian builders. Lower these for a fast smoke
+run; raise them for publication-grade posteriors.
+
+| Var | Builders | Effect | Default |
+|---|---|---|---|
+| `CAOS_NUTS_CHAINS` | `build_bayesian_classification_deep.py`, `build_bayesian_classification_labelled.py`, `build_bayesian_method_comparison.py` | MCMC chains | `4` (deep) / `2` (labelled, method_comparison) |
+| `CAOS_NUTS_DRAWS` | same three | posterior draws per chain | `1000` |
+| `CAOS_NUTS_TUNE` | same three | tuning (warmup) steps | `1000` |
+
+## Download / fetch guards
+
+| Var | Builders | Effect | Default |
+|---|---|---|---|
+| `CAOS_HIDSAG_DOWNLOAD_IDS` | `fetch_hidsag.py` | comma-separated HIDSAG asset ids to download | `""` → nothing extra |
+| `CAOS_MAX_LOCAL_DOWNLOAD_BYTES` | `fetch_public_hsi.py`, `fetch_public_spectral_libraries.py`, `fetch_public_unmixing.py` | per-file download cap in bytes (`0` disables the cap) | `0` → no cap |
+
+## Notes
+
+- Only `build_wordifications_all.py` exposes an `argparse` CLI; the
+  builders above are env-driven (the project's standing convention for
+  partial/parameterised runs). A consistent `--scene` / `--variant` CLI
+  across all builders is a separate, deferred refactor (#589 Tier 3).
+- `RANDOM_STATE = 42` is the canonical seed and is **not** env-tunable on
+  purpose — reproducibility is a fixed property, not a runtime knob.

--- a/data-pipeline/run_hidsag_preprocessing_sensitivity.py
+++ b/data-pipeline/run_hidsag_preprocessing_sensitivity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,10 @@ from scipy.signal import savgol_filter
 
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from research_core.provenance import git_sha  # noqa: E402 — needs ROOT on path
 CURATED_PATH = ROOT / "data" / "derived" / "core" / "hidsag_curated_subset.json"
 BAND_QUALITY_PATH = ROOT / "data" / "derived" / "core" / "hidsag_band_quality.json"
 BENCHMARK_PATH = ROOT / "data" / "derived" / "core" / "local_core_benchmarks.json"
@@ -669,6 +674,8 @@ def main() -> None:
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),
         "builder_version": "run_hidsag_preprocessing_sensitivity v0.2",
+        # Audit fix (#589 Tier 1): per-artefact git sha for traceability.
+        "git_sha": git_sha(),
         "methods": {
             "task_selection": "Per subset, reuse one representative classification task and one representative regression target selected from the current local_core_benchmarks.json results.",
             "policy_count": len(POLICIES),

--- a/data-pipeline/run_local_core_benchmarks.py
+++ b/data-pipeline/run_local_core_benchmarks.py
@@ -32,6 +32,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from research_core.paths import CORE_DERIVED_DIR, DERIVED_DIR
+from research_core.provenance import git_sha
 from research_core.raw_scenes import (
     approximate_wavelengths as approximate_scene_wavelengths,
     load_scene,
@@ -1793,6 +1794,8 @@ def main() -> None:
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),
         "builder_version": "run_local_core_benchmarks v0.2",
+        # Audit fix (#589 Tier 1): per-artefact git sha for traceability.
+        "git_sha": git_sha(),
         "methods": {
             "representation": "band-frequency count vectors from normalized spectra",
             "topic_model": "scikit-learn LatentDirichletAllocation",

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -230,7 +230,7 @@
       "repr_body": "Twelve wordification recipes (V1 band → V12 GMM-token), three schemes (uniform/quantile/equalised), Q ∈ {8, 16, 32}. Plus five deep encoders: CAE-1D / CAE-2D / CAE-3D anchor and full-patch / β-VAE. PCA, NMF, ICA as fair K-dim baselines.",
       "pipe_tag": "69 builders",
       "pipe_title": "Pipeline",
-      "pipe_body": "Diagram of the 12 stages of the data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Five torch builders detect GPU automatically with CPU fallback.",
+      "pipe_body": "Diagram of the 12 stages of the data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Six torch builders detect GPU automatically with CPU fallback.",
       "app_tag": "direct · routed · embedded",
       "app_title": "Application",
       "app_body": "How topics are applied to downstream tasks: flat feature (theta_logistic, dominated by raw), gating (topic_routed_soft = soft mixture of per-topic specialists, matches or beats raw 6/6), embedded (concat [θ | pca_K], small effect on IP). The B-3 follow-up closes: the Dirichlet simplex matters, not K-dim compression."

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -230,7 +230,7 @@
       "repr_body": "Doce recetas de wordificación (V1 banda → V12 GMM-token), tres esquemas (uniform/quantile/equalised), Q ∈ {8, 16, 32}. Más cinco encoders profundos: CAE-1D / CAE-2D / CAE-3D anchor & full-patch / β-VAE. PCA, NMF, ICA como baselines K-dim de comparación justa.",
       "pipe_tag": "69 builders",
       "pipe_title": "Pipeline",
-      "pipe_body": "Diagrama de las 12 etapas del data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Cinco builders torch detectan GPU automáticamente con fallback CPU.",
+      "pipe_body": "Diagrama de las 12 etapas del data-pipeline: fetch_* (acquire) → research_core (paths/loaders) → build_* (offline compute) → curate_for_web → manifest. Seis builders torch detectan GPU automáticamente con fallback CPU.",
       "app_tag": "directo · routed · embedded",
       "app_title": "Aplicación",
       "app_body": "Cómo se aplican los tópicos a tareas downstream: feature plano (theta_logistic, dominado por raw), gating (topic_routed_soft = soft mixture de especialistas por tópico, gana o iguala raw en 6/6), embedded (concat [θ | pca_K], pequeño efecto en IP). El B-3 follow-up cierra: el simplex Dirichlet importa, no la compresión K-dim."

--- a/research_core/provenance.py
+++ b/research_core/provenance.py
@@ -1,0 +1,54 @@
+"""Shared provenance helpers for data-pipeline builders (#589 Tier 1).
+
+Two small, dependency-free helpers so every per-builder artefact can carry
+the same traceable stamp the web manifest does:
+
+- ``git_sha()``   — the HEAD commit the artefact was generated at, or ``None``
+                    when git is unavailable (e.g. an exported tarball).
+- ``iso_z_now()`` — an ISO-8601 UTC timestamp with a trailing ``Z`` (the
+                    project's canonical ``generated_at`` format).
+
+Before this module, ``git_sha`` lived only in ``manifests/index.json``
+(written by ``curate_for_web.py``); individual core artefacts shipped no
+sha, so an old artefact could not be tied back to a commit. The audit
+(#589) flagged the gap. Builders import these helpers and add the fields
+to their output payloads; the on-disk artefacts pick the sha up on their
+next regeneration.
+"""
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Repo root = two levels up from this file (research_core/ lives at the root).
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def git_sha() -> str | None:
+    """Return the current HEAD sha, or ``None`` if git is unavailable.
+
+    Mirrors ``curate_for_web.get_git_sha`` so the per-builder stamp and the
+    manifest stamp are produced the same way.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    except Exception:  # noqa: BLE001 — any git/OS failure means "no sha"
+        return None
+
+
+def iso_z_now() -> str:
+    """ISO-8601 UTC timestamp with a trailing ``Z`` (e.g. ``2026-06-04T12:00:00Z``)."""
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )

--- a/scripts/GPU_SETUP.md
+++ b/scripts/GPU_SETUP.md
@@ -24,7 +24,7 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 and moves both tensors and models to that device. If CUDA is not
 available the builder transparently falls back to CPU with no extra
-configuration. The five GPU-aware builders are:
+configuration. The six GPU-aware builders are:
 
 | Builder | Methods | Typical CPU vs GPU per scene |
 |---|---|---|
@@ -32,7 +32,8 @@ configuration. The five GPU-aware builders are:
 | `data-pipeline/build_deep_seed_stability.py` | cae_1d, cae_2d, cae_3d, beta_vae × N seeds | N × (5–30 min) vs N × (5–30 s) |
 | `data-pipeline/build_deep_anomaly.py` | cae_1d + beta_vae per-document reconstruction error | 5–10 min vs 5–10 s |
 | `data-pipeline/build_neural_topic_models.py` | ProdLDA (pyro) | 5–30 min vs 5–30 s per (K × scene) cell |
-| `data-pipeline/build_topic_routed_deep_gate.py` | (consumes precomputed deep latents — no GPU work itself) | n/a |
+| `data-pipeline/build_wordifications_v13.py` | V13 VQ-VAE codebook (torch) | 2–10 min vs 2–10 s per scene |
+| `data-pipeline/build_v_sweep_hidsag.py` | embeds the V13 VQ-VAE step for the HIDSAG sweep (torch) | 1–5 min vs 1–5 s per subset |
 
 Builders that are inherently CPU-only and **do not benefit from a GPU**:
 
@@ -45,6 +46,9 @@ Builders that are inherently CPU-only and **do not benefit from a GPU**:
 - All Bayesian builders that use the default `pm.sample` (PyMC NUTS in
   C compiled mode). These can be ported to JAX/NumPyro for GPU but
   this is a separate cycle.
+- `build_topic_routed_deep_gate.py` — consumes precomputed deep latents,
+  does no torch work of its own (previously mis-listed as GPU-aware,
+  #589 Tier 2).
 
 If your machine has no GPU, only the LDA-family training and the
 classical sklearn baselines will run at full speed; the deep methods
@@ -230,5 +234,5 @@ CUDA backend.
 - [NVIDIA driver compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/)
 - [PyTorch CUDA backward compatibility](https://pytorch.org/docs/stable/notes/cuda.html)
 - Internal: see `data-pipeline/build_representations.py` `_torch_device()`
-  helper for the auto-detection pattern used across all five GPU-aware
+  helper for the auto-detection pattern used across all six GPU-aware
   builders.

--- a/tests/test_core_provenance.py
+++ b/tests/test_core_provenance.py
@@ -1,0 +1,55 @@
+"""Provenance-contract guard for the 3 core benchmark builders (#589 Tier 1).
+
+The audit flagged that ``method_statistics.json``,
+``local_core_benchmarks.json`` and ``hidsag_preprocessing_sensitivity.json``
+shipped a bare ``date.today()`` and carried no ``builder_version`` /
+``git_sha``. The builders now stamp all three via
+``research_core.provenance``. These builders re-train models, so their
+on-disk artefacts are regenerated only in a deliberate benchmark window —
+we therefore lock the *source contract* here (cheap, no retrain) rather
+than asserting against the published JSON.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PIPE = ROOT / "data-pipeline"
+ISO_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+CORE_BUILDERS = [
+    "build_method_statistics.py",
+    "run_local_core_benchmarks.py",
+    "run_hidsag_preprocessing_sensitivity.py",
+]
+
+
+def test_provenance_helpers_behave() -> None:
+    import sys
+
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    from research_core.provenance import git_sha, iso_z_now
+
+    ts = iso_z_now()
+    assert ISO_Z.match(ts), f"iso_z_now() not ISO-8601 Z: {ts!r}"
+
+    sha = git_sha()
+    assert sha is None or re.fullmatch(r"[0-9a-f]{40}", sha), (
+        f"git_sha() should be a 40-hex sha or None, got {sha!r}"
+    )
+
+
+def test_core_builders_stamp_git_sha() -> None:
+    for name in CORE_BUILDERS:
+        src = (PIPE / name).read_text(encoding="utf-8")
+        assert "from research_core.provenance import git_sha" in src, (
+            f"{name}: missing git_sha import (provenance contract #589)"
+        )
+        assert '"git_sha": git_sha()' in src, (
+            f"{name}: must stamp git_sha in its output payload (#589)"
+        )
+        assert '"builder_version":' in src, (
+            f"{name}: must stamp builder_version (#589)"
+        )


### PR DESCRIPTION
Closes out the actionable items of the 2026-05-26 data-pipeline audit (#589).

## Tier 1
- **git_sha provenance** — new `research_core/provenance.py` (`git_sha()` + `iso_z_now()`); the 3 core benchmark builders (`build_method_statistics`, `run_local_core_benchmarks`, `run_hidsag_preprocessing_sensitivity`) now stamp `git_sha` (ISO-Z + `builder_version` already landed in c391).
- **Guard test** `tests/test_core_provenance.py` locks the source contract — these builders re-train models, so their on-disk artefacts refresh in a deliberate benchmark window, not on every CI run (the heavy retrain is intentionally deferred to avoid drifting the launch-frozen ground-truth numbers).
- SLIC `random_seed=42` ✓ (c391); `llm_tea_leaves/` ✓ (all 6 scenes present).

## Tier 2/3
- **GPU-builder count fix**: `build_topic_routed_deep_gate` is NOT GPU-aware (consumes precomputed latents); the V13 VQ-VAE torch path (`build_wordifications_v13` + `build_v_sweep_hidsag`, #765) IS. Corrected to **6** CUDA-detecting builders in `GPU_SETUP.md` + i18n EN/ES.
- **`data-pipeline/env-vars.md`**: documents all 15 `CAOS_*` env vars across 12 builders.
- **`data-pipeline/DAG.md`**: build-order source-of-truth (added in this PR).

80/80 tests pass. Remaining #589 items (artefact retrain regen, memory chunking, unified argparse CLI) are deliberate post-launch deferrals, documented in the issue.