### PR TITLE
deep-review: fix family-level wiring (descriptions + stale types)

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -216,15 +216,18 @@ function toHidsagSubsetCode(id: string): string {
   return id.toUpperCase();
 }
 
+// Keyed by the inventory `family_id`. Previously two keys ("hidsag-mineral",
+// "unmixing-roi") did not match any real family_id, so the HIDSAG and the
+// unlabeled families silently fell back to the generic `default` blurb.
 const FAMILY_DESCRIPTIONS: Record<string, string> = {
   "labeled-spectral-image":
     "Hyperspectral cubes with per-pixel labels — the canonical UPV/EHU benchmarks. Natural starting point for classification.",
   "individual-spectra":
-    "Individual spectra with material identity or reference (USGS splib07, MicaSense). No spatial geometry.",
-  "hidsag-mineral":
-    "HIDSAG subsets with per-sample geochemical and mineralogical measurements. Continuous targets, not classes.",
-  "unmixing-roi":
-    "Borsoi Samson / Jasper Ridge / Urban — scenes with endmembers and reference abundances for unmixing.",
+    "Individual reference spectra with material identity (USGS splib07, ECOSTRESS). No spatial geometry — spectral libraries.",
+  "regions-with-measurements":
+    "HIDSAG mineral subsets — spectra grouped into region documents with per-sample geochemical / mineralogical targets. Continuous targets, not classes.",
+  "unlabeled-spectral-image":
+    "Unlabeled hyperspectral / multispectral cubes (Cuprite, unmixing-ROI suite, MicaSense, HySpecNet) — no per-pixel labels; for unmixing and unsupervised exploration.",
   default:
     "Dataset family available for the lab workflow.",
 };

--- a/frontend/src/state/useSelectionStore.ts
+++ b/frontend/src/state/useSelectionStore.ts
@@ -2,18 +2,34 @@
 // removed in c343 (the hook was never imported; selection state lives in
 // the XState workspace machine + URL params).
 
+// Dataset family ids — these MUST match the `family_id` values emitted by the
+// inventory (`/api/local-dataset-inventory`). They were previously a stale
+// fiction ("hsi-labelled", "hidsag-mineral", …) that matched nothing; the
+// machine worked only because callers cast to this type. Kept in sync with the
+// real ids so any literal branch (e.g. FAMILY_DESCRIPTIONS) is checkable.
 export type DatasetFamily =
-  | "hsi-labelled"
-  | "hidsag-mineral"
-  | "usgs-reference"
-  | "msi-field"
-  | "unmixing-roi";
+  | "labeled-spectral-image"
+  | "unlabeled-spectral-image"
+  | "individual-spectra"
+  | "regions-with-measurements";
 
+// Representation ids actually selectable in the Workspace (the `id` field of
+// REPRESENTATIONS + "raw" for the EDA landing). Previously fiction
+// ("ntm"/"dmr" never existed; most real ids were missing).
 export type RepresentationKind =
   | "raw"
   | "lda"
-  | "ntm"
-  | "dmr"
-  | "pca"
+  | "lda_sparse"
+  | "lda_tomo"
+  | "hdp"
+  | "ctm"
+  | "prodlda"
   | "nmf"
-  | "ae";
+  | "pca"
+  | "ae"
+  | "ica"
+  | "cae_1d"
+  | "cae_2d"
+  | "cae_3d"
+  | "cae_3d_full"
+  | "beta_vae";


### PR DESCRIPTION
Deep workspace-flow review (per Felipe — 'not only HIDSAG'). Found: (1) FAMILY_DESCRIPTIONS keyed by stale family_ids that match nothing, so the HIDSAG + unlabeled families silently showed the generic 'default' blurb in the family picker — corrected to the real ids with accurate copy; (2) DatasetFamily + RepresentationKind TS types were wholly fictional (e.g. 'hsi-labelled','ntm') and only 'worked' via as-casts — replaced with the real inventory family_ids + selectable rep ids so future literal branches are checkable. Confirmed non-issues: the 5 catalogue-only labeled datasets correctly fall to the inventory view (no derived data); LABELLED_SCENES + family_id comparisons are sound. tsc 0, vitest green.