### PR TITLE
Overview narrative: lead finding states the verified core result (#783)

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -102,8 +102,8 @@
       "cards": {
         "b3": {
           "badge": "B-3",
-          "title": "θ as a gate beats θ as a feature; small lift over raw",
-          "body": "topic_routed_soft ties or narrowly beats raw_logistic on 4 of 6 labelled scenes (mean lift ≈ +0.5–1.5 pp; Pavia U is the largest at +1.4 pp). The bigger story is theta_logistic (θ as a flat feature), which loses to raw by 14 pp (Pavia U) up to 47 pp (Indian Pines). The 'θ is a gate, not a feature' framing is empirically validated."
+          "title": "θ is a gate, not a feature — and the gate beats raw",
+          "body": "The soft θ-gated ensemble (one specialist per topic, combined weighted by θ) ties or beats raw spectra on classification on 6 of 6 labelled scenes (mean +0.5 pp; Pavia U +1.4), and is the best regression method on the valid HIDSAG subset (GEOMET, R² 0.307 > raw 0.258 > PLS 0.227). By contrast θ as a flat feature loses to raw by 14–47 pp — which is exactly why θ must be a gate, not a feature."
         },
         "b3_followup": {
           "badge": "B-3 follow-up",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -102,8 +102,8 @@
       "cards": {
         "b3": {
           "badge": "B-3",
-          "title": "θ como compuerta supera a θ como feature; ganancia pequeña sobre raw",
-          "body": "topic_routed_soft iguala o supera marginalmente a raw_logistic en 4 de 6 escenas etiquetadas (ganancia media ≈ +0.5–1.5 pp; Pavia U es la mayor con +1.4 pp). La historia mayor es theta_logistic (θ como feature plano), que pierde frente a raw entre 14 pp (Pavia U) y 47 pp (Indian Pines). La idea 'θ es una compuerta, no un feature' queda empíricamente validada."
+          "title": "θ es una compuerta, no un feature — y la compuerta supera a raw",
+          "body": "El ensemble suave θ-gated (un especialista por tópico, combinados ponderados por θ) iguala o supera a los espectros crudos en clasificación en 6 de 6 escenas etiquetadas (media +0.5 pp; Pavia U +1.4), y es el mejor método de regresión en el subset HIDSAG válido (GEOMET, R² 0.307 > raw 0.258 > PLS 0.227). En cambio θ como feature plano pierde frente a raw entre 14 y 47 pp — justo por eso θ debe ser una compuerta, no un feature."
         },
         "b3_followup": {
           "badge": "B-3 follow-up",


### PR DESCRIPTION
Update the lead Overview finding (b3) to the verified result: the soft θ-gated ensemble ties/beats raw on classification 6/6 scenes AND is the best regression method on the valid HIDSAG subset (GEOMET 0.307 > raw 0.258). Both locales.