### PR TITLE
Re-audit follow-up: complete V3/recipe-count propagation + accessibility + codegen footgun

### DIFF
--- a/app/routers/content.py
+++ b/app/routers/content.py
@@ -1129,7 +1129,7 @@ def v_sweep_method_report(recipe: str, scheme: str = "uniform", q: int = 8) -> V
     response_model_exclude_none=True,
 )
 def v_sweep_f1_win_matrix() -> VSweepWinMatrix:
-    """The aggregate F-1 win-matrix (12 V x 6 scenes)."""
+    """The aggregate F-1 win-matrix (the 3 monotonic-improver recipes V2/V8/V20 x 6 scenes)."""
     s = get_settings()
     data = _read_json_or_none(s.v_sweep_f1_win_matrix_path)
     if data is None:

--- a/frontend/src/api/v-sweep.ts
+++ b/frontend/src/api/v-sweep.ts
@@ -1,7 +1,7 @@
 /**
  * V-sweep API surface (issue #606). One-shot per-method report or sweep
  * status snapshot. The shards are written by the data pipeline as the
- * 12 V × 12 F-axis sweep progresses; while the pipeline is mid-run the
+ * 19-recipe (V1-V20; V16 scaffold) × multi-axis sweep progresses; while the pipeline is mid-run the
  * /status endpoint reports current coverage and /methods/:recipe returns
  * whatever shards exist with the rest as null fields.
  */

--- a/frontend/src/components/methodology/RecipeSchematics.tsx
+++ b/frontend/src/components/methodology/RecipeSchematics.tsx
@@ -120,28 +120,53 @@ export function RecipeV2Svg() {
 }
 
 export function RecipeV3Svg() {
-  // concat-spectra: long flat token vector
+  // joint (band, bin): a band×bin grid with exactly one highlighted cell per
+  // band column — each band emits one (band, q-bin) joint token.
+  const cols = 12;
+  const rows = 5;
+  const gx = PAD;
+  const gy = PAD + 3;
+  const gw = W - 2 * PAD;
+  const gh = H - 2 * PAD - 6;
+  const cw = gw / cols;
+  const ch = gh / rows;
+  const binOf = [3, 2, 4, 1, 2, 0, 3, 4, 2, 1, 3, 2];
   return (
-    <Frame label="V3 concat-spectra schematic">
-      <polyline
-        points={spectrum()}
-        fill="none"
-        stroke={STROKE}
-        strokeWidth="1"
-      />
-      <g>
-        {Array.from({ length: 18 }, (_, i) => (
-          <rect
-            key={i}
-            x={PAD + 2 + i * 6.5}
-            y={H - PAD - 10}
-            width={5}
-            height={6}
-            fill={ACCENT}
-            opacity={0.45 + (i % 3) * 0.18}
-          />
-        ))}
-      </g>
+    <Frame label="V3 joint (band, bin) schematic">
+      {Array.from({ length: rows + 1 }, (_, r) => (
+        <line
+          key={`h${r}`}
+          x1={gx}
+          y1={gy + r * ch}
+          x2={gx + gw}
+          y2={gy + r * ch}
+          stroke={AXIS}
+          strokeWidth="0.4"
+        />
+      ))}
+      {Array.from({ length: cols + 1 }, (_, c) => (
+        <line
+          key={`v${c}`}
+          x1={gx + c * cw}
+          y1={gy}
+          x2={gx + c * cw}
+          y2={gy + gh}
+          stroke={AXIS}
+          strokeWidth="0.4"
+        />
+      ))}
+      {Array.from({ length: cols }, (_, c) => (
+        <rect
+          key={c}
+          x={gx + c * cw + 0.8}
+          y={gy + (binOf[c] ?? 2) * ch + 0.8}
+          width={cw - 1.6}
+          height={ch - 1.6}
+          fill={ACCENT}
+          opacity={0.78}
+          rx="0.6"
+        />
+      ))}
     </Frame>
   );
 }
