### PR TITLE
feat: funding & acknowledgements (Overview + footer)

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -25,6 +25,8 @@ export function Footer() {
         <span>{t("common:site_title")}</span>
         <span>·</span>
         <span>{t("common:site_tagline")}</span>
+        <span aria-hidden style={{ opacity: 0.5 }}>·</span>
+        <span className="text-[12px]">{t("common:funding_short")}</span>
         <span className="ml-auto inline-flex items-baseline gap-x-3 font-mono text-[11.5px]">
           <span title="App version (manual, bumped per cycle)">
             <span style={{ color: "var(--color-fg-faint)" }}>v</span>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "site_title": "CAOS LDA HSI",
   "site_tagline": "Probabilistic topic models on hyperspectral imagery",
+  "funding_short": "Funded by AMTC Basal (ANID/PIA AFB220002) · ANID FONDECYT Postdoctorado 3220094",
   "actions": {
     "toggle_theme": "Toggle theme",
     "toggle_language": "Switch language"

--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -2,6 +2,11 @@
   "overview": {
     "title": "Overview",
     "lead": "CAOS LDA HSI explores what probabilistic topic models can capture when documents are pixels, regions, or measurements drawn from hyperspectral imagery.",
+    "acknowledgements": {
+      "title": "Funding & acknowledgements",
+      "funding": "This work was partially funded by the Advanced Mining Technology Center (AMTC) Basal project (ANID/PIA AFB220002) and ANID FONDECYT Postdoctorado 3220094.",
+      "data": "Hyperspectral scenes are courtesy of the Computational Intelligence Group, UPV/EHU. The HIDSAG mineralogical database arises from a collaboration on machine-learning applications to geosciences. Built on the open-source scientific Python stack (scikit-learn, NumPy, SciPy, Gensim, tomotopy, Pyro)."
+    },
     "landing_cta": {
       "lead": "Probabilistic topic models on hyperspectral imagery — a multi-axis evaluation framework that asks whether LDA basis spectra add interpretable value over deep encoders for HSI scene classification.",
       "open_workspace": "Open the Workspace →",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -1,6 +1,7 @@
 {
   "site_title": "CAOS LDA HSI",
   "site_tagline": "Modelos probabilísticos de tópicos sobre imágenes hiperespectrales",
+  "funding_short": "Financiado por AMTC Basal (ANID/PIA AFB220002) · ANID FONDECYT Postdoctorado 3220094",
   "actions": {
     "toggle_theme": "Alternar tema",
     "toggle_language": "Cambiar idioma"

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -2,6 +2,11 @@
   "overview": {
     "title": "Visión general",
     "lead": "CAOS LDA HSI explora qué pueden capturar los modelos probabilísticos de tópicos cuando los documentos son píxeles, regiones o mediciones extraídas de imágenes hiperespectrales.",
+    "acknowledgements": {
+      "title": "Financiamiento y agradecimientos",
+      "funding": "Este trabajo fue financiado parcialmente por el Advanced Mining Technology Center (AMTC), proyecto Basal (ANID/PIA AFB220002) y ANID FONDECYT Postdoctorado 3220094.",
+      "data": "Las escenas hiperespectrales son cortesía del Computational Intelligence Group, UPV/EHU. La base mineralógica HIDSAG surge de una colaboración en aplicaciones de machine learning a las geociencias. Construido sobre el stack científico de Python de código abierto (scikit-learn, NumPy, SciPy, Gensim, tomotopy, Pyro)."
+    },
     "landing_cta": {
       "lead": "Modelos probabilísticos de tópicos sobre imágenes hiperespectrales — un framework de evaluación multi-eje que pregunta si los espectros base de LDA añaden valor interpretable sobre los codificadores profundos en la clasificación de escenas HSI.",
       "open_workspace": "Abrir el Laboratorio →",

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -44,6 +44,23 @@ export default function Overview() {
       <MethodCoverage />
       <Papers />
       <ReadingPath />
+      <section
+        className="mt-10 rounded-lg border p-5"
+        style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}
+      >
+        <h3
+          className="text-sm font-semibold uppercase tracking-wider mb-2"
+          style={{ color: "var(--color-fg-faint)" }}
+        >
+          {t("pages:overview.acknowledgements.title")}
+        </h3>
+        <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-fg-subtle)" }}>
+          {t("pages:overview.acknowledgements.funding")}
+        </p>
+        <p className="text-[12px] leading-relaxed mt-2" style={{ color: "var(--color-fg-faint)" }}>
+          {t("pages:overview.acknowledgements.data")}
+        </p>
+      </section>
     </PageShell>
   );
 }


### PR DESCRIPTION
Felipe: ensure funders are credited so no one can claim missing acknowledgement. Added the journal's funding statement — AMTC Basal (ANID/PIA AFB220002) + ANID FONDECYT Postdoctorado 3220094 — plus data-provider credits (UPV/EHU, HIDSAG) as an Overview acknowledgements block, and a short funding line in the global footer (always visible). EN/ES, parity verified.