### PR TITLE
deep-review pass 2: audit fixes (lda_sweep NPMI, n<50 guard, SPA 404, copy cleanup)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -68,7 +68,15 @@ if _dist.is_dir():
     _dist_resolved = _dist.resolve()
 
     @app.get("/{path:path}", include_in_schema=False)
-    def spa_fallback(path: str) -> FileResponse:
+    def spa_fallback(path: str):
+        # Unmatched API/static paths must NOT fall through to the SPA shell.
+        # Returning index.html (200 text/html) where the client expects JSON
+        # makes fetch().json() throw an opaque SyntaxError instead of a clean
+        # 404; surface a real 404 for these prefixes.
+        if path.startswith("api/") or path.startswith("generated/"):
+            return ORJSONResponse(
+                {"detail": "Not Found", "path": f"/{path}"}, status_code=404
+            )
         # Guard against path traversal: a request like
         # "/../app/config.py" would otherwise resolve to a file outside
         # _dist. nginx normalises in prod, but the FastAPI route is

--- a/data-pipeline/build_lda_sweep.py
+++ b/data-pipeline/build_lda_sweep.py
@@ -126,9 +126,18 @@ def npmi_coherence(phi: np.ndarray, doc_term: np.ndarray, top_n: int = TOP_N_FOR
                 p_ij = float((bin_dt[:, wi] * bin_dt[:, wj]).sum() / D)
                 if p_i < eps or p_j < eps or p_ij < eps:
                     continue
+                if p_ij >= 1.0 - eps:
+                    # Both words occur in (almost) every document: perfect
+                    # co-occurrence. The NPMI limit as p_ij -> 1 is +1.
+                    # Computing it directly gives 0/0 = NaN (the bug that
+                    # made npmi_mean NaN for dense scenes and turned
+                    # recommended_K into a max-of-NaN fall-through).
+                    pairs.append(1.0)
+                    continue
                 pmi = np.log(p_ij / (p_i * p_j))
                 npmi = pmi / (-np.log(p_ij))
-                pairs.append(float(npmi))
+                if np.isfinite(npmi):
+                    pairs.append(float(npmi))
         if pairs:
             npmi_per_topic.append(float(np.mean(pairs)))
     return float(np.mean(npmi_per_topic)) if npmi_per_topic else 0.0
@@ -204,7 +213,7 @@ def build_for_scene(scene_id: str) -> dict | None:
         stab_min = float(np.min(matched_cos_pairs)) if matched_cos_pairs else 0.0
 
         valid_test = [m["perplexity_test"] for m in seed_metrics if not np.isnan(m["perplexity_test"])]
-        valid_npmi = [m["npmi"] for m in seed_metrics]
+        valid_npmi = [m["npmi"] for m in seed_metrics if np.isfinite(m["npmi"])]
         grid_results.append({
             "K": K,
             "n_seeds": len(SEEDS),

--- a/frontend/src/pages/benchmarks/BenchmarksDeep.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksDeep.tsx
@@ -317,7 +317,7 @@ function Cae3dAnchorVsFullSection() {
   return (
     <Section
       title="CAE-3D — anchor decoder vs full-patch decoder (K-curve {4, 8})"
-      lead="Two decoders share the same 3-D conv encoder. Anchor reconstructs only the centre-pixel spectrum (Linear K→B); full-patch reconstructs the entire P×P patch (Linear K→B·P·P). Cycle 52 ran K=8; cycle 55 added K=4. The decoder target is itself a hyperparameter — direction is broadly stable across capacity, with one inversion (Pavia U)."
+      lead="Two decoders share the same 3-D conv encoder. Anchor reconstructs only the centre-pixel spectrum (Linear K→B); full-patch reconstructs the entire P×P patch (Linear K→B·P·P). Both K=8 and K=4 capacities are swept. The decoder target is itself a hyperparameter — direction is broadly stable across capacity, with one inversion (Pavia U)."
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>

--- a/frontend/src/pages/benchmarks/BenchmarksGating.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksGating.tsx
@@ -27,7 +27,7 @@ function DeepGateSection() {
     return (
       <Section
         title="B-3 follow-up — any encoder as gate? raw vs θ-routed vs deep gates"
-        lead="Loading deep-gate payloads from /api/topic-routed-deep-gate/{scene}…"
+        lead="Loading deep-gate payloads…"
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
       </Section>
@@ -73,7 +73,7 @@ function DeepGateSection() {
   return (
     <Section
       title="B-3 follow-up — any encoder as gate? raw vs θ-routed vs deep gates"
-      lead="Five candidate gates compete on per-fold macro F1 across labelled scenes: raw_logistic (no gating), θ_routed (LDA topic mixture, natural Dirichlet simplex), and three deep gates (PCA-8, CAE-1D-8, β-VAE-8) projected onto the simplex via softmax. Tests whether any deep encoder recovers θ's gating advantage. Source: /api/topic-routed-deep-gate/{scene}."
+      lead="Five candidate gates compete on per-fold macro F1 across labelled scenes: raw_logistic (no gating), θ_routed (LDA topic mixture, natural Dirichlet simplex), and three deep gates (PCA-8, CAE-1D-8, β-VAE-8) projected onto the simplex via softmax. Tests whether any deep encoder recovers θ's gating advantage."
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
@@ -169,7 +169,7 @@ function NeuralTopicComparisonSection() {
     return (
       <Section
         title="Neural topic models — head-to-head LDA vs ProdLDA vs ETM"
-        lead="Loading per-scene neural-topic comparison from /api/neural-topic-comparison/{scene}…"
+        lead="Loading per-scene neural-topic comparison…"
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
       </Section>
@@ -236,8 +236,8 @@ function NeuralTopicComparisonSection() {
 
   return (
     <Section
-      title="Neural topic models — head-to-head LDA vs ProdLDA vs ETM (cycles 61–63)"
-      lead="Three neural-style topic models compared on the canonical 220-per-class stratified sample. Two metrics: (1) K-means(theta) ARI vs ground-truth label — clustering quality. (2) c_v topic coherence (Röder 2015 sliding-window, top-15 words) — semantic quality. ProdLDA + ETM cells show mean ± std across N=5 seeds (cycle 63 multi-seed sweep). LDA cell uses the canonical fit (single seed; per-seed LDA stability is in the separate Workspace stability tab). The two metrics tell different stories — coherence ≠ class discriminability on band-frequency vocabularies."
+      title="Neural topic models — head-to-head LDA vs ProdLDA vs ETM"
+      lead="Three neural-style topic models compared on the canonical 220-per-class stratified sample. Two metrics: (1) K-means(theta) ARI vs ground-truth label — clustering quality. (2) c_v topic coherence (Röder 2015 sliding-window, top-15 words) — semantic quality. ProdLDA + ETM cells show mean ± std across N=5 seeds. LDA cell uses the canonical fit (single seed; per-seed LDA stability is in the separate Workspace stability tab). The two metrics tell different stories — coherence ≠ class discriminability on band-frequency vocabularies."
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>

--- a/frontend/src/pages/benchmarks/BenchmarksHidsag.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksHidsag.tsx
@@ -301,15 +301,32 @@ function PreprocessingSubsetCard({
           }))}
           good="green"
         />
-        <PolicyBars
-          title="Regression · R²"
-          rows={subset.regression_policy_ranking.map((r) => ({
-            policy_id: r.policy_id,
-            best_model: r.best_model,
-            value: r.best_r2,
-          }))}
-          good="amber"
-        />
+        {(subset.sample_count ?? 0) >= 50 ? (
+          <PolicyBars
+            title="Regression · R²"
+            rows={subset.regression_policy_ranking.map((r) => ({
+              policy_id: r.policy_id,
+              best_model: r.best_model,
+              value: r.best_r2,
+            }))}
+            good="amber"
+          />
+        ) : (
+          <div>
+            <div
+              className="text-[11px] uppercase tracking-widest font-semibold mb-2"
+              style={{ color: "var(--color-fg-faint)" }}
+            >
+              Regression · R²
+            </div>
+            <p className="text-[12px]" style={{ color: "var(--color-fg-faint)" }}>
+              Not shown — cross-validated R² is not estimable at n&lt;50
+              (here n={subset.sample_count}); the test folds explode to
+              R²≪0 and the metric is noise, not a result. See the regression
+              panel below for the n≥50 subsets.
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
@@ -408,7 +408,7 @@ function MultiAxisBatterySection() {
     return (
       <Section
         title="Multi-Axis Addendum B — battery summary"
-        lead="One row per labelled scene, one column per axis (B-1 fair-baseline F1, B-3 topic-routed F1, B-6 LDA off-diag stability). Loads in parallel from /api/linear-probe-panel/, /api/topic-routed-classifier/, /api/topic-stability/. See the wiki for the full framework."
+        lead="One row per labelled scene, one column per axis (B-1 fair-baseline F1, B-3 topic-routed F1, B-6 LDA off-diag stability). The three axes load in parallel. See the wiki for the full framework."
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
           Loading multi-axis battery payloads…


### PR DESCRIPTION
Fixes from the 5-surface deep audit (data/frontend/backend/manuscripts/wiki):

- **D1 (data builder)** lda_sweep NPMI=NaN → recommended_K artifact: perfect-cooccurrence pairs gave 0/0=NaN, making recommended_K a max-of-NaN fall-through (K=4) for 4 scenes. NPMI edge fixed (p_ij→1 ⇒ +1) + non-finite filtered. **Data regen (4 affected scenes) in progress — will deploy in a follow-up.**
- **D4 (frontend)** HIDSAG per-subset regression R² guarded to n≥50 (PORPHYRY R²=-4801 no longer headlined in the preprocessing-sensitivity cards).
- **B1 (backend)** SPA catch-all returns clean 404 JSON for unmatched /api & /generated (was 200 text/html → opaque client parse error).
- **F1/F2 (frontend copy)** stripped internal cycle numbers + /api debug paths from user-facing leads.

Manuscripts (separate repo) + wiki fixes pushed separately. tsc 0, vitest 50/50, build OK.