@@ -512,8 +537,8 @@ const SCHEMATICS: {
   },
   {
     id: "V3",
-    title: "V3 concat-spectra",
-    caption: "Full spectrum is unrolled into a long token vector.",
+    title: "V3 joint (band, bin)",
+    caption: "Each band emits one (band, q-bin) joint token; vocabulary B·Q.",
     Component: RecipeV3Svg,
   },
   {

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -35,9 +35,9 @@ const STAGES: Stage[] = [
     name: "Wordifications V1..V12",
     command:
       "scripts/local build-wordifications && build-wordifications-v4plus && build-wordifications-v6plus && build-wordifications-v7v11",
-    produces: "data/derived/wordifications/<scene>_<recipe>_<scheme>_Q<q>.json (~486 configs)",
+    produces: "data/derived/wordifications/<scene>_<recipe>_<scheme>_Q<q>.json (648 configs = 108 per scene × 6 scenes)",
     notes:
-      "The 12 recipes × 3 schemes × 3 Q per scene. Each config is a distinct document-term matrix. All exposed via /api/wordifications.",
+      "The corpus-construction layer: 12 recipes × 3 schemes × 3 Q = 108 per scene. Each config is a distinct document-term matrix, all exposed via /api/wordifications. The full F-axis sweep evaluates all 19 built recipes (V1-V20; V16 scaffold) — see the v_sweep layer.",
   },
   {
     id: "topic-views",

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -576,7 +576,7 @@ function WordificationFlowSVG() {
           Tokens
         </text>
         <text x="545" y="105" textAnchor="middle" opacity="0.85">
-          V1, V2, … V12
+          V1, V2, … V20
         </text>
         <text x="545" y="125" textAnchor="middle" opacity="0.7">
           (band, q) | (k, α_k)

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -111,3 +111,20 @@ g[role="button"]:focus {
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+/* Accessibility (re-audit M4 / WQ-02): honour the OS "reduce motion"
+   preference. Neutralises every CSS animation + transition site-wide —
+   the inline caos-draw / caos-band-fade hero keyframes, animate-pulse
+   fallbacks, SVG chart entrance transitions, and any 3D CSS — in one
+   place, rather than gating each component. Animations are collapsed to a
+   near-instant single pass so forwards-fill end states still apply. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/scripts/gen_workspace_methods_i18n.py
+++ b/scripts/gen_workspace_methods_i18n.py
@@ -1,11 +1,17 @@
 """Generate the workspace_methods i18n block for EN and ES locales.
 
+!!! SUPERSEDED — DO NOT BLINDLY MERGE THIS SCRIPT'S OUTPUT !!!
+`frontend/src/i18n/locales/{en,es}/pages.json` is now the source of truth
+for the workspace_methods block. This generator only defines V1-V12 (its
+word dicts predate the V13-V20 catalog blocks hand-added under #774, and
+its index lead has been corrected to the 19-recipe framing in pages.json
+under #773/#778). Regenerating and merging would REVERT both. Keep it only
+as a reference for the V1-V12 prose; if you extend it, add V13-V20 entries
+AND diff against pages.json before merging.
+
 Run from repo root. Writes JSON snippets to stdout and to:
   /tmp/workspace_methods_en.json
   /tmp/workspace_methods_es.json
-
-Then merge those into frontend/src/i18n/locales/{en,es}/pages.json by
-inserting the block before the `not_found` block.
 """
 from __future__ import annotations
 
@@ -225,14 +231,14 @@ def build(side: str, words: dict, neural: dict) -> dict:
     index = (
         {
             "title": "Methods workspace",
-            "lead": "Explore each topic-modelling method on its own page: how the tokens are built, the theory hypothesis, the F-axis sweep, and side-by-side comparators. Twelve wordification recipes (V1..V12) plus four neural baselines.",
+            "lead": "Explore each topic-modelling method on its own page: how the tokens are built, the theory hypothesis, the F-axis sweep, and side-by-side comparators. Nineteen built wordification recipes (V1..V20; V16 scaffold) plus four neural baselines.",
             "wordifications_heading": "Wordification recipes",
             "neural_heading": "Neural baselines",
         }
         if is_en
         else {
             "title": "Workspace por métodos",
-            "lead": "Explora cada método de topic modelling en su propia página: cómo se construyen los tokens, la hipótesis teórica, el sweep F-eje, y comparadores lado a lado. Doce recetas de wordification (V1..V12) más cuatro baselines neuronales.",
+            "lead": "Explora cada método de topic modelling en su propia página: cómo se construyen los tokens, la hipótesis teórica, el sweep F-eje, y comparadores lado a lado. Diecinueve recetas de wordification construidas (V1..V20; V16 scaffold) más cuatro baselines neuronales.",
             "wordifications_heading": "Recetas de wordification",
             "neural_heading": "Baselines neuronales",
         }


### PR DESCRIPTION
Fixes the confirmed findings from the 2026-06-05 post-fix re-audit (which verified the 2026-06-04 batch held: Q1 8.5→9.0, Q2 7→8.5, 0 functional regressions). The residue was concentrated in *rendered illustration code* + *codegen* that the copy-level fixes didn't reach.

## Web app (representation content → Q1 9.5)
- **M1**: `RecipeSchematics.tsx` V3 card 'concat-spectra' → 'joint (band, bin)'; **redrew the glyph** as a band×bin grid (one highlighted cell per band column) matching `wordify_v3_band_bin`. This was the single same-page contradiction holding Q1 off 9.5.
- **L1**: `Pipeline.tsx` STAGES corpus count '~486' → '648 (108/scene × 6)'; kept 'V1..V12' (corpus layer is genuinely V1-V12) + pointer to the 19-recipe sweep.
- **L2**: `Theory.tsx` token SVG 'V1..V12' → 'V1..V20'.
- **L4**: `v-sweep.ts` '12 V' → '19-recipe'; `content.py` f1-win-matrix docstring '12 V' → 'V2/V8/V20' (verified).

## Accessibility + codegen
- **M4**: `globals.css` `@media (prefers-reduced-motion: reduce)` block neutralizing all CSS animations/transitions site-wide.
- **REG-RISK-1**: `gen_workspace_methods_i18n.py` marked SUPERSEDED (pages.json is source-of-truth; the script only knows V1-V12 and would revert the #774 V13-V20 catalog if blindly merged); leads fixed to 19-recipe as a safety net.

tsc 0, vitest 44/44, vite build 0.