### PR TITLE
feat(i18n): benchmarks subtree EN/ES

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -1386,6 +1386,271 @@
       "hidsag_tag": "Family-D geochemistry regression",
       "llm": "B-12 LLM",
       "llm_tag": "Tea-leaves word intrusion (gated)"
+    },
+    "axes": {
+      "loading": "Loading…",
+      "scene_label": "Scene:",
+      "col_scene": "scene",
+      "cross_scene_title": "B-8 cross-scene transfer — fit on A, infer on B",
+      "cross_scene_loading": "Loading transfer matrix…",
+      "cross_scene_lead": "5 AVIRIS-class scenes resampled to a common {{nBands}}-band {{minNm}}-{{maxNm}} nm grid. Each cell is the macro-F1 of a 5-fold logistic on θ (LDA fit on row scene, inferred on column scene). Diagonal = within-scene baseline. Pavia U excluded (ROSIS).",
+      "cross_scene_aria": "Cross-scene transfer matrix",
+      "cross_scene_axis_target": "target scene (column)",
+      "cross_scene_axis_source": "source scene (row)",
+      "cross_scene_finding": "Diagonal cells (white border) are within-scene F1 — they match the native-grid B-3 numbers within ±0.025, so the resampling is honest. Salinas → Salinas-A = 0.747 is the strongest off-diagonal (same campaign, overlapping fields). KSC's collapsed topics neither transfer well (KSC → others ≤ 0.405) nor receive well (others → KSC ≤ 0.405). Salinas-A is the easiest target (0.65-0.75 from any source — compact 6-class).",
+      "rate_distortion_title": "B-2 rate-distortion curve — reconstruction RMSE vs K",
+      "rate_distortion_loading": "Loading rate-distortion curves…",
+      "rate_distortion_lead": "LDA / NMF / PCA reconstruction RMSE on a 20% held-out test split, across K∈{4, 6, 8, 10, 12, 16}. PCA is the L2-optimal compressor (wins everywhere). NMF a close second. LDA last because it optimises a multinomial likelihood, not L2 RMSE — this is the expected picture and is documented as Axis G.",
+      "rate_distortion_aria": "rate-distortion curve",
+      "mi_title": "B-4 mutual information — per-feature MI(z; y)",
+      "mi_loading": "Loading mutual information…",
+      "mi_lead": "For each method, MI between every latent feature z_k and the label y. Bright = high MI = informative feature. Per-feature distribution is the right discriminative signal — joint MI clips to label entropy once K is non-degenerate.",
+      "mi_entropy_note": "Label entropy H(Y) = {{nats}} nats ({{bits}} bits) — the upper bound for joint MI. Top {{count}} methods sorted by per-feature MI sum.",
+      "mi_heatmap_aria": "MI heatmap",
+      "mi_feature_axis": "feature index k → (capped at {{maxCols}} for readability)",
+      "endmember_title": "B-11 endmember baseline — NFINDR / ATGP vs LDA topics",
+      "endmember_loading": "Loading endmember baseline…",
+      "endmember_lead": "At K={{K}}, NFINDR + ATGP endmembers extracted from the canonical labelled-pixel subset ({{nPixels}} px, {{nBands}} bands). Cosine similarity between LDA topics and NFINDR endmembers — at the same K, both methods land on the same spectral primitives (typical cosine 0.92-1.00).",
+      "endmember_rmse_label": "{{method}} RMSE (normalised)",
+      "endmember_matrix_label": "Topic × NFINDR endmember cosine matrix:",
+      "endmember_matrix_aria": "topic × endmember cosine matrix",
+      "endmember_finding": "Bright cells = high cosine (topic and endmember spectrally aligned). Diagonal-like pattern = the two methods recover the same spectral primitives. Master-plan position: at the same K, NMF, NFINDR, and LDA all recover comparable spectral structure; what separates them is interpretability and downstream gating utility (B-3, B-7).",
+      "spatial_title": "B-10 spatial coherence — Moran's I + Geary's C",
+      "spatial_loading": "Loading spatial coherence…",
+      "spatial_lead": "Per-topic θ_k abundance maps Moran's I + Geary's C with 4-neighbour rook contiguity, mean across topics. Two readings: subsampled (220-per-class basis) and full (full-pixel mask LDA refit). KSC's collapse on the subsampled basis is a pipeline artifact — full-pixel refit recovers spatial coherence.",
+      "spatial_col_sub_moran": "subsampled mean Moran I",
+      "spatial_col_sub_geary": "subsampled mean Geary C",
+      "spatial_col_full_moran": "full-pixel mean Moran I",
+      "spatial_col_full_geary": "full-pixel mean Geary C",
+      "spatial_finding": "Headline: 5/6 scenes show high spatial coherence (mean Moran I ≥ 0.80) on the subsampled basis. KSC drops to 0.064 (red) — but the <strong>full-pixel refit</strong> recovers I = 0.837, demonstrating that KSC's \"collapse\" is an artifact of stratified 220-per-class sampling on a sparse-class scene, not a fundamental data problem.",
+      "super_topics_title": "Cross-scene super-topics (master plan §12)",
+      "super_topics_lead_loading": "Hierarchical clustering of every topic across all six labelled scenes on the common 400–2500 nm grid (average linkage on cosine). Reveals which topics group across scenes vs. stay scene-local.",
+      "super_topics_unavailable": "super_topics payload not available yet.",
+      "super_topics_lead": "Hierarchical clustering of all {{nTopics}} topics across {{nScenes}} labelled scenes on the common 400–2500 nm grid (average linkage on cosine). Cut level shown: {{cutLevel}} → {{nClusters}} super-topic clusters. Multi-scene clusters identify topics that recur across data sets — what \"unites\" the scenes.",
+      "super_topics_col_cluster": "cluster",
+      "super_topics_col_members": "members",
+      "super_topics_col_scenes": "scenes",
+      "super_topics_col_topic_ids": "topic ids"
+    },
+    "backbone_f7": {
+      "title": "F-7 NMI under each topic-model backbone (HDP / ProdLDA / ETM extension)",
+      "lead": "The c397 backbone factorial reported F-2 c_v only. c432–c434 added F-7 NMI for V1/V3/V12/V14/V18/V20, then extended in c435 to every recipe with available wordifications. Each cell is the per-(scene, recipe) F-7 NMI mean across 6 labelled scenes. Bold accent = per-backbone winner.",
+      "table": {
+        "backboneRecipe": "backbone \\ recipe",
+        "mean": "mean",
+        "meanFourBackbones": "mean (4 backbones)"
+      },
+      "footnote": "Recipes ordered by mean F-7 NMI across the four backbones. V8 (NFINDR endmember-fraction) leads the cross-backbone mean (0.431 at Q=8). V20 (MI-weighted) is top-3 under LDA and ETM but slips to 4th under ProdLDA and 6th under HDP — no single recipe is top-3 under all four backbones, which is itself the finding: cross-prior portability is recipe-specific, not universal."
+    },
+    "deep": {
+      "anomaly": {
+        "title": "B-9 anomaly indicators — LDA vs deep ρ comparison",
+        "loadingLead": "Loading anomaly correlations…",
+        "loading": "Loading…",
+        "lead": "Spearman ρ between per-document anomaly score and theta-logistic misclassification. Positive ρ (green) = the indicator flags hard examples (works as anomaly); negative (red) = the indicator anti-correlates (deep encoders concentrate capacity on rare informative spectra). LDA's recon NLL works as anomaly; deep methods invert the heuristic.",
+        "col": {
+          "scene": "scene",
+          "ldaNll": "LDA recon NLL ρ",
+          "ldaSoftmax": "LDA softmax ρ",
+          "caeRmse": "CAE-1D recon RMSE ρ",
+          "bvRmse": "β-VAE recon RMSE ρ",
+          "bvKl": "β-VAE KL ρ"
+        },
+        "note": "Headline: LDA recon NLL is positive ρ on every scene (Pavia U +0.306, Salinas-A +0.298, KSC +0.226, IP +0.214) — it works as an anomaly indicator. Deep methods produce mostly negative ρ — the \"high recon = unfamiliar\" heuristic does NOT transfer to deep nonlinear encoders. Deep encoders concentrate capacity on rare informative spectra, which the latent then discriminates well."
+      },
+      "kcurve": {
+        "title": "CAE-1D capacity-driven scaling — ARI vs K",
+        "loadingLead": "Per-scene CAE-1D K-curve (K∈{4,6,8,10,12,16,32}). Each line is one labelled scene; each point is the K-means(latent) ARI vs ground-truth label.",
+        "loading": "Loading deep K-curve payloads (42 cells)…",
+        "lead": "K-means(latent) ARI vs ground-truth label, per scene. Almost-monotonic on every scene (Salinas 0.547 → 0.561, KSC 0.250 → 0.314 from K=4 to K=32). x-axis is log K.",
+        "aria": "CAE-1D K curve",
+        "xAxis": "latent dimension K (log scale)",
+        "yAxis": "K-means(latent) ARI vs label",
+        "note": "Capacity-driven scaling: every scene improves with K; no overfitting at K=32. KSC's canonical fit (LDA θ-logistic F1=0.021 on B-3) recovers to F1=0.710 at CAE-1D K=32 on the linear-probe panel, a 33× gain attributable to deep encoder capacity."
+      },
+      "cae3d": {
+        "title": "CAE-3D — anchor decoder vs full-patch decoder (K-curve {4, 8})",
+        "loadingLead": "Loading anchor + full-patch payloads at K∈{4, 8} across 6 labelled scenes…",
+        "loading": "Loading…",
+        "lead": "Two decoders share the same 3-D conv encoder. Anchor reconstructs only the centre-pixel spectrum (Linear K→B); full-patch reconstructs the entire P×P patch (Linear K→B·P·P). Both K=8 and K=4 capacities are swept. The decoder target is itself a hyperparameter — direction is broadly stable across capacity, with one inversion (Pavia U).",
+        "col": {
+          "scene": "scene",
+          "full": "full",
+          "anchor": "anchor"
+        },
+        "netMean": "net mean ΔARI",
+        "note": "Honest read: net mean ΔARI is essentially neutral at both K (+0.011 K=4, +0.003 K=8). Direction matches across K on 5/6 scenes — IP and Botswana persistently benefit; Salinas family persistently harmed (magnitude grows with K). Pavia U is the single capacity-dependent inversion: full-patch helps at K=4 (+0.026), hurts at K=8 (-0.023). The decoder target is itself a hyperparameter worth surfacing per scene, not a default to flip globally."
+      },
+      "betaVae": {
+        "title": "β-VAE β-sweep — disentanglement vs posterior collapse",
+        "loadingLead": "Loading β-sweep payloads…",
+        "loading": "Loading…",
+        "lead": "K-means(latent) ARI per scene at K=8 across β∈{1, 2, 4, 8, 16}. Bright = high ARI; black cells = posterior collapse (β-VAE encoder converges to q(z|x)≈p(z), latent is uninformative).",
+        "aria": "β-VAE β-sweep ARI grid",
+        "note": "Salinas posterior collapse at β≥8 (ARI=0.000 — KL term overwhelms the reconstruction signal; encoder maps every input to N(0, I)). Salinas-A resists collapse and even gains with β (compact 6-class signal dominates the regulariser). Pavia U degrades monotonically with β. The β=4 default sits at the inflection point."
+      }
+    },
+    "gating": {
+      "common": {
+        "loading": "Loading…",
+        "scene": "scene",
+        "winsBestPerScene": "wins (best per scene)"
+      },
+      "deepGate": {
+        "title": "B-3 follow-up — any encoder as gate? raw vs θ-routed vs deep gates",
+        "loadingLead": "Loading deep-gate payloads…",
+        "lead": "Five candidate gates compete on per-fold macro F1 across labelled scenes: raw_logistic (no gating), θ_routed (LDA topic mixture, natural Dirichlet simplex), and three deep gates (PCA-8, CAE-1D-8, β-VAE-8) projected onto the simplex via softmax. Tests whether any deep encoder recovers θ's gating advantage.",
+        "finding": {
+          "part1": "Honest finding: deep gates with naive softmax-to-simplex projection do",
+          "not": "not",
+          "part2": "outperform raw_logistic or θ_routed. raw_logistic wins on most scenes; θ_routed ties or wins where Dirichlet-simplex structure aligns with class topology (e.g. Salinas). The advantage of θ comes from the natural simplex constraint of Dirichlet-distributed topic mixtures, not merely from compressing to K dimensions — softmaxed deep latents fail to recover the gating mechanism."
+        }
+      },
+      "neuralTopic": {
+        "title": "Neural topic models — head-to-head LDA vs ProdLDA vs ETM",
+        "loadingLead": "Loading per-scene neural-topic comparison…",
+        "lead": "Three neural-style topic models compared on the canonical 220-per-class stratified sample. Two metrics: (1) K-means(theta) ARI vs ground-truth label — clustering quality. (2) c_v topic coherence (Röder 2015 sliding-window, top-15 words) — semantic quality. ProdLDA + ETM cells show mean ± std across N=5 seeds. LDA cell uses the canonical fit (single seed; per-seed LDA stability is in the separate Workspace stability tab). The two metrics tell different stories — coherence ≠ class discriminability on band-frequency vocabularies.",
+        "header": {
+          "cls": "cls",
+          "ariVsLabel": "ARI vs label",
+          "cvCoherence": "c_v coherence (top-15)"
+        },
+        "finding": {
+          "headline": "Coherence vs discriminability are NOT the same metric on band-frequency tokens.",
+          "body1": "ProdLDA wins c_v on every scene (highest semantic coherence among the three) but loses ARI on 4/6 scenes — its topics are internally tight but do not align with class structure. LDA wins ARI on 4/6 scenes (most class-discriminative theta on average) yet loses c_v on every scene. ETM lands between on both axes — slight improvement over ProdLDA on ARI (5/6 wins), slight regression on c_v.",
+          "ruleLabel": "Operational rule",
+          "body2": ": pick the topic family by the downstream task, not by coherence alone. For class clustering use LDA (or neural fallback when LDA collapses, e.g. KSC). For interpretability / topic-vocabulary cards (Workspace Topics tab) use ProdLDA's higher coherence. ETM is the safe middle if both matter."
+        }
+      },
+      "bayesian": {
+        "title": "Bayesian method comparison — hierarchical NUTS posteriors",
+        "loadingLead": "Loading PyMC posteriors at 4 chains × 1000 tune + 1000 draws…",
+        "lead": "PyMC hierarchical normal model: y ~ N(μ_method + α_scene + γ_fold, σ). Posterior means shown as red dots, HDI94 intervals as blue bars. Methods are ordered by posterior mean. Vertical dashed line at μ=0 is the model-mean reference.",
+        "forestFooter": "{{obs}} observations · {{methods}} methods · {{summary}}",
+        "forest": {
+          "classification": {
+            "title": "Classification (labelled scenes, 150 obs)",
+            "note": "raw / pca / topic_routed_* HDIs strictly positive; theta_logistic HDI includes 0 — naive theta-flat is statistically indistinguishable from the model mean."
+          },
+          "classificationDeep": {
+            "title": "Classification with deep gates (labelled scenes, 150 obs)",
+            "note": "B-3 follow-up: gates are raw_logistic vs. θ_routed vs. PCA-8 / CAE-1D-8 / β-VAE-8 routed (deep latents softmaxed to a simplex). raw_logistic dominates θ_routed and all deep gates with P≥0.999; θ_routed dominates every deep gate with P≥0.999. Decisive Bayesian evidence that softmaxed deep latents do NOT recover θ's gating advantage — θ's edge comes from the natural Dirichlet simplex."
+          },
+          "regression": {
+            "title": "Regression (HIDSAG, n≥50 subsets: GEOMET + MINERAL1)",
+            "note": "Pool restricted to n≥50 subsets — the three small-n subsets (PORPHYRY R²≈−12500, MINERAL2, GEOCHEM) are excluded because their exploding R² poisoned the earlier pooled posterior. Honest read: pooled across the two valid subsets no method clears zero (raw_ridge highest point estimate, the proposed soft θ-gated ensemble second, statistically indistinguishable). But the soft gate beats its own hard-routing ablation by ~0.44 R² units, and per-subset on GEOMET (n=146) the soft ensemble is the best method (R²=0.307 > raw 0.258). The win is subset-specific, not universal."
+          }
+        }
+      }
+    },
+    "hidsag": {
+      "cross_preproc": {
+        "title": "HIDSAG — cross-preprocessing stability (B-6 follow-up)",
+        "lead": "How stable LDA topics are when the preprocessing recipe changes. Reported as Hungarian-matched top-15 token Jaccard across the 4 policies (raw / heuristic-band-mask / SNV / SavGol+SNV). Low = topics change substantially across recipes; high = topics survive.",
+        "policies_count_one": "{{count}} policy",
+        "policies_count_other": "{{count}} policies",
+        "off_diag_mean": "off-diag mean",
+        "metric_note": "Metric: top-15 token Jaccard with Hungarian assignment. Each cell of the N×N matrices is the average per-topic stability between policies i, j.",
+        "matrix_aria": "Cross-preprocessing matrix for {{code}}"
+      },
+      "preprocessing": {
+        "title": "HIDSAG — spectral preprocessing sensitivity",
+        "lead": "Four preprocessing policies (raw / heuristic-bad-band-mask / SNV / Savitzky-Golay+SNV) over the 5 HIDSAG scenes. Measures how downstream performance (classification + regression) changes when the spectral cleaning recipe varies.",
+        "loading": "Loading preprocessing sensitivity…",
+        "load_error": "Could not load {{endpoint}}.",
+        "classification_title": "Classification · balanced accuracy",
+        "regression_title": "Regression · R²",
+        "regression_not_shown": "Not shown — cross-validated R² is not estimable at n<50 (here n={{n}}); the test folds explode to R²≪0 and the metric is noise, not a result. See the regression panel below for the n≥50 subsets."
+      },
+      "regression": {
+        "title": "HIDSAG — regression over measurements",
+        "lead": "A hard cross-domain probe: can the topic representations linearly predict continuous geo-assays (Cu %, Au g/t, mineralogy)? R² < 0 means worse than predicting the target's mean. This is separate from — and much harder than — the labelled-scene topic results; treat it as a stress test, not the headline.",
+        "loading": "Loading HIDSAG rankings…",
+        "no_block": "No regression block available.",
+        "forest_aria": "HIDSAG {{code}} forest",
+        "excluded_label": "<strong>Excluded (n < {{minN}}):</strong>",
+        "excluded_note": ". Cross-validated regression R² is not estimable at these sample sizes — the folds are too small for the band/feature dimension, so the values are statistical noise rather than results.",
+        "r2_explainer": "R² < 0 means the model predicts the numeric target worse than its own mean — expected for assay regression (Cu %, Au g/t) on these small mineral subsets (n = tens to low hundreds). This is a deliberately hard cross-domain probe and is <em>separate</em> from the labelled-scene topic results, where the representations do separate classes.",
+        "off_scale_note": "Methods with R² ≪ 0 (catastrophic small-sample fits) are clamped to the axis edge at {{floor}} and labelled with their true value.",
+        "method_labels": {
+          "soft_theta_gated": "soft θ-gated ensemble  ★ proposed",
+          "hard_route": "hard route (ablation)",
+          "raw_ridge": "raw spectra · Ridge",
+          "raw_pls": "raw spectra · PLS",
+          "theta_region": "θ feature · region",
+          "theta_cube": "θ feature · cube",
+          "theta_pixel": "θ feature · pixel"
+        }
+      }
+    },
+    "llm": {
+      "empty": {
+        "title": "B-12 — LLM tea-leaves (Stammbach et al. TACL 2024)",
+        "lead": "Word-intrusion + coherent-label probes via Anthropic Claude. Builder is gated by ANTHROPIC_API_KEY; outputs land in data/derived/llm_tea_leaves once the env var is set and the builder is run.",
+        "note": "No scenes evaluated yet. Set <code>ANTHROPIC_API_KEY</code> and run <code>build-b12-llm-tea-leaves</code> to populate."
+      },
+      "section": {
+        "title": "B-12 — LLM tea-leaves (Stammbach et al. 2023, EMNLP)",
+        "lead": "Per-scene word-intrusion accuracy + per-topic LLM-generated labels. Higher intrusion accuracy means the LLM correctly identifies the foreign word slipped into each topic's top-10 — a coherence signal that correlates with NPMI in prior work. Outputs shipped here are the deterministic Claude Opus 4.7 self-judgment stand-in (see model column); a full API-driven run via build_b12_llm_tea_leaves.py is also implemented for external reproduction."
+      },
+      "table": {
+        "scene": "scene",
+        "topics": "topics",
+        "intrusionAccuracy": "intrusion accuracy",
+        "model": "model"
+      },
+      "detail": {
+        "summary": "{{sceneId}} — per-topic LLM labels",
+        "topic": "topic {{topicId}}",
+        "skipped": "— skipped ({{reason}})",
+        "noLabel": "(no label)"
+      }
+    },
+    "summary": {
+      "forest_title": "Forest plot — macro-F1 with CI95 per scene",
+      "forest_lead": "Each bar is a scene × method; the dot is the mean, the whiskers are the 2.5 and 97.5 percentiles of the bootstrap over the 25 evaluations.",
+      "forest_aria": "Forest plot for {{scene}}",
+      "paired_title": "Paired comparisons (Δ macro-F1)",
+      "paired_lead": "Each pair shows the difference between methods per evaluation; summarised as mean ± std of Δ. Negative = the second method loses.",
+      "paired_col_a": "A",
+      "paired_col_b": "B",
+      "paired_col_delta_mean": "Δ mean",
+      "paired_col_delta_std": "Δ std",
+      "paired_col_delta_range": "[Δ min, Δ max]",
+      "method_defs_title": "Method definitions",
+      "stat_scenes_evaluated": "Scenes evaluated",
+      "stat_evaluations_per_method": "Evaluations per method",
+      "stat_alpha_significance": "α significance",
+      "classes_suffix": "classes",
+      "battery_title": "Multi-Axis Addendum B — battery summary",
+      "battery_lead_loading": "One row per labelled scene, one column per axis (B-1 fair-baseline F1, B-3 topic-routed F1, B-6 LDA off-diag stability). The three axes load in parallel. See the wiki for the full framework.",
+      "battery_loading": "Loading multi-axis battery payloads…",
+      "battery_lead": "One row per labelled scene. Columns: theta-as-feature F1 (B-1, naive), ICA-10 F1 (B-1, fair-baseline winner), best CAE-1D F1 across K∈{4..32} (B-1 deep ladder), topic_routed_soft F1 (B-3 the master-plan thesis), raw_logistic F1 (B-3 strong baseline), and LDA off-diagonal stability (B-6, N=7 seeds). The framework is on the wiki Multi-Axis-Addendum-B page.",
+      "battery_col_scene": "scene",
+      "battery_col_theta_flat": "θ flat (B-1)",
+      "battery_col_ica10": "ICA-10 (B-1)",
+      "battery_col_cae_best": "CAE-1D best (B-1)",
+      "battery_col_theta_logistic": "θ_logistic (B-3)",
+      "battery_col_routed_soft": "routed_soft (B-3)",
+      "battery_col_raw_logistic": "raw_logistic (B-3)",
+      "battery_col_lda_stability": "LDA stability (B-6)",
+      "battery_headlines": "<strong>Headlines:</strong> ICA-10 wins B-1 fair-baseline on every scene. CAE-1D K=32 closes much of the gap (KSC θ=0.021 → CAE-1D K=32=0.710, a 33× recovery). topic_routed_soft matches or beats raw_logistic on every scene; θ_logistic loses by 30-50 points everywhere — the master-plan thesis \"θ as a gate, never as a feature\" is empirically validated. LDA off-diag stability ≥ 0.954 across all 6 scenes vs CAE-1D 0.74-0.97 and β-VAE 0.18-0.89."
+    },
+    "vsweep_coverage": {
+      "title": "V-sweep coverage matrix (10 axes × 19 recipes × 6 scenes)",
+      "lead": "1140 numeric cells in total — all populated. Toggle between boolean (cells filled?) and value (per-cell numeric, viridis colormap). F-13 SHAP has no scalar value so it stays boolean.",
+      "toggle": {
+        "values": "values",
+        "boolean": "boolean"
+      },
+      "table": {
+        "axisSceneRecipe": "axis \\ scene·recipe"
+      },
+      "footnote": "Generated {{date}}. F-14 jaccard uses inverted colour (lower = better, mapped to \"high\" colour band). F-17 cross-scene (portable only) and B-12 / F-15 per-scene LLM-judge records are reported in their dedicated panels.",
+      "recipeMeans": {
+        "heading": "Per-axis recipe-mean ranking",
+        "axis": "axis"
+      }
     }
   },
   "workspace_methods": {

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -1386,6 +1386,271 @@
       "hidsag_tag": "Familia-D regresión geoquímica",
       "llm": "B-12 LLM",
       "llm_tag": "Tea-leaves word intrusion (gated)"
+    },
+    "axes": {
+      "loading": "Cargando…",
+      "scene_label": "Escena:",
+      "col_scene": "escena",
+      "cross_scene_title": "B-8 transferencia entre escenas — ajustar en A, inferir en B",
+      "cross_scene_loading": "Cargando matriz de transferencia…",
+      "cross_scene_lead": "5 escenas de clase AVIRIS remuestreadas a una grilla común de {{nBands}} bandas {{minNm}}-{{maxNm}} nm. Cada celda es el macro-F1 de una regresión logística de 5 pliegues sobre θ (LDA ajustado en la escena de la fila, inferido en la escena de la columna). Diagonal = línea base intra-escena. Pavia U excluida (ROSIS).",
+      "cross_scene_aria": "Matriz de transferencia entre escenas",
+      "cross_scene_axis_target": "escena destino (columna)",
+      "cross_scene_axis_source": "escena origen (fila)",
+      "cross_scene_finding": "Las celdas diagonales (borde blanco) son el F1 intra-escena — coinciden con los números B-3 de grilla nativa dentro de ±0.025, por lo que el remuestreo es fiel. Salinas → Salinas-A = 0.747 es la transferencia fuera de la diagonal más fuerte (misma campaña, campos superpuestos). Los tópicos colapsados de KSC ni transfieren bien (KSC → otros ≤ 0.405) ni reciben bien (otros → KSC ≤ 0.405). Salinas-A es el destino más fácil (0.65-0.75 desde cualquier origen — compacta, 6 clases).",
+      "rate_distortion_title": "B-2 curva tasa-distorsión — RMSE de reconstrucción vs K",
+      "rate_distortion_loading": "Cargando curvas tasa-distorsión…",
+      "rate_distortion_lead": "RMSE de reconstrucción de LDA / NMF / PCA sobre una partición de prueba retenida del 20%, a lo largo de K∈{4, 6, 8, 10, 12, 16}. PCA es el compresor óptimo en L2 (gana en todas partes). NMF queda muy cerca en segundo lugar. LDA queda última porque optimiza una verosimilitud multinomial, no el RMSE L2 — esta es la imagen esperada y está documentada como Eje G.",
+      "rate_distortion_aria": "curva tasa-distorsión",
+      "mi_title": "B-4 información mutua — MI(z; y) por característica",
+      "mi_loading": "Cargando información mutua…",
+      "mi_lead": "Para cada método, la MI entre cada característica latente z_k y la etiqueta y. Brillante = MI alta = característica informativa. La distribución por característica es la señal discriminativa correcta — la MI conjunta se satura en la entropía de la etiqueta cuando K deja de ser degenerada.",
+      "mi_entropy_note": "Entropía de la etiqueta H(Y) = {{nats}} nats ({{bits}} bits) — la cota superior de la MI conjunta. Los {{count}} métodos principales ordenados por la suma de MI por característica.",
+      "mi_heatmap_aria": "mapa de calor de MI",
+      "mi_feature_axis": "índice de característica k → (limitado a {{maxCols}} por legibilidad)",
+      "endmember_title": "B-11 línea base de endmembers — NFINDR / ATGP vs tópicos LDA",
+      "endmember_loading": "Cargando línea base de endmembers…",
+      "endmember_lead": "Con K={{K}}, los endmembers NFINDR + ATGP se extraen del subconjunto canónico de píxeles etiquetados ({{nPixels}} px, {{nBands}} bandas). Similitud coseno entre los tópicos LDA y los endmembers NFINDR — con el mismo K, ambos métodos recuperan las mismas primitivas espectrales (coseno típico 0.92-1.00).",
+      "endmember_rmse_label": "{{method}} RMSE (normalizado)",
+      "endmember_matrix_label": "Matriz coseno tópico × endmember NFINDR:",
+      "endmember_matrix_aria": "matriz coseno tópico × endmember",
+      "endmember_finding": "Celdas brillantes = coseno alto (tópico y endmember alineados espectralmente). Patrón cuasi-diagonal = los dos métodos recuperan las mismas primitivas espectrales. Posición del plan maestro: con el mismo K, NMF, NFINDR y LDA recuperan una estructura espectral comparable; lo que los separa es la interpretabilidad y la utilidad de gating aguas abajo (B-3, B-7).",
+      "spatial_title": "B-10 coherencia espacial — I de Moran + C de Geary",
+      "spatial_loading": "Cargando coherencia espacial…",
+      "spatial_lead": "I de Moran + C de Geary sobre los mapas de abundancia θ_k por tópico con contigüidad rook de 4 vecinos, promediados entre tópicos. Dos lecturas: submuestreada (base de 220 por clase) y completa (reajuste de LDA con máscara de todos los píxeles). El colapso de KSC sobre la base submuestreada es un artefacto del pipeline — el reajuste con todos los píxeles recupera la coherencia espacial.",
+      "spatial_col_sub_moran": "I de Moran media submuestreada",
+      "spatial_col_sub_geary": "C de Geary media submuestreada",
+      "spatial_col_full_moran": "I de Moran media todos los píxeles",
+      "spatial_col_full_geary": "C de Geary media todos los píxeles",
+      "spatial_finding": "Titular: 5/6 escenas muestran alta coherencia espacial (I de Moran media ≥ 0.80) sobre la base submuestreada. KSC cae a 0.064 (rojo) — pero el <strong>reajuste con todos los píxeles</strong> recupera I = 0.837, demostrando que el \"colapso\" de KSC es un artefacto del muestreo estratificado de 220 por clase en una escena de clases escasas, no un problema fundamental de los datos.",
+      "super_topics_title": "Super-tópicos entre escenas (plan maestro §12)",
+      "super_topics_lead_loading": "Agrupamiento jerárquico de cada tópico de las seis escenas etiquetadas sobre la grilla común 400–2500 nm (enlace promedio sobre coseno). Revela qué tópicos se agrupan entre escenas frente a los que permanecen locales a una escena.",
+      "super_topics_unavailable": "La carga útil de super_topics aún no está disponible.",
+      "super_topics_lead": "Agrupamiento jerárquico de los {{nTopics}} tópicos de las {{nScenes}} escenas etiquetadas sobre la grilla común 400–2500 nm (enlace promedio sobre coseno). Nivel de corte mostrado: {{cutLevel}} → {{nClusters}} clústeres de super-tópicos. Los clústeres multi-escena identifican tópicos que reaparecen entre conjuntos de datos — lo que \"une\" a las escenas.",
+      "super_topics_col_cluster": "clúster",
+      "super_topics_col_members": "miembros",
+      "super_topics_col_scenes": "escenas",
+      "super_topics_col_topic_ids": "ids de tópico"
+    },
+    "backbone_f7": {
+      "title": "F-7 NMI bajo cada backbone de modelo de tópicos (extensión HDP / ProdLDA / ETM)",
+      "lead": "El factorial de backbones c397 reportó solo F-2 c_v. c432–c434 añadieron F-7 NMI para V1/V3/V12/V14/V18/V20, y luego c435 lo extendió a cada receta con wordifications disponibles. Cada celda es la media de F-7 NMI por (escena, receta) sobre 6 escenas etiquetadas. Acento en negrita = ganador por backbone.",
+      "table": {
+        "backboneRecipe": "backbone \\ receta",
+        "mean": "media",
+        "meanFourBackbones": "media (4 backbones)"
+      },
+      "footnote": "Recetas ordenadas por media de F-7 NMI sobre los cuatro backbones. V8 (fracción de endmembers NFINDR) lidera la media cruzada entre backbones (0.431 con Q=8). V20 (ponderada por MI) está en el top-3 bajo LDA y ETM, pero cae al 4.º bajo ProdLDA y al 6.º bajo HDP — ninguna receta está en el top-3 bajo los cuatro backbones, lo cual es en sí mismo el hallazgo: la portabilidad entre priors es específica de la receta, no universal."
+    },
+    "deep": {
+      "anomaly": {
+        "title": "Indicadores de anomalía B-9 — comparación de ρ: LDA vs profundo",
+        "loadingLead": "Cargando correlaciones de anomalía…",
+        "loading": "Cargando…",
+        "lead": "ρ de Spearman entre el puntaje de anomalía por documento y la mala clasificación theta-logística. ρ positivo (verde) = el indicador detecta ejemplos difíciles (funciona como anomalía); negativo (rojo) = el indicador anticorrelaciona (los codificadores profundos concentran capacidad en espectros raros e informativos). El NLL de reconstrucción de LDA funciona como anomalía; los métodos profundos invierten la heurística.",
+        "col": {
+          "scene": "escena",
+          "ldaNll": "ρ NLL recon LDA",
+          "ldaSoftmax": "ρ softmax LDA",
+          "caeRmse": "ρ RMSE recon CAE-1D",
+          "bvRmse": "ρ RMSE recon β-VAE",
+          "bvKl": "ρ KL β-VAE"
+        },
+        "note": "Conclusión: el NLL de reconstrucción de LDA tiene ρ positivo en todas las escenas (Pavia U +0.306, Salinas-A +0.298, KSC +0.226, IP +0.214) — funciona como indicador de anomalía. Los métodos profundos producen ρ mayormente negativo — la heurística de \"reconstrucción alta = desconocido\" NO se transfiere a codificadores profundos no lineales. Los codificadores profundos concentran capacidad en espectros raros e informativos, que el latente luego discrimina bien."
+      },
+      "kcurve": {
+        "title": "Escalamiento por capacidad de CAE-1D — ARI vs K",
+        "loadingLead": "Curva-K de CAE-1D por escena (K∈{4,6,8,10,12,16,32}). Cada línea es una escena etiquetada; cada punto es el ARI de K-means(latente) vs la etiqueta de referencia.",
+        "loading": "Cargando datos de la curva-K profunda (42 celdas)…",
+        "lead": "ARI de K-means(latente) vs etiqueta de referencia, por escena. Casi monótono en todas las escenas (Salinas 0.547 → 0.561, KSC 0.250 → 0.314 de K=4 a K=32). El eje x es log K.",
+        "aria": "Curva K de CAE-1D",
+        "xAxis": "dimensión latente K (escala logarítmica)",
+        "yAxis": "ARI de K-means(latente) vs etiqueta",
+        "note": "Escalamiento por capacidad: todas las escenas mejoran con K; sin sobreajuste en K=32. El ajuste canónico de KSC (LDA θ-logística F1=0.021 en B-3) se recupera a F1=0.710 con CAE-1D K=32 en el panel de sonda lineal, una ganancia de 33× atribuible a la capacidad del codificador profundo."
+      },
+      "cae3d": {
+        "title": "CAE-3D — decodificador ancla vs decodificador de parche completo (curva-K {4, 8})",
+        "loadingLead": "Cargando datos de ancla + parche completo en K∈{4, 8} para 6 escenas etiquetadas…",
+        "loading": "Cargando…",
+        "lead": "Dos decodificadores comparten el mismo codificador convolucional 3-D. El ancla reconstruye solo el espectro del píxel central (Linear K→B); el parche completo reconstruye todo el parche P×P (Linear K→B·P·P). Se barren ambas capacidades K=8 y K=4. El objetivo del decodificador es en sí un hiperparámetro — la dirección es ampliamente estable a través de la capacidad, con una inversión (Pavia U).",
+        "col": {
+          "scene": "escena",
+          "full": "completo",
+          "anchor": "ancla"
+        },
+        "netMean": "ΔARI media neta",
+        "note": "Lectura honesta: el ΔARI medio neto es esencialmente neutro en ambos K (+0.011 K=4, +0.003 K=8). La dirección coincide entre K en 5/6 escenas — IP y Botswana se benefician de forma persistente; la familia Salinas se perjudica de forma persistente (la magnitud crece con K). Pavia U es la única inversión dependiente de la capacidad: el parche completo ayuda en K=4 (+0.026) y perjudica en K=8 (-0.023). El objetivo del decodificador es en sí un hiperparámetro que conviene exponer por escena, no un valor por defecto a invertir globalmente."
+      },
+      "betaVae": {
+        "title": "Barrido de β en β-VAE — desenredo vs colapso posterior",
+        "loadingLead": "Cargando datos del barrido de β…",
+        "loading": "Cargando…",
+        "lead": "ARI de K-means(latente) por escena en K=8 a través de β∈{1, 2, 4, 8, 16}. Brillante = ARI alto; celdas negras = colapso posterior (el codificador β-VAE converge a q(z|x)≈p(z), el latente es no informativo).",
+        "aria": "Cuadrícula de ARI del barrido de β en β-VAE",
+        "note": "Colapso posterior de Salinas en β≥8 (ARI=0.000 — el término KL domina la señal de reconstrucción; el codificador mapea toda entrada a N(0, I)). Salinas-A resiste el colapso e incluso mejora con β (la señal compacta de 6 clases domina el regularizador). Pavia U se degrada monótonamente con β. El valor por defecto β=4 se ubica en el punto de inflexión."
+      }
+    },
+    "gating": {
+      "common": {
+        "loading": "Cargando…",
+        "scene": "escena",
+        "winsBestPerScene": "victorias (mejor por escena)"
+      },
+      "deepGate": {
+        "title": "Seguimiento B-3 — ¿cualquier encoder como compuerta? raw vs θ-routed vs compuertas profundas",
+        "loadingLead": "Cargando payloads de compuerta profunda…",
+        "lead": "Cinco compuertas candidatas compiten en macro F1 por fold a lo largo de las escenas etiquetadas: raw_logistic (sin gating), θ_routed (mezcla de tópicos LDA, símplex Dirichlet natural) y tres compuertas profundas (PCA-8, CAE-1D-8, β-VAE-8) proyectadas sobre el símplex vía softmax. Evalúa si algún encoder profundo recupera la ventaja de gating de θ.",
+        "finding": {
+          "part1": "Hallazgo honesto: las compuertas profundas con proyección ingenua softmax-a-símplex",
+          "not": "no",
+          "part2": "superan a raw_logistic ni a θ_routed. raw_logistic gana en la mayoría de las escenas; θ_routed empata o gana donde la estructura símplex-Dirichlet se alinea con la topología de clases (p. ej. Salinas). La ventaja de θ proviene de la restricción natural del símplex de las mezclas de tópicos distribuidas según Dirichlet, no de la mera compresión a K dimensiones — los latentes profundos pasados por softmax no logran recuperar el mecanismo de gating."
+        }
+      },
+      "neuralTopic": {
+        "title": "Modelos de tópicos neuronales — comparación directa LDA vs ProdLDA vs ETM",
+        "loadingLead": "Cargando comparación de tópicos neuronales por escena…",
+        "lead": "Tres modelos de tópicos de estilo neuronal comparados sobre la muestra estratificada canónica de 220 por clase. Dos métricas: (1) ARI de K-means(theta) vs etiqueta de referencia — calidad de clustering. (2) coherencia de tópicos c_v (ventana deslizante de Röder 2015, top-15 palabras) — calidad semántica. Las celdas de ProdLDA + ETM muestran media ± desv. estándar a lo largo de N=5 semillas. La celda de LDA usa el ajuste canónico (semilla única; la estabilidad por semilla de LDA está en la pestaña separada de estabilidad del Workspace). Las dos métricas cuentan historias distintas — coherencia ≠ discriminabilidad de clases sobre vocabularios de frecuencia de banda.",
+        "header": {
+          "cls": "cls",
+          "ariVsLabel": "ARI vs etiqueta",
+          "cvCoherence": "coherencia c_v (top-15)"
+        },
+        "finding": {
+          "headline": "Coherencia y discriminabilidad NO son la misma métrica sobre tokens de frecuencia de banda.",
+          "body1": "ProdLDA gana c_v en todas las escenas (la mayor coherencia semántica entre los tres) pero pierde ARI en 4/6 escenas — sus tópicos son internamente compactos pero no se alinean con la estructura de clases. LDA gana ARI en 4/6 escenas (la theta más discriminativa de clases en promedio) pero pierde c_v en todas las escenas. ETM queda en medio en ambos ejes — leve mejora sobre ProdLDA en ARI (5/6 victorias), leve regresión en c_v.",
+          "ruleLabel": "Regla operativa",
+          "body2": ": elige la familia de tópicos según la tarea aguas abajo, no solo por la coherencia. Para clustering de clases usa LDA (o el respaldo neuronal cuando LDA colapsa, p. ej. KSC). Para interpretabilidad / tarjetas de vocabulario de tópicos (pestaña Topics del Workspace) usa la mayor coherencia de ProdLDA. ETM es el punto medio seguro si ambos importan."
+        }
+      },
+      "bayesian": {
+        "title": "Comparación bayesiana de métodos — posteriores jerárquicos NUTS",
+        "loadingLead": "Cargando posteriores de PyMC con 4 cadenas × 1000 tune + 1000 draws…",
+        "lead": "Modelo normal jerárquico de PyMC: y ~ N(μ_method + α_scene + γ_fold, σ). Las medias posteriores se muestran como puntos rojos, los intervalos HDI94 como barras azules. Los métodos están ordenados por media posterior. La línea vertical discontinua en μ=0 es la referencia de la media del modelo.",
+        "forestFooter": "{{obs}} observaciones · {{methods}} métodos · {{summary}}",
+        "forest": {
+          "classification": {
+            "title": "Clasificación (escenas etiquetadas, 150 obs)",
+            "note": "Los HDI de raw / pca / topic_routed_* son estrictamente positivos; el HDI de theta_logistic incluye 0 — la theta-flat ingenua es estadísticamente indistinguible de la media del modelo."
+          },
+          "classificationDeep": {
+            "title": "Clasificación con compuertas profundas (escenas etiquetadas, 150 obs)",
+            "note": "Seguimiento B-3: las compuertas son raw_logistic vs. θ_routed vs. PCA-8 / CAE-1D-8 / β-VAE-8 routed (latentes profundos pasados por softmax a un símplex). raw_logistic domina a θ_routed y a todas las compuertas profundas con P≥0.999; θ_routed domina a cada compuerta profunda con P≥0.999. Evidencia bayesiana decisiva de que los latentes profundos pasados por softmax NO recuperan la ventaja de gating de θ — la ventaja de θ proviene del símplex Dirichlet natural."
+          },
+          "regression": {
+            "title": "Regresión (HIDSAG, subconjuntos n≥50: GEOMET + MINERAL1)",
+            "note": "Pool restringido a subconjuntos n≥50 — los tres subconjuntos de n pequeño (PORPHYRY R²≈−12500, MINERAL2, GEOCHEM) se excluyen porque su R² explosivo contaminó el posterior agrupado anterior. Lectura honesta: agrupado sobre los dos subconjuntos válidos, ningún método supera el cero (raw_ridge con la mayor estimación puntual, el ensemble propuesto con gating suave de θ en segundo lugar, estadísticamente indistinguible). Pero la compuerta suave supera a su propia ablación de routing duro por ~0.44 unidades de R², y por subconjunto en GEOMET (n=146) el ensemble suave es el mejor método (R²=0.307 > raw 0.258). La victoria es específica del subconjunto, no universal."
+          }
+        }
+      }
+    },
+    "hidsag": {
+      "cross_preproc": {
+        "title": "HIDSAG — estabilidad entre preprocesamientos (seguimiento B-6)",
+        "lead": "Qué tan estables son los tópicos LDA cuando cambia la receta de preprocesamiento. Se reporta como el índice de Jaccard de los 15 tokens principales con emparejamiento húngaro entre las 4 políticas (crudo / máscara de bandas heurística / SNV / SavGol+SNV). Bajo = los tópicos cambian sustancialmente entre recetas; alto = los tópicos se mantienen.",
+        "policies_count_one": "{{count}} política",
+        "policies_count_other": "{{count}} políticas",
+        "off_diag_mean": "media fuera de diagonal",
+        "metric_note": "Métrica: Jaccard de los 15 tokens principales con asignación húngara. Cada celda de las matrices N×N es la estabilidad media por tópico entre las políticas i, j.",
+        "matrix_aria": "Matriz entre preprocesamientos para {{code}}"
+      },
+      "preprocessing": {
+        "title": "HIDSAG — sensibilidad al preprocesamiento espectral",
+        "lead": "Cuatro políticas de preprocesamiento (crudo / máscara heurística de bandas malas / SNV / Savitzky-Golay+SNV) sobre las 5 escenas HIDSAG. Mide cómo cambia el desempeño posterior (clasificación + regresión) cuando varía la receta de limpieza espectral.",
+        "loading": "Cargando sensibilidad al preprocesamiento…",
+        "load_error": "No se pudo cargar {{endpoint}}.",
+        "classification_title": "Clasificación · exactitud balanceada",
+        "regression_title": "Regresión · R²",
+        "regression_not_shown": "No se muestra — el R² validado de forma cruzada no es estimable con n<50 (aquí n={{n}}); los pliegues de prueba se disparan a R²≪0 y la métrica es ruido, no un resultado. Vea el panel de regresión más abajo para los subconjuntos con n≥50."
+      },
+      "regression": {
+        "title": "HIDSAG — regresión sobre mediciones",
+        "lead": "Una prueba interdominio exigente: ¿pueden las representaciones de tópicos predecir linealmente ensayos geológicos continuos (Cu %, Au g/t, mineralogía)? R² < 0 significa peor que predecir la media del objetivo. Esto es independiente de —y mucho más difícil que— los resultados de tópicos en escenas etiquetadas; trátelo como una prueba de estrés, no como el resultado principal.",
+        "loading": "Cargando rankings HIDSAG…",
+        "no_block": "No hay bloque de regresión disponible.",
+        "forest_aria": "Bosque HIDSAG {{code}}",
+        "excluded_label": "<strong>Excluidos (n < {{minN}}):</strong>",
+        "excluded_note": ". El R² de regresión validado de forma cruzada no es estimable con estos tamaños de muestra — los pliegues son demasiado pequeños para la dimensión de bandas/características, así que los valores son ruido estadístico en lugar de resultados.",
+        "r2_explainer": "R² < 0 significa que el modelo predice el objetivo numérico peor que su propia media — algo esperable en la regresión de ensayos (Cu %, Au g/t) sobre estos pequeños subconjuntos minerales (n = decenas a pocas centenas). Es una prueba interdominio deliberadamente difícil y es <em>independiente</em> de los resultados de tópicos en escenas etiquetadas, donde las representaciones sí separan clases.",
+        "off_scale_note": "Los métodos con R² ≪ 0 (ajustes catastróficos en muestras pequeñas) se recortan al borde del eje en {{floor}} y se etiquetan con su valor real.",
+        "method_labels": {
+          "soft_theta_gated": "ensamble suave con compuerta θ  ★ propuesto",
+          "hard_route": "ruta dura (ablación)",
+          "raw_ridge": "espectro crudo · Ridge",
+          "raw_pls": "espectro crudo · PLS",
+          "theta_region": "característica θ · región",
+          "theta_cube": "característica θ · cubo",
+          "theta_pixel": "característica θ · píxel"
+        }
+      }
+    },
+    "llm": {
+      "empty": {
+        "title": "B-12 — hojas de té LLM (Stammbach et al. TACL 2024)",
+        "lead": "Sondas de intrusión de palabras + etiquetas coherentes vía Anthropic Claude. El generador está condicionado por ANTHROPIC_API_KEY; las salidas se guardan en data/derived/llm_tea_leaves una vez definida la variable de entorno y ejecutado el generador.",
+        "note": "Aún no hay escenas evaluadas. Define <code>ANTHROPIC_API_KEY</code> y ejecuta <code>build-b12-llm-tea-leaves</code> para poblarlas."
+      },
+      "section": {
+        "title": "B-12 — hojas de té LLM (Stammbach et al. 2023, EMNLP)",
+        "lead": "Exactitud de intrusión de palabras por escena + etiquetas generadas por el LLM por tópico. Una mayor exactitud de intrusión significa que el LLM identifica correctamente la palabra ajena introducida en el top-10 de cada tópico — una señal de coherencia que correlaciona con NPMI en trabajos previos. Las salidas incluidas aquí son el sustituto determinista de autoevaluación de Claude Opus 4.7 (ver columna model); también se implementa una ejecución completa vía API con build_b12_llm_tea_leaves.py para reproducción externa."
+      },
+      "table": {
+        "scene": "escena",
+        "topics": "tópicos",
+        "intrusionAccuracy": "exactitud de intrusión",
+        "model": "modelo"
+      },
+      "detail": {
+        "summary": "{{sceneId}} — etiquetas LLM por tópico",
+        "topic": "tópico {{topicId}}",
+        "skipped": "— omitido ({{reason}})",
+        "noLabel": "(sin etiqueta)"
+      }
+    },
+    "summary": {
+      "forest_title": "Diagrama de bosque — macro-F1 con CI95 por escena",
+      "forest_lead": "Cada barra es una escena × método; el punto es la media y los bigotes son los percentiles 2.5 y 97.5 del bootstrap sobre las 25 evaluaciones.",
+      "forest_aria": "Diagrama de bosque para {{scene}}",
+      "paired_title": "Comparaciones pareadas (Δ macro-F1)",
+      "paired_lead": "Cada par muestra la diferencia entre métodos por evaluación; resumida como media ± desviación estándar de Δ. Negativo = el segundo método pierde.",
+      "paired_col_a": "A",
+      "paired_col_b": "B",
+      "paired_col_delta_mean": "Δ media",
+      "paired_col_delta_std": "Δ desv. est.",
+      "paired_col_delta_range": "[Δ mín, Δ máx]",
+      "method_defs_title": "Definiciones de los métodos",
+      "stat_scenes_evaluated": "Escenas evaluadas",
+      "stat_evaluations_per_method": "Evaluaciones por método",
+      "stat_alpha_significance": "Significancia α",
+      "classes_suffix": "clases",
+      "battery_title": "Multi-Axis Addendum B — resumen de la batería",
+      "battery_lead_loading": "Una fila por escena etiquetada, una columna por eje (B-1 F1 de línea base justa, B-3 F1 topic-routed, B-6 estabilidad off-diag de LDA). Los tres ejes cargan en paralelo. Consulta la wiki para el marco completo.",
+      "battery_loading": "Cargando los datos de la batería multi-eje…",
+      "battery_lead": "Una fila por escena etiquetada. Columnas: F1 de theta-como-característica (B-1, ingenuo), F1 ICA-10 (B-1, ganador de la línea base justa), mejor F1 CAE-1D sobre K∈{4..32} (B-1 escalera profunda), F1 topic_routed_soft (B-3 la tesis del master-plan), F1 raw_logistic (B-3 línea base fuerte) y estabilidad off-diagonal de LDA (B-6, N=7 semillas). El marco está en la página Multi-Axis-Addendum-B de la wiki.",
+      "battery_col_scene": "escena",
+      "battery_col_theta_flat": "θ flat (B-1)",
+      "battery_col_ica10": "ICA-10 (B-1)",
+      "battery_col_cae_best": "CAE-1D best (B-1)",
+      "battery_col_theta_logistic": "θ_logistic (B-3)",
+      "battery_col_routed_soft": "routed_soft (B-3)",
+      "battery_col_raw_logistic": "raw_logistic (B-3)",
+      "battery_col_lda_stability": "estabilidad LDA (B-6)",
+      "battery_headlines": "<strong>Titulares:</strong> ICA-10 gana la línea base justa B-1 en todas las escenas. CAE-1D K=32 cierra gran parte de la brecha (KSC θ=0.021 → CAE-1D K=32=0.710, una recuperación de 33×). topic_routed_soft iguala o supera a raw_logistic en todas las escenas; θ_logistic pierde por 30-50 puntos en todas partes — la tesis del master-plan \"θ como compuerta, nunca como característica\" queda validada empíricamente. La estabilidad off-diag de LDA ≥ 0.954 en las 6 escenas frente a CAE-1D 0.74-0.97 y β-VAE 0.18-0.89."
+    },
+    "vsweep_coverage": {
+      "title": "Matriz de cobertura del V-sweep (10 ejes × 19 recetas × 6 escenas)",
+      "lead": "1140 celdas numéricas en total — todas pobladas. Alterna entre boolean (¿celdas llenas?) y value (numérico por celda, mapa de color viridis). F-13 SHAP no tiene valor escalar, así que permanece en modo boolean.",
+      "toggle": {
+        "values": "valores",
+        "boolean": "booleano"
+      },
+      "table": {
+        "axisSceneRecipe": "eje \\ escena·receta"
+      },
+      "footnote": "Generado el {{date}}. F-14 jaccard usa color invertido (menor = mejor, mapeado a la banda de color \"alta\"). F-17 entre escenas (solo portables) y los registros de juez-LLM por escena B-12 / F-15 se reportan en sus paneles dedicados.",
+      "recipeMeans": {
+        "heading": "Ranking de media por receta y eje",
+        "axis": "eje"
+      }
     }
   },
   "workspace_methods": {

--- a/frontend/src/pages/benchmarks/BackboneF7Panel.tsx
+++ b/frontend/src/pages/benchmarks/BackboneF7Panel.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { request } from "@/api/_http";
 import { Section } from "@/components/Section";
 
@@ -28,6 +29,7 @@ function cellColour(v: number): string {
 }
 
 export function BackboneF7Panel() {
+  const { t } = useTranslation(["pages"]);
   const { data, isLoading, isError } = useQuery<BackbonesF7Payload>({
     queryKey: ["backbones-f7"],
     queryFn: () => request<BackbonesF7Payload>("/api/v-sweep/backbones-f7"),
@@ -68,15 +70,15 @@ export function BackboneF7Panel() {
   return (
     <Section
       id="backbone-f7"
-      title="F-7 NMI under each topic-model backbone (HDP / ProdLDA / ETM extension)"
-      lead="The c397 backbone factorial reported F-2 c_v only. c432–c434 added F-7 NMI for V1/V3/V12/V14/V18/V20, then extended in c435 to every recipe with available wordifications. Each cell is the per-(scene, recipe) F-7 NMI mean across 6 labelled scenes. Bold accent = per-backbone winner."
+      title={t("pages:benchmarks.backbone_f7.title")}
+      lead={t("pages:benchmarks.backbone_f7.lead")}
     >
       <div className="overflow-x-auto">
         <table className="w-full text-[12px] border-collapse" style={{ borderColor: "var(--color-border)" }}>
           <thead>
             <tr>
               <th className="text-left px-2 py-1 border font-mono" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-                backbone \ recipe
+                {t("pages:benchmarks.backbone_f7.table.backboneRecipe")}
               </th>
               {sortedRecipes.map((r) => (
                 <th
@@ -88,7 +90,7 @@ export function BackboneF7Panel() {
                 </th>
               ))}
               <th className="text-right px-2 py-1 border font-mono" style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}>
-                mean
+                {t("pages:benchmarks.backbone_f7.table.mean")}
               </th>
             </tr>
           </thead>
@@ -130,7 +132,7 @@ export function BackboneF7Panel() {
             })}
             <tr style={{ borderTop: "2px solid var(--color-border)" }}>
               <td className="px-2 py-1 border font-mono" style={{ borderColor: "var(--color-border)", fontWeight: 700 }}>
-                mean (4 backbones)
+                {t("pages:benchmarks.backbone_f7.table.meanFourBackbones")}
               </td>
               {sortedRecipes.map((r) => {
                 const v = meanAcrossBackbones[r];
@@ -156,11 +158,7 @@ export function BackboneF7Panel() {
         </table>
       </div>
       <p className="mt-2 text-[11.5px]" style={{ color: "var(--color-fg-faint)" }}>
-        Recipes ordered by mean F-7 NMI across the four backbones. V8 (NFINDR
-        endmember-fraction) leads the cross-backbone mean (0.431 at Q=8). V20
-        (MI-weighted) is top-3 under LDA and ETM but slips to 4th under ProdLDA and 6th
-        under HDP — no single recipe is top-3 under all four backbones, which is itself the
-        finding: cross-prior portability is recipe-specific, not universal.
+        {t("pages:benchmarks.backbone_f7.footnote")}
       </p>
     </Section>
   );

--- a/frontend/src/pages/benchmarks/BenchmarksAxes.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksAxes.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
 import { useQuery, useQueries } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { Section } from "@/components/Section";
@@ -18,6 +19,7 @@ export function BenchmarksAxes() {
 }
 
 function SpatialCoherenceSection() {
+  const { t } = useTranslation(["pages"]);
   const subQs = useQueries({
     queries: LABELLED_SCENES.map((sc) => ({
       queryKey: ["topic-spatial-continuous", sc],
@@ -35,8 +37,8 @@ function SpatialCoherenceSection() {
   const ready = subQs.every((q) => q.data || q.error);
   if (!ready) {
     return (
-      <Section title="B-10 spatial coherence — Moran's I + Geary's C" lead="Loading spatial coherence…">
-        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+      <Section title={t("pages:benchmarks.axes.spatial_title")} lead={t("pages:benchmarks.axes.spatial_loading")}>
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.axes.loading")}</p>
       </Section>
     );
   }
@@ -49,18 +51,18 @@ function SpatialCoherenceSection() {
   }));
   return (
     <Section
-      title="B-10 spatial coherence — Moran's I + Geary's C"
-      lead="Per-topic θ_k abundance maps Moran's I + Geary's C with 4-neighbour rook contiguity, mean across topics. Two readings: subsampled (220-per-class basis) and full (full-pixel mask LDA refit). KSC's collapse on the subsampled basis is a pipeline artifact — full-pixel refit recovers spatial coherence."
+      title={t("pages:benchmarks.axes.spatial_title")}
+      lead={t("pages:benchmarks.axes.spatial_lead")}
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
           <thead>
             <tr style={{ color: "var(--color-text-muted)" }}>
-              <th className="text-left font-mono text-[12px] pb-2 pr-3">scene</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">subsampled mean Moran I</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">subsampled mean Geary C</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">full-pixel mean Moran I</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">full-pixel mean Geary C</th>
+              <th className="text-left font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.axes.col_scene")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.axes.spatial_col_sub_moran")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.axes.spatial_col_sub_geary")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.axes.spatial_col_full_moran")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.axes.spatial_col_full_geary")}</th>
             </tr>
           </thead>
           <tbody>
@@ -97,16 +99,17 @@ function SpatialCoherenceSection() {
         </table>
       </div>
       <p className="mt-3 text-[12.5px]" style={{ color: "var(--color-text-muted)" }}>
-        Headline: 5/6 scenes show high spatial coherence (mean Moran I ≥ 0.80) on the subsampled basis.
-        KSC drops to 0.064 (red) — but the <strong>full-pixel refit</strong> recovers I = 0.837, demonstrating that
-        KSC's "collapse" is an artifact of stratified 220-per-class sampling on a sparse-class scene, not a fundamental
-        data problem.
+        <Trans
+          i18nKey="pages:benchmarks.axes.spatial_finding"
+          components={{ strong: <strong /> }}
+        />
       </p>
     </Section>
   );
 }
 
 function EndmemberBaselineSection() {
+  const { t } = useTranslation(["pages"]);
   const [scene, setScene] = useState<string>(LABELLED_SCENES[0]!);
   const { data, error } = useQuery({
     queryKey: ["endmember-baseline", scene],
@@ -115,8 +118,8 @@ function EndmemberBaselineSection() {
   });
   if (!data || error) {
     return (
-      <Section title="B-11 endmember baseline — NFINDR / ATGP vs LDA topics" lead="Loading endmember baseline…">
-        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+      <Section title={t("pages:benchmarks.axes.endmember_title")} lead={t("pages:benchmarks.axes.endmember_loading")}>
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.axes.loading")}</p>
       </Section>
     );
   }
@@ -125,11 +128,15 @@ function EndmemberBaselineSection() {
 
   return (
     <Section
-      title="B-11 endmember baseline — NFINDR / ATGP vs LDA topics"
-      lead={`At K=${data.K}, NFINDR + ATGP endmembers extracted from the canonical labelled-pixel subset (${data.n_pixels_used.toLocaleString()} px, ${data.n_bands} bands). Cosine similarity between LDA topics and NFINDR endmembers — at the same K, both methods land on the same spectral primitives (typical cosine 0.92-1.00).`}
+      title={t("pages:benchmarks.axes.endmember_title")}
+      lead={t("pages:benchmarks.axes.endmember_lead", {
+        K: data.K,
+        nPixels: data.n_pixels_used.toLocaleString(),
+        nBands: data.n_bands,
+      })}
     >
       <div className="flex items-center gap-2 mb-3 flex-wrap">
-        <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>Scene:</span>
+        <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.axes.scene_label")}</span>
         {LABELLED_SCENES.map((sc) => (
           <button
             key={sc}
@@ -157,7 +164,7 @@ function EndmemberBaselineSection() {
             }}
           >
             <div className="text-[10px] mb-1 font-mono uppercase tracking-wide" style={{ color: "var(--color-text-muted)" }}>
-              {m.replace(/_/g, " ")} RMSE (normalised)
+              {t("pages:benchmarks.axes.endmember_rmse_label", { method: m.replace(/_/g, " ") })}
             </div>
             <div className="font-mono text-[13px]" style={{ color: "var(--color-text)" }}>
               {v.toFixed(4)}
@@ -168,12 +175,12 @@ function EndmemberBaselineSection() {
       {matrix.length > 0 ? (
         <div className="overflow-x-auto">
           <p className="text-[12px] mb-2" style={{ color: "var(--color-text-muted)" }}>
-            Topic × NFINDR endmember cosine matrix:
+            {t("pages:benchmarks.axes.endmember_matrix_label")}
           </p>
           <svg
             viewBox={`0 0 ${matrix[0]!.length * cell + 80} ${matrix.length * cell + 50}`}
             role="img"
-            aria-label="topic × endmember cosine matrix"
+            aria-label={t("pages:benchmarks.axes.endmember_matrix_aria")}
             style={{ maxWidth: "min(100%, 540px)" }}
           >
             {matrix.map((row, i) =>
@@ -228,13 +235,14 @@ function EndmemberBaselineSection() {
         </div>
       ) : null}
       <p className="mt-3 text-[12.5px]" style={{ color: "var(--color-text-muted)" }}>
-        Bright cells = high cosine (topic and endmember spectrally aligned). Diagonal-like pattern = the two methods recover the same spectral primitives. Master-plan position: at the same K, NMF, NFINDR, and LDA all recover comparable spectral structure; what separates them is interpretability and downstream gating utility (B-3, B-7).
+        {t("pages:benchmarks.axes.endmember_finding")}
       </p>
     </Section>
   );
 }
 
 function MutualInfoSection() {
+  const { t } = useTranslation(["pages"]);
   const [scene, setScene] = useState<string>(LABELLED_SCENES[0]!);
   const { data, error } = useQuery({
     queryKey: ["mutual-information", scene],
@@ -243,8 +251,8 @@ function MutualInfoSection() {
   });
   if (!data || error) {
     return (
-      <Section title="B-4 mutual information — per-feature MI(z; y)" lead="Loading mutual information…">
-        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+      <Section title={t("pages:benchmarks.axes.mi_title")} lead={t("pages:benchmarks.axes.mi_loading")}>
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.axes.loading")}</p>
       </Section>
     );
   }
@@ -272,11 +280,11 @@ function MutualInfoSection() {
 
   return (
     <Section
-      title="B-4 mutual information — per-feature MI(z; y)"
-      lead="For each method, MI between every latent feature z_k and the label y. Bright = high MI = informative feature. Per-feature distribution is the right discriminative signal — joint MI clips to label entropy once K is non-degenerate."
+      title={t("pages:benchmarks.axes.mi_title")}
+      lead={t("pages:benchmarks.axes.mi_lead")}
     >
       <div className="flex items-center gap-2 mb-3 flex-wrap">
-        <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>Scene:</span>
+        <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.axes.scene_label")}</span>
         {LABELLED_SCENES.map((sc) => (
           <button
             key={sc}
@@ -297,10 +305,14 @@ function MutualInfoSection() {
         className="text-[12px] mb-2"
         style={{ color: "var(--color-text-muted)" }}
       >
-        Label entropy H(Y) = {data.label_entropy_nats.toFixed(3)} nats ({data.label_entropy_bits.toFixed(3)} bits) — the upper bound for joint MI. Top {methods.length} methods sorted by per-feature MI sum.
+        {t("pages:benchmarks.axes.mi_entropy_note", {
+          nats: data.label_entropy_nats.toFixed(3),
+          bits: data.label_entropy_bits.toFixed(3),
+          count: methods.length,
+        })}
       </p>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label="MI heatmap" style={{ maxWidth: "min(100%, 760px)" }}>
+        <svg viewBox={`0 0 ${W} ${H}`} role="img" aria-label={t("pages:benchmarks.axes.mi_heatmap_aria")} style={{ maxWidth: "min(100%, 760px)" }}>
           {methods.map(([mname, info], i) => {
             const feats = info.per_feature_mi.slice(0, maxCols);
             return (
@@ -347,7 +359,7 @@ function MutualInfoSection() {
             );
           })}
           <text x={labelW + (maxCols * cellW) / 2} y={14} fontSize="11" textAnchor="middle" fill="currentColor" opacity="0.7">
-            feature index k → (capped at {maxCols} for readability)
+            {t("pages:benchmarks.axes.mi_feature_axis", { maxCols })}
           </text>
         </svg>
       </div>
@@ -356,6 +368,7 @@ function MutualInfoSection() {
 }
 
 function RateDistortionSection() {
+  const { t } = useTranslation(["pages"]);
   const [scene, setScene] = useState<string>(LABELLED_SCENES[0]!);
   const { data, error } = useQuery({
     queryKey: ["rate-distortion-curve", scene],
@@ -365,11 +378,11 @@ function RateDistortionSection() {
   if (!data || error) {
     return (
       <Section
-        title="B-2 rate-distortion curve — reconstruction RMSE vs K"
-        lead="Loading rate-distortion curves…"
+        title={t("pages:benchmarks.axes.rate_distortion_title")}
+        lead={t("pages:benchmarks.axes.rate_distortion_loading")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          Loading…
+          {t("pages:benchmarks.axes.loading")}
         </p>
       </Section>
     );
@@ -399,12 +412,12 @@ function RateDistortionSection() {
   };
   return (
     <Section
-      title="B-2 rate-distortion curve — reconstruction RMSE vs K"
-      lead="LDA / NMF / PCA reconstruction RMSE on a 20% held-out test split, across K∈{4, 6, 8, 10, 12, 16}. PCA is the L2-optimal compressor (wins everywhere). NMF a close second. LDA last because it optimises a multinomial likelihood, not L2 RMSE — this is the expected picture and is documented as Axis G."
+      title={t("pages:benchmarks.axes.rate_distortion_title")}
+      lead={t("pages:benchmarks.axes.rate_distortion_lead")}
     >
       <div className="flex items-center gap-2 mb-3 flex-wrap">
         <span className="text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-          Scene:
+          {t("pages:benchmarks.axes.scene_label")}
         </span>
         {LABELLED_SCENES.map((sc) => (
           <button
@@ -423,7 +436,7 @@ function RateDistortionSection() {
         ))}
       </div>
 
-      <svg viewBox={`0 0 ${W} ${H + 30}`} role="img" aria-label="rate-distortion curve">
+      <svg viewBox={`0 0 ${W} ${H + 30}`} role="img" aria-label={t("pages:benchmarks.axes.rate_distortion_aria")}>
         <line x1={padding} y1={H - padding} x2={W - padding} y2={H - padding} stroke="currentColor" strokeWidth="1" />
         <line x1={padding} y1={padding} x2={padding} y2={H - padding} stroke="currentColor" strokeWidth="1" />
         {Ks.map((k) => (
@@ -492,6 +505,7 @@ function RateDistortionSection() {
 }
 
 function CrossSceneTransferSection() {
+  const { t } = useTranslation(["pages"]);
   const { data, error } = useQuery({
     queryKey: ["cross-scene-transfer"],
     queryFn: () => api.crossSceneTransfer(),
@@ -500,11 +514,11 @@ function CrossSceneTransferSection() {
   if (!data || error) {
     return (
       <Section
-        title="B-8 cross-scene transfer — fit on A, infer on B"
-        lead="Loading transfer matrix…"
+        title={t("pages:benchmarks.axes.cross_scene_title")}
+        lead={t("pages:benchmarks.axes.cross_scene_loading")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          Loading…
+          {t("pages:benchmarks.axes.loading")}
         </p>
       </Section>
     );
@@ -525,14 +539,18 @@ function CrossSceneTransferSection() {
   }
   return (
     <Section
-      title="B-8 cross-scene transfer — fit on A, infer on B"
-      lead={`5 AVIRIS-class scenes resampled to a common ${data.common_wavelength_grid.n_bands}-band ${data.common_wavelength_grid.min_nm}-${data.common_wavelength_grid.max_nm} nm grid. Each cell is the macro-F1 of a 5-fold logistic on θ (LDA fit on row scene, inferred on column scene). Diagonal = within-scene baseline. Pavia U excluded (ROSIS).`}
+      title={t("pages:benchmarks.axes.cross_scene_title")}
+      lead={t("pages:benchmarks.axes.cross_scene_lead", {
+        nBands: data.common_wavelength_grid.n_bands,
+        minNm: data.common_wavelength_grid.min_nm,
+        maxNm: data.common_wavelength_grid.max_nm,
+      })}
     >
       <div className="overflow-x-auto">
         <svg
           viewBox={`0 0 ${labelW + scenes.length * cell + 50} ${headerH + scenes.length * cell + 30}`}
           role="img"
-          aria-label="Cross-scene transfer matrix"
+          aria-label={t("pages:benchmarks.axes.cross_scene_aria")}
           style={{ maxWidth: "min(100%, 760px)" }}
         >
           <text
@@ -543,7 +561,7 @@ function CrossSceneTransferSection() {
             fill="currentColor"
             fontWeight="600"
           >
-            target scene (column)
+            {t("pages:benchmarks.axes.cross_scene_axis_target")}
           </text>
           {scenes.map((s, j) => (
             <text
@@ -617,7 +635,7 @@ function CrossSceneTransferSection() {
             fontWeight="600"
             transform={`rotate(-90, 20, ${headerH + (scenes.length * cell) / 2})`}
           >
-            source scene (row)
+            {t("pages:benchmarks.axes.cross_scene_axis_source")}
           </text>
         </svg>
       </div>
@@ -625,12 +643,7 @@ function CrossSceneTransferSection() {
         className="mt-3 text-[12.5px]"
         style={{ color: "var(--color-text-muted)" }}
       >
-        Diagonal cells (white border) are within-scene F1 — they match the
-        native-grid B-3 numbers within ±0.025, so the resampling is honest.
-        Salinas → Salinas-A = 0.747 is the strongest off-diagonal (same
-        campaign, overlapping fields). KSC's collapsed topics neither transfer
-        well (KSC → others ≤ 0.405) nor receive well (others → KSC ≤ 0.405).
-        Salinas-A is the easiest target (0.65-0.75 from any source — compact 6-class).
+        {t("pages:benchmarks.axes.cross_scene_finding")}
       </p>
     </Section>
   );
@@ -640,6 +653,7 @@ function CrossSceneTransferSection() {
 
 
 function SuperTopicsSection() {
+  const { t } = useTranslation(["pages"]);
   const { data, error } = useQuery({
     queryKey: ["super-topics"],
     queryFn: () => api.superTopics(),
@@ -648,11 +662,11 @@ function SuperTopicsSection() {
   if (error || !data) {
     return (
       <Section
-        title="Cross-scene super-topics (master plan §12)"
-        lead="Hierarchical clustering of every topic across all six labelled scenes on the common 400–2500 nm grid (average linkage on cosine). Reveals which topics group across scenes vs. stay scene-local."
+        title={t("pages:benchmarks.axes.super_topics_title")}
+        lead={t("pages:benchmarks.axes.super_topics_lead_loading")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          super_topics payload not available yet.
+          {t("pages:benchmarks.axes.super_topics_unavailable")}
         </p>
       </Section>
     );
@@ -664,16 +678,21 @@ function SuperTopicsSection() {
   );
   return (
     <Section
-      title="Cross-scene super-topics (master plan §12)"
-      lead={`Hierarchical clustering of all ${data.n_topics_total} topics across ${data.n_scenes} labelled scenes on the common 400–2500 nm grid (average linkage on cosine). Cut level shown: ${cut8.cut_level} → ${cut8.n_clusters} super-topic clusters. Multi-scene clusters identify topics that recur across data sets — what "unites" the scenes.`}
+      title={t("pages:benchmarks.axes.super_topics_title")}
+      lead={t("pages:benchmarks.axes.super_topics_lead", {
+        nTopics: data.n_topics_total,
+        nScenes: data.n_scenes,
+        cutLevel: cut8.cut_level,
+        nClusters: cut8.n_clusters,
+      })}
     >
       <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
         <thead>
           <tr style={{ color: "var(--color-text-muted)" }}>
-            <th className="text-left font-mono text-[12px] pb-2">cluster</th>
-            <th className="text-left font-mono text-[12px] pb-2">members</th>
-            <th className="text-left font-mono text-[12px] pb-2">scenes</th>
-            <th className="text-left font-mono text-[12px] pb-2">topic ids</th>
+            <th className="text-left font-mono text-[12px] pb-2">{t("pages:benchmarks.axes.super_topics_col_cluster")}</th>
+            <th className="text-left font-mono text-[12px] pb-2">{t("pages:benchmarks.axes.super_topics_col_members")}</th>
+            <th className="text-left font-mono text-[12px] pb-2">{t("pages:benchmarks.axes.super_topics_col_scenes")}</th>
+            <th className="text-left font-mono text-[12px] pb-2">{t("pages:benchmarks.axes.super_topics_col_topic_ids")}</th>
           </tr>
         </thead>
         <tbody>

--- a/frontend/src/pages/benchmarks/BenchmarksDeep.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksDeep.tsx
@@ -1,4 +1,5 @@
 import { useQueries } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { api } from "@/api/client";
 import { Section } from "@/components/Section";
 import { LABELLED_SCENES } from "./shared";
@@ -15,6 +16,7 @@ export function BenchmarksDeep() {
 }
 
 function AnomalyComparisonSection() {
+  const { t } = useTranslation(["pages"]);
   const ldaQs = useQueries({
     queries: LABELLED_SCENES.map((sc) => ({
       queryKey: ["topic-anomaly", sc],
@@ -36,11 +38,11 @@ function AnomalyComparisonSection() {
   if (!ready) {
     return (
       <Section
-        title="B-9 anomaly indicators — LDA vs deep ρ comparison"
-        lead="Loading anomaly correlations…"
+        title={t("pages:benchmarks.deep.anomaly.title")}
+        lead={t("pages:benchmarks.deep.anomaly.loadingLead")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          Loading…
+          {t("pages:benchmarks.deep.anomaly.loading")}
         </p>
       </Section>
     );
@@ -71,19 +73,19 @@ function AnomalyComparisonSection() {
 
   return (
     <Section
-      title="B-9 anomaly indicators — LDA vs deep ρ comparison"
-      lead="Spearman ρ between per-document anomaly score and theta-logistic misclassification. Positive ρ (green) = the indicator flags hard examples (works as anomaly); negative (red) = the indicator anti-correlates (deep encoders concentrate capacity on rare informative spectra). LDA's recon NLL works as anomaly; deep methods invert the heuristic."
+      title={t("pages:benchmarks.deep.anomaly.title")}
+      lead={t("pages:benchmarks.deep.anomaly.lead")}
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
           <thead>
             <tr style={{ color: "var(--color-text-muted)" }}>
-              <th className="text-left font-mono text-[12px] pb-2 pr-3">scene</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">LDA recon NLL ρ</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">LDA softmax ρ</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">CAE-1D recon RMSE ρ</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">β-VAE recon RMSE ρ</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">β-VAE KL ρ</th>
+              <th className="text-left font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.anomaly.col.scene")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.anomaly.col.ldaNll")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.anomaly.col.ldaSoftmax")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.anomaly.col.caeRmse")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.anomaly.col.bvRmse")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.anomaly.col.bvKl")}</th>
             </tr>
           </thead>
           <tbody>
@@ -104,11 +106,7 @@ function AnomalyComparisonSection() {
         className="mt-3 text-[12.5px]"
         style={{ color: "var(--color-text-muted)" }}
       >
-        Headline: LDA recon NLL is positive ρ on every scene (Pavia U +0.306,
-        Salinas-A +0.298, KSC +0.226, IP +0.214) — it works as an anomaly indicator.
-        Deep methods produce mostly negative ρ — the "high recon = unfamiliar" heuristic
-        does NOT transfer to deep nonlinear encoders. Deep encoders concentrate capacity
-        on rare informative spectra, which the latent then discriminates well.
+        {t("pages:benchmarks.deep.anomaly.note")}
       </p>
     </Section>
   );
@@ -117,6 +115,7 @@ function AnomalyComparisonSection() {
 const CAE_1D_KS = [4, 6, 8, 10, 12, 16, 32];
 
 function DeepKCurveSection() {
+  const { t } = useTranslation(["pages"]);
   // For each scene × K, fetch the CAE-1D representation and read ARI
   const queries = useQueries({
     queries: LABELLED_SCENES.flatMap((sc) =>
@@ -133,11 +132,11 @@ function DeepKCurveSection() {
   if (!ready) {
     return (
       <Section
-        title="CAE-1D capacity-driven scaling — ARI vs K"
-        lead="Per-scene CAE-1D K-curve (K∈{4,6,8,10,12,16,32}). Each line is one labelled scene; each point is the K-means(latent) ARI vs ground-truth label."
+        title={t("pages:benchmarks.deep.kcurve.title")}
+        lead={t("pages:benchmarks.deep.kcurve.loadingLead")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          Loading deep K-curve payloads (42 cells)…
+          {t("pages:benchmarks.deep.kcurve.loading")}
         </p>
       </Section>
     );
@@ -175,10 +174,10 @@ function DeepKCurveSection() {
 
   return (
     <Section
-      title="CAE-1D capacity-driven scaling — ARI vs K"
-      lead="K-means(latent) ARI vs ground-truth label, per scene. Almost-monotonic on every scene (Salinas 0.547 → 0.561, KSC 0.250 → 0.314 from K=4 to K=32). x-axis is log K."
+      title={t("pages:benchmarks.deep.kcurve.title")}
+      lead={t("pages:benchmarks.deep.kcurve.lead")}
     >
-      <svg viewBox={`0 0 ${W + 60} ${H + 40}`} role="img" aria-label="CAE-1D K curve">
+      <svg viewBox={`0 0 ${W + 60} ${H + 40}`} role="img" aria-label={t("pages:benchmarks.deep.kcurve.aria")}>
         <line x1={40} y1={H} x2={40 + W} y2={H} stroke="currentColor" strokeWidth="1" />
         <line x1={40} y1={0} x2={40} y2={H} stroke="currentColor" strokeWidth="1" />
         {[0, 0.2, 0.4, 0.6, 0.8, 1.0].map((y) => (
@@ -254,7 +253,7 @@ function DeepKCurveSection() {
           );
         })}
         <text x={40 + W / 2} y={H + 32} fontSize="11" textAnchor="middle" fill="currentColor" opacity="0.7">
-          latent dimension K (log scale)
+          {t("pages:benchmarks.deep.kcurve.xAxis")}
         </text>
         <text
           x={10}
@@ -265,19 +264,18 @@ function DeepKCurveSection() {
           opacity="0.7"
           transform={`rotate(-90, 10, ${H / 2})`}
         >
-          K-means(latent) ARI vs label
+          {t("pages:benchmarks.deep.kcurve.yAxis")}
         </text>
       </svg>
       <p className="mt-3 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-        Capacity-driven scaling: every scene improves with K; no overfitting at K=32. KSC's
-        canonical fit (LDA θ-logistic F1=0.021 on B-3) recovers to F1=0.710 at CAE-1D K=32 on
-        the linear-probe panel, a 33× gain attributable to deep encoder capacity.
+        {t("pages:benchmarks.deep.kcurve.note")}
       </p>
     </Section>
   );
 }
 
 function Cae3dAnchorVsFullSection() {
+  const { t } = useTranslation(["pages"]);
   const KS = [4, 8] as const;
   const queries = useQueries({
     queries: LABELLED_SCENES.flatMap((sc) =>
@@ -291,10 +289,10 @@ function Cae3dAnchorVsFullSection() {
   if (!ready) {
     return (
       <Section
-        title="CAE-3D — anchor decoder vs full-patch decoder (K-curve {4, 8})"
-        lead="Loading anchor + full-patch payloads at K∈{4, 8} across 6 labelled scenes…"
+        title={t("pages:benchmarks.deep.cae3d.title")}
+        lead={t("pages:benchmarks.deep.cae3d.loadingLead")}
       >
-        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.deep.cae3d.loading")}</p>
       </Section>
     );
   }
@@ -316,19 +314,19 @@ function Cae3dAnchorVsFullSection() {
   });
   return (
     <Section
-      title="CAE-3D — anchor decoder vs full-patch decoder (K-curve {4, 8})"
-      lead="Two decoders share the same 3-D conv encoder. Anchor reconstructs only the centre-pixel spectrum (Linear K→B); full-patch reconstructs the entire P×P patch (Linear K→B·P·P). Both K=8 and K=4 capacities are swept. The decoder target is itself a hyperparameter — direction is broadly stable across capacity, with one inversion (Pavia U)."
+      title={t("pages:benchmarks.deep.cae3d.title")}
+      lead={t("pages:benchmarks.deep.cae3d.lead")}
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
           <thead>
             <tr style={{ color: "var(--color-text-muted)" }}>
-              <th className="text-left font-mono text-[12px] pb-2 pr-3">scene</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">full K=4</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">anchor K=4</th>
+              <th className="text-left font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.cae3d.col.scene")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.cae3d.col.full")} K=4</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.cae3d.col.anchor")} K=4</th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">ΔK=4</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">full K=8</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">anchor K=8</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.cae3d.col.full")} K=8</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.deep.cae3d.col.anchor")} K=8</th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">ΔK=8</th>
             </tr>
           </thead>
@@ -355,7 +353,7 @@ function Cae3dAnchorVsFullSection() {
               </tr>
             ))}
             <tr style={{ borderTop: "2px solid var(--color-border)" }}>
-              <td className="py-1.5 pr-3 font-mono text-[11px]" style={{ color: "var(--color-text-muted)" }}>net mean ΔARI</td>
+              <td className="py-1.5 pr-3 font-mono text-[11px]" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.deep.cae3d.netMean")}</td>
               <td className="py-1.5 pr-3" />
               <td className="py-1.5 pr-3" />
               <td
@@ -383,10 +381,7 @@ function Cae3dAnchorVsFullSection() {
         </table>
       </div>
       <p className="mt-3 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-        Honest read: net mean ΔARI is essentially neutral at both K (+0.011 K=4, +0.003 K=8). Direction matches across K on
-        5/6 scenes — IP and Botswana persistently benefit; Salinas family persistently harmed (magnitude grows with K). Pavia U
-        is the single capacity-dependent inversion: full-patch helps at K=4 (+0.026), hurts at K=8 (-0.023). The decoder target
-        is itself a hyperparameter worth surfacing per scene, not a default to flip globally.
+        {t("pages:benchmarks.deep.cae3d.note")}
       </p>
     </Section>
   );
@@ -401,6 +396,7 @@ const BETA_VAE_BS = [
 ];
 
 function BetaVaeCollapseSection() {
+  const { t } = useTranslation(["pages"]);
   const queries = useQueries({
     queries: LABELLED_SCENES.flatMap((sc) =>
       BETA_VAE_BS.map((b) => ({
@@ -414,11 +410,11 @@ function BetaVaeCollapseSection() {
   if (!ready) {
     return (
       <Section
-        title="β-VAE β-sweep — disentanglement vs posterior collapse"
-        lead="Loading β-sweep payloads…"
+        title={t("pages:benchmarks.deep.betaVae.title")}
+        lead={t("pages:benchmarks.deep.betaVae.loadingLead")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          Loading…
+          {t("pages:benchmarks.deep.betaVae.loading")}
         </p>
       </Section>
     );
@@ -443,14 +439,14 @@ function BetaVaeCollapseSection() {
 
   return (
     <Section
-      title="β-VAE β-sweep — disentanglement vs posterior collapse"
-      lead="K-means(latent) ARI per scene at K=8 across β∈{1, 2, 4, 8, 16}. Bright = high ARI; black cells = posterior collapse (β-VAE encoder converges to q(z|x)≈p(z), latent is uninformative)."
+      title={t("pages:benchmarks.deep.betaVae.title")}
+      lead={t("pages:benchmarks.deep.betaVae.lead")}
     >
       <div className="overflow-x-auto">
         <svg
           viewBox={`0 0 ${BETA_VAE_BS.length * cell + 200} ${LABELLED_SCENES.length * rowH + headerH + 30}`}
           role="img"
-          aria-label="β-VAE β-sweep ARI grid"
+          aria-label={t("pages:benchmarks.deep.betaVae.aria")}
           style={{ maxWidth: "640px" }}
         >
           {BETA_VAE_BS.map((b, j) => (
@@ -513,10 +509,7 @@ function BetaVaeCollapseSection() {
         </svg>
       </div>
       <p className="mt-3 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-        Salinas posterior collapse at β≥8 (ARI=0.000 — KL term overwhelms the reconstruction
-        signal; encoder maps every input to N(0, I)). Salinas-A resists collapse and even gains
-        with β (compact 6-class signal dominates the regulariser). Pavia U degrades monotonically
-        with β. The β=4 default sits at the inflection point.
+        {t("pages:benchmarks.deep.betaVae.note")}
       </p>
     </Section>
   );

--- a/frontend/src/pages/benchmarks/BenchmarksGating.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksGating.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueries } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { api } from "@/api/client";
 import type { BayesianComparison } from "@/api/client";
 import { Section } from "@/components/Section";
@@ -15,6 +16,7 @@ export function BenchmarksGating() {
 }
 
 function DeepGateSection() {
+  const { t } = useTranslation(["pages"]);
   const queries = useQueries({
     queries: LABELLED_SCENES.map((sc) => ({
       queryKey: ["topic-routed-deep-gate", sc],
@@ -26,10 +28,10 @@ function DeepGateSection() {
   if (!ready) {
     return (
       <Section
-        title="B-3 follow-up — any encoder as gate? raw vs θ-routed vs deep gates"
-        lead="Loading deep-gate payloads…"
+        title={t("pages:benchmarks.gating.deepGate.title")}
+        lead={t("pages:benchmarks.gating.deepGate.loadingLead")}
       >
-        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.gating.common.loading")}</p>
       </Section>
     );
   }
@@ -72,14 +74,14 @@ function DeepGateSection() {
 
   return (
     <Section
-      title="B-3 follow-up — any encoder as gate? raw vs θ-routed vs deep gates"
-      lead="Five candidate gates compete on per-fold macro F1 across labelled scenes: raw_logistic (no gating), θ_routed (LDA topic mixture, natural Dirichlet simplex), and three deep gates (PCA-8, CAE-1D-8, β-VAE-8) projected onto the simplex via softmax. Tests whether any deep encoder recovers θ's gating advantage."
+      title={t("pages:benchmarks.gating.deepGate.title")}
+      lead={t("pages:benchmarks.gating.deepGate.lead")}
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
           <thead>
             <tr style={{ color: "var(--color-text-muted)" }}>
-              <th className="text-left font-mono text-[12px] pb-2 pr-3">scene</th>
+              <th className="text-left font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.gating.common.scene")}</th>
               {METHODS.map((m) => (
                 <th key={m.key} className="text-right font-mono text-[12px] pb-2 pr-3">
                   {m.label}
@@ -122,7 +124,7 @@ function DeepGateSection() {
                 className="py-1.5 pr-3 font-mono text-[11px]"
                 style={{ color: "var(--color-text-muted)" }}
               >
-                wins (best per scene)
+                {t("pages:benchmarks.gating.common.winsBestPerScene")}
               </td>
               {METHODS.map((m) => (
                 <td
@@ -138,18 +140,15 @@ function DeepGateSection() {
         </table>
       </div>
       <p className="mt-3 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-        Honest finding: deep gates with naive softmax-to-simplex projection do <em>not</em>{" "}
-        outperform raw_logistic or θ_routed. raw_logistic wins on most scenes; θ_routed
-        ties or wins where Dirichlet-simplex structure aligns with class topology
-        (e.g. Salinas). The advantage of θ comes from the natural simplex constraint
-        of Dirichlet-distributed topic mixtures, not merely from compressing to K
-        dimensions — softmaxed deep latents fail to recover the gating mechanism.
+        {t("pages:benchmarks.gating.deepGate.finding.part1")} <em>{t("pages:benchmarks.gating.deepGate.finding.not")}</em>{" "}
+        {t("pages:benchmarks.gating.deepGate.finding.part2")}
       </p>
     </Section>
   );
 }
 
 function NeuralTopicComparisonSection() {
+  const { t } = useTranslation(["pages"]);
   const queries = useQueries({
     queries: LABELLED_SCENES.map((sc) => ({
       queryKey: ["neural-topic-comparison", sc],
@@ -168,10 +167,10 @@ function NeuralTopicComparisonSection() {
   if (!ready) {
     return (
       <Section
-        title="Neural topic models — head-to-head LDA vs ProdLDA vs ETM"
-        lead="Loading per-scene neural-topic comparison…"
+        title={t("pages:benchmarks.gating.neuralTopic.title")}
+        lead={t("pages:benchmarks.gating.neuralTopic.loadingLead")}
       >
-        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>Loading…</p>
+        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>{t("pages:benchmarks.gating.common.loading")}</p>
       </Section>
     );
   }
@@ -236,28 +235,28 @@ function NeuralTopicComparisonSection() {
 
   return (
     <Section
-      title="Neural topic models — head-to-head LDA vs ProdLDA vs ETM"
-      lead="Three neural-style topic models compared on the canonical 220-per-class stratified sample. Two metrics: (1) K-means(theta) ARI vs ground-truth label — clustering quality. (2) c_v topic coherence (Röder 2015 sliding-window, top-15 words) — semantic quality. ProdLDA + ETM cells show mean ± std across N=5 seeds. LDA cell uses the canonical fit (single seed; per-seed LDA stability is in the separate Workspace stability tab). The two metrics tell different stories — coherence ≠ class discriminability on band-frequency vocabularies."
+      title={t("pages:benchmarks.gating.neuralTopic.title")}
+      lead={t("pages:benchmarks.gating.neuralTopic.lead")}
     >
       <div className="overflow-x-auto">
         <table className="w-full text-sm" style={{ color: "var(--color-text)" }}>
           <thead>
             <tr style={{ color: "var(--color-text-muted)" }}>
-              <th className="text-left font-mono text-[12px] pb-2 pr-3">scene</th>
-              <th className="text-right font-mono text-[12px] pb-2 pr-3">cls</th>
+              <th className="text-left font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.gating.common.scene")}</th>
+              <th className="text-right font-mono text-[12px] pb-2 pr-3">{t("pages:benchmarks.gating.neuralTopic.header.cls")}</th>
               <th
                 className="text-right font-mono text-[12px] pb-2 pr-3"
                 colSpan={3}
                 style={{ borderBottom: "1px solid var(--color-border)" }}
               >
-                ARI vs label
+                {t("pages:benchmarks.gating.neuralTopic.header.ariVsLabel")}
               </th>
               <th
                 className="text-right font-mono text-[12px] pb-2 pr-3"
                 colSpan={3}
                 style={{ borderBottom: "1px solid var(--color-border)" }}
               >
-                c_v coherence (top-15)
+                {t("pages:benchmarks.gating.neuralTopic.header.cvCoherence")}
               </th>
             </tr>
             <tr style={{ color: "var(--color-text-muted)" }}>
@@ -330,7 +329,7 @@ function NeuralTopicComparisonSection() {
             ))}
             <tr style={{ borderTop: "2px solid var(--color-border)" }}>
               <td className="py-1.5 pr-3 font-mono text-[11px]" style={{ color: "var(--color-text-muted)" }} colSpan={2}>
-                wins (best per scene)
+                {t("pages:benchmarks.gating.common.winsBestPerScene")}
               </td>
               {METHODS.map((m) => (
                 <td
@@ -355,23 +354,17 @@ function NeuralTopicComparisonSection() {
         </table>
       </div>
       <p className="mt-3 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-        <strong>Coherence vs discriminability are NOT the same metric on band-frequency
-        tokens.</strong> ProdLDA wins c_v on every scene (highest semantic coherence among the
-        three) but loses ARI on 4/6 scenes — its topics are internally tight but do not align
-        with class structure. LDA wins ARI on 4/6 scenes (most class-discriminative theta on
-        average) yet loses c_v on every scene. ETM lands between on both axes — slight
-        improvement over ProdLDA on ARI (5/6 wins), slight regression on c_v.
+        <strong>{t("pages:benchmarks.gating.neuralTopic.finding.headline")}</strong>{" "}
+        {t("pages:benchmarks.gating.neuralTopic.finding.body1")}
         <br /><br />
-        <strong>Operational rule</strong>: pick the topic family by the downstream task, not by
-        coherence alone. For class clustering use LDA (or neural fallback when LDA collapses,
-        e.g. KSC). For interpretability / topic-vocabulary cards (Workspace Topics tab) use
-        ProdLDA's higher coherence. ETM is the safe middle if both matter.
+        <strong>{t("pages:benchmarks.gating.neuralTopic.finding.ruleLabel")}</strong>{t("pages:benchmarks.gating.neuralTopic.finding.body2")}
       </p>
     </Section>
   );
 }
 
 function BayesianHdiSection() {
+  const { t } = useTranslation(["pages"]);
   const cls = useQuery({
     queryKey: ["bayesian-classification-labelled"],
     queryFn: () => api.bayesianClassificationLabelled(),
@@ -391,11 +384,11 @@ function BayesianHdiSection() {
   if (!cls.data && !reg.data && !clsDeep.data) {
     return (
       <Section
-        title="Bayesian method comparison — hierarchical NUTS posteriors"
-        lead="Loading PyMC posteriors at 4 chains × 1000 tune + 1000 draws…"
+        title={t("pages:benchmarks.gating.bayesian.title")}
+        lead={t("pages:benchmarks.gating.bayesian.loadingLead")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          Loading…
+          {t("pages:benchmarks.gating.common.loading")}
         </p>
       </Section>
     );
@@ -510,7 +503,7 @@ function BayesianHdiSection() {
           className="mt-2 text-[11.5px]"
           style={{ color: "var(--color-text-muted)" }}
         >
-          {payload.n_observations} observations · {payload.method_posteriors.length} methods · {payload.model_summary}
+          {t("pages:benchmarks.gating.bayesian.forestFooter", { obs: payload.n_observations, methods: payload.method_posteriors.length, summary: payload.model_summary })}
         </p>
       </div>
     );
@@ -518,23 +511,23 @@ function BayesianHdiSection() {
 
   return (
     <Section
-      title="Bayesian method comparison — hierarchical NUTS posteriors"
-      lead="PyMC hierarchical normal model: y ~ N(μ_method + α_scene + γ_fold, σ). Posterior means shown as red dots, HDI94 intervals as blue bars. Methods are ordered by posterior mean. Vertical dashed line at μ=0 is the model-mean reference."
+      title={t("pages:benchmarks.gating.bayesian.title")}
+      lead={t("pages:benchmarks.gating.bayesian.lead")}
     >
       {renderForest(
-        "Classification (labelled scenes, 150 obs)",
+        t("pages:benchmarks.gating.bayesian.forest.classification.title"),
         cls.data,
-        "raw / pca / topic_routed_* HDIs strictly positive; theta_logistic HDI includes 0 — naive theta-flat is statistically indistinguishable from the model mean.",
+        t("pages:benchmarks.gating.bayesian.forest.classification.note"),
       )}
       {renderForest(
-        "Classification with deep gates (labelled scenes, 150 obs)",
+        t("pages:benchmarks.gating.bayesian.forest.classificationDeep.title"),
         clsDeep.data,
-        "B-3 follow-up: gates are raw_logistic vs. θ_routed vs. PCA-8 / CAE-1D-8 / β-VAE-8 routed (deep latents softmaxed to a simplex). raw_logistic dominates θ_routed and all deep gates with P≥0.999; θ_routed dominates every deep gate with P≥0.999. Decisive Bayesian evidence that softmaxed deep latents do NOT recover θ's gating advantage — θ's edge comes from the natural Dirichlet simplex.",
+        t("pages:benchmarks.gating.bayesian.forest.classificationDeep.note"),
       )}
       {renderForest(
-        "Regression (HIDSAG, n≥50 subsets: GEOMET + MINERAL1)",
+        t("pages:benchmarks.gating.bayesian.forest.regression.title"),
         reg.data,
-        "Pool restricted to n≥50 subsets — the three small-n subsets (PORPHYRY R²≈−12500, MINERAL2, GEOCHEM) are excluded because their exploding R² poisoned the earlier pooled posterior. Honest read: pooled across the two valid subsets no method clears zero (raw_ridge highest point estimate, the proposed soft θ-gated ensemble second, statistically indistinguishable). But the soft gate beats its own hard-routing ablation by ~0.44 R² units, and per-subset on GEOMET (n=146) the soft ensemble is the best method (R²=0.307 > raw 0.258). The win is subset-specific, not universal.",
+        t("pages:benchmarks.gating.bayesian.forest.regression.note"),
       )}
     </Section>
   );

--- a/frontend/src/pages/benchmarks/BenchmarksHidsag.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksHidsag.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueries } from "@tanstack/react-query";
+import { Trans, useTranslation } from "react-i18next";
 import { api } from "@/api/client";
 import type {
   HidsagCrossPreprocessingStability as HidsagCrossPreprocessingStabilityPayload,
@@ -19,6 +20,7 @@ export function BenchmarksHidsag() {
 }
 
 function HidsagCrossPreprocessingStability() {
+  const { t } = useTranslation(["pages"]);
   const subsets = ["GEOMET", "MINERAL1", "MINERAL2", "GEOCHEM", "PORPHYRY"];
   const queries = useQueries({
     queries: subsets.map((code) => ({
@@ -35,8 +37,8 @@ function HidsagCrossPreprocessingStability() {
   return (
     <Section
       id="hidsag-cross-preproc-stability"
-      title="HIDSAG — cross-preprocessing stability (B-6 follow-up)"
-      lead="How stable LDA topics are when the preprocessing recipe changes. Reported as Hungarian-matched top-15 token Jaccard across the 4 policies (raw / heuristic-band-mask / SNV / SavGol+SNV). Low = topics change substantially across recipes; high = topics survive."
+      title={t("pages:benchmarks.hidsag.cross_preproc.title")}
+      lead={t("pages:benchmarks.hidsag.cross_preproc.lead")}
     >
       <div className="space-y-4 mt-2">
         {successes.map((s) => (
@@ -60,8 +62,11 @@ function HidsagCrossPreprocessingStability() {
                 className="text-xs font-mono"
                 style={{ color: "var(--color-fg-faint)" }}
               >
-                K={s.data!.topic_count} · {s.data!.policies.length} policies ·{" "}
-                off-diag mean ={" "}
+                K={s.data!.topic_count} ·{" "}
+                {t("pages:benchmarks.hidsag.cross_preproc.policies_count", {
+                  count: s.data!.policies.length,
+                })}{" "}
+                · {t("pages:benchmarks.hidsag.cross_preproc.off_diag_mean")} ={" "}
                 <span
                   style={{
                     color:
@@ -85,8 +90,7 @@ function HidsagCrossPreprocessingStability() {
         className="mt-3 text-[12px]"
         style={{ color: "var(--color-fg-faint)" }}
       >
-        Metric: top-15 token Jaccard with Hungarian assignment. Each cell of
-        the N×N matrices is the average per-topic stability between policies i, j.
+        {t("pages:benchmarks.hidsag.cross_preproc.metric_note")}
       </p>
     </Section>
   );
@@ -97,6 +101,7 @@ function CrossPreprocessingMatrix({
 }: {
   data: HidsagCrossPreprocessingStabilityPayload;
 }) {
+  const { t } = useTranslation(["pages"]);
   const policies = data.policies;
   const matrix = data.pairwise_matched_jaccard_top15_mean_matrix;
   const n = policies.length;
@@ -112,7 +117,9 @@ function CrossPreprocessingMatrix({
       viewBox={`0 0 ${w} ${h}`}
       xmlns="http://www.w3.org/2000/svg"
       role="img"
-      aria-label={`Cross-preprocessing matrix for ${data.subset_code}`}
+      aria-label={t("pages:benchmarks.hidsag.cross_preproc.matrix_aria", {
+        code: data.subset_code,
+      })}
       style={{ color: "var(--color-fg)" }}
     >
       <g
@@ -185,6 +192,7 @@ function CrossPreprocessingMatrix({
 }
 
 function HidsagPreprocessing() {
+  const { t } = useTranslation(["pages"]);
   const { data, isLoading, error } = useQuery({
     queryKey: ["hidsag-preprocessing-sensitivity"],
     queryFn: api.hidsagPreprocessingSensitivity,
@@ -194,12 +202,12 @@ function HidsagPreprocessing() {
   return (
     <Section
       id="hidsag-preprocessing"
-      title="HIDSAG — spectral preprocessing sensitivity"
-      lead="Four preprocessing policies (raw / heuristic-bad-band-mask / SNV / Savitzky-Golay+SNV) over the 5 HIDSAG scenes. Measures how downstream performance (classification + regression) changes when the spectral cleaning recipe varies."
+      title={t("pages:benchmarks.hidsag.preprocessing.title")}
+      lead={t("pages:benchmarks.hidsag.preprocessing.lead")}
     >
       {isLoading && (
         <p style={{ color: "var(--color-fg-faint)" }}>
-          Loading preprocessing sensitivity…
+          {t("pages:benchmarks.hidsag.preprocessing.loading")}
         </p>
       )}
       {error && (
@@ -211,7 +219,9 @@ function HidsagPreprocessing() {
           }}
         >
           <p style={{ color: "var(--color-warn)" }}>
-            Could not load /api/hidsag-preprocessing-sensitivity.
+            {t("pages:benchmarks.hidsag.preprocessing.load_error", {
+              endpoint: "/api/hidsag-preprocessing-sensitivity",
+            })}
           </p>
           <p
             className="mt-2 text-sm"
@@ -268,6 +278,7 @@ function PreprocessingSubsetCard({
 }: {
   subset: HidsagPreprocessingSubset;
 }) {
+  const { t } = useTranslation(["pages"]);
   return (
     <div
       className="rounded-md border p-4"
@@ -293,7 +304,7 @@ function PreprocessingSubsetCard({
       </header>
       <div className="grid sm:grid-cols-2 gap-5">
         <PolicyBars
-          title="Classification · balanced accuracy"
+          title={t("pages:benchmarks.hidsag.preprocessing.classification_title")}
           rows={subset.classification_policy_ranking.map((r) => ({
             policy_id: r.policy_id,
             best_model: r.best_model,
@@ -303,7 +314,7 @@ function PreprocessingSubsetCard({
         />
         {(subset.sample_count ?? 0) >= 50 ? (
           <PolicyBars
-            title="Regression · R²"
+            title={t("pages:benchmarks.hidsag.preprocessing.regression_title")}
             rows={subset.regression_policy_ranking.map((r) => ({
               policy_id: r.policy_id,
               best_model: r.best_model,
@@ -317,13 +328,12 @@ function PreprocessingSubsetCard({
               className="text-[11px] uppercase tracking-widest font-semibold mb-2"
               style={{ color: "var(--color-fg-faint)" }}
             >
-              Regression · R²
+              {t("pages:benchmarks.hidsag.preprocessing.regression_title")}
             </div>
             <p className="text-[12px]" style={{ color: "var(--color-fg-faint)" }}>
-              Not shown — cross-validated R² is not estimable at n&lt;50
-              (here n={subset.sample_count}); the test folds explode to
-              R²≪0 and the metric is noise, not a result. See the regression
-              panel below for the n≥50 subsets.
+              {t("pages:benchmarks.hidsag.preprocessing.regression_not_shown", {
+                n: subset.sample_count,
+              })}
             </p>
           </div>
         )}
@@ -412,6 +422,7 @@ function PolicyBars({
 }
 
 function HidsagBenchmarks() {
+  const { t } = useTranslation(["pages"]);
   const queries = useQueries({
     queries: HIDSAG_SUBSETS.map((code) => ({
       queryKey: ["hidsag-method", code],
@@ -437,12 +448,12 @@ function HidsagBenchmarks() {
   return (
     <Section
       id="hidsag"
-      title="HIDSAG — regression over measurements"
-      lead="A hard cross-domain probe: can the topic representations linearly predict continuous geo-assays (Cu %, Au g/t, mineralogy)? R² < 0 means worse than predicting the target's mean. This is separate from — and much harder than — the labelled-scene topic results; treat it as a stress test, not the headline."
+      title={t("pages:benchmarks.hidsag.regression.title")}
+      lead={t("pages:benchmarks.hidsag.regression.lead")}
     >
       {loading && (
         <p style={{ color: "var(--color-fg-faint)" }}>
-          Loading HIDSAG rankings…
+          {t("pages:benchmarks.hidsag.regression.loading")}
         </p>
       )}
       <div className="space-y-6 mt-2">
@@ -455,13 +466,15 @@ function HidsagBenchmarks() {
           className="mt-4 text-[12px]"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          <strong>Excluded (n &lt; {MIN_N}):</strong>{" "}
+          <Trans
+            i18nKey="pages:benchmarks.hidsag.regression.excluded_label"
+            values={{ minN: MIN_N }}
+            components={{ strong: <strong /> }}
+          />{" "}
           {excludedReg
             .map((s) => `${s.code} (n=${s.data.sample_count ?? "?"})`)
             .join(", ")}
-          . Cross-validated regression R² is not estimable at these sample
-          sizes — the folds are too small for the band/feature dimension, so the
-          values are statistical noise rather than results.
+          {t("pages:benchmarks.hidsag.regression.excluded_note")}
         </p>
       )}
     </Section>
@@ -471,22 +484,24 @@ function HidsagBenchmarks() {
 // Readable labels + role for each regression method, so the forest plot
 // reads as "what is compared" rather than raw identifiers. The proposed
 // method (soft theta-gated ensemble) is highlighted; the naive hard route is
-// marked as an ablation.
-const METHOD_INFO: Record<string, { label: string; role: "proposed" | "ablation" | "baseline" | "feature" }> = {
-  topic_routed_linear_regression: { label: "soft θ-gated ensemble  ★ proposed", role: "proposed" },
-  topic_routed_hard_linear_regression: { label: "hard route (ablation)", role: "ablation" },
-  raw_ridge_regression: { label: "raw spectra · Ridge", role: "baseline" },
-  pls_regression: { label: "raw spectra · PLS", role: "baseline" },
-  region_topic_mixture_linear_regression: { label: "θ feature · region", role: "feature" },
-  cube_topic_mixture_linear_regression: { label: "θ feature · cube", role: "feature" },
-  topic_mixture_linear_regression: { label: "θ feature · pixel", role: "feature" },
+// marked as an ablation. Labels are resolved via i18n at render time
+// (label_key → t(...)); the role drives the colour/weight encoding.
+const METHOD_INFO: Record<string, { label_key: string; role: "proposed" | "ablation" | "baseline" | "feature" }> = {
+  topic_routed_linear_regression: { label_key: "soft_theta_gated", role: "proposed" },
+  topic_routed_hard_linear_regression: { label_key: "hard_route", role: "ablation" },
+  raw_ridge_regression: { label_key: "raw_ridge", role: "baseline" },
+  pls_regression: { label_key: "raw_pls", role: "baseline" },
+  region_topic_mixture_linear_regression: { label_key: "theta_region", role: "feature" },
+  cube_topic_mixture_linear_regression: { label_key: "theta_cube", role: "feature" },
+  topic_mixture_linear_regression: { label_key: "theta_pixel", role: "feature" },
 };
 
-function methodInfo(method: string): { label: string; role: "proposed" | "ablation" | "baseline" | "feature" } {
-  return METHOD_INFO[method] ?? { label: method, role: "baseline" };
+function methodInfo(method: string): { label_key: string | null; role: "proposed" | "ablation" | "baseline" | "feature" } {
+  return METHOD_INFO[method] ?? { label_key: null, role: "baseline" };
 }
 
 function HidsagSubsetCard({ stats }: { stats: HidsagMethodStatistics }) {
+  const { t } = useTranslation(["pages"]);
   const block = stats.regression;
   if (!block || !block.method_aggregates) {
     return (
@@ -508,7 +523,7 @@ function HidsagSubsetCard({ stats }: { stats: HidsagMethodStatistics }) {
           className="text-sm"
           style={{ color: "var(--color-fg-faint)" }}
         >
-          No regression block available.
+          {t("pages:benchmarks.hidsag.regression.no_block")}
         </p>
       </div>
     );
@@ -579,7 +594,9 @@ function HidsagSubsetCard({ stats }: { stats: HidsagMethodStatistics }) {
         viewBox={`0 0 ${w} ${h}`}
         xmlns="http://www.w3.org/2000/svg"
         role="img"
-        aria-label={`HIDSAG ${stats.subset_code} forest`}
+        aria-label={t("pages:benchmarks.hidsag.regression.forest_aria", {
+          code: stats.subset_code,
+        })}
         style={{ color: "var(--color-fg)" }}
       >
         <g
@@ -637,7 +654,9 @@ function HidsagSubsetCard({ stats }: { stats: HidsagMethodStatistics }) {
                   fontWeight={info.role === "proposed" ? 700 : 400}
                   fill={info.role === "proposed" ? "#22c55e" : "currentColor"}
                 >
-                  {info.label}
+                  {info.label_key
+                    ? t(`pages:benchmarks.hidsag.regression.method_labels.${info.label_key}`)
+                    : e.method}
                 </text>
                 {e.ci95_lo !== null && e.ci95_hi !== null && (
                   <line
@@ -680,13 +699,14 @@ function HidsagSubsetCard({ stats }: { stats: HidsagMethodStatistics }) {
         className="mt-1 text-[11.5px]"
         style={{ color: "var(--color-fg-faint)" }}
       >
-        R² &lt; 0 means the model predicts the numeric target worse than its
-        own mean — expected for assay regression (Cu %, Au g/t) on these small
-        mineral subsets (n = tens to low hundreds). This is a deliberately hard
-        cross-domain probe and is <em>separate</em> from the labelled-scene
-        topic results, where the representations do separate classes.
+        <Trans
+          i18nKey="pages:benchmarks.hidsag.regression.r2_explainer"
+          components={{ em: <em /> }}
+        />
         {anyOffScale
-          ? ` Methods with R² ≪ 0 (catastrophic small-sample fits) are clamped to the axis edge at ${FLOOR} and labelled with their true value.`
+          ? ` ${t("pages:benchmarks.hidsag.regression.off_scale_note", {
+              floor: FLOOR,
+            })}`
           : ""}
       </p>
     </div>

--- a/frontend/src/pages/benchmarks/BenchmarksLlm.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksLlm.tsx
@@ -1,4 +1,5 @@
 import { useQueries } from "@tanstack/react-query";
+import { Trans, useTranslation } from "react-i18next";
 import { api } from "@/api/client";
 import { Section } from "@/components/Section";
 import { LABELLED_SCENES } from "./shared";
@@ -12,6 +13,7 @@ export function BenchmarksLlm() {
 }
 
 function LlmTeaLeavesSection() {
+  const { t } = useTranslation(["pages"]);
   const queries = useQueries({
     queries: LABELLED_SCENES.map((sceneId) => ({
       queryKey: ["llm-tea-leaves", sceneId],
@@ -26,12 +28,14 @@ function LlmTeaLeavesSection() {
   if (ready.length === 0) {
     return (
       <Section
-        title="B-12 — LLM tea-leaves (Stammbach et al. TACL 2024)"
-        lead="Word-intrusion + coherent-label probes via Anthropic Claude. Builder is gated by ANTHROPIC_API_KEY; outputs land in data/derived/llm_tea_leaves once the env var is set and the builder is run."
+        title={t("pages:benchmarks.llm.empty.title")}
+        lead={t("pages:benchmarks.llm.empty.lead")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          No scenes evaluated yet. Set <code className="font-mono">ANTHROPIC_API_KEY</code>{" "}
-          and run <code className="font-mono">build-b12-llm-tea-leaves</code> to populate.
+          <Trans
+            i18nKey="pages:benchmarks.llm.empty.note"
+            components={{ code: <code className="font-mono" /> }}
+          />
         </p>
       </Section>
     );
@@ -39,8 +43,8 @@ function LlmTeaLeavesSection() {
 
   return (
     <Section
-      title="B-12 — LLM tea-leaves (Stammbach et al. 2023, EMNLP)"
-      lead="Per-scene word-intrusion accuracy + per-topic LLM-generated labels. Higher intrusion accuracy means the LLM correctly identifies the foreign word slipped into each topic's top-10 — a coherence signal that correlates with NPMI in prior work. Outputs shipped here are the deterministic Claude Opus 4.7 self-judgment stand-in (see model column); a full API-driven run via build_b12_llm_tea_leaves.py is also implemented for external reproduction."
+      title={t("pages:benchmarks.llm.section.title")}
+      lead={t("pages:benchmarks.llm.section.lead")}
     >
       <div className="space-y-6">
         <table
@@ -49,12 +53,12 @@ function LlmTeaLeavesSection() {
         >
           <thead>
             <tr style={{ color: "var(--color-text-muted)" }}>
-              <th className="text-left font-mono text-[12px] pb-2">scene</th>
-              <th className="text-left font-mono text-[12px] pb-2">topics</th>
+              <th className="text-left font-mono text-[12px] pb-2">{t("pages:benchmarks.llm.table.scene")}</th>
+              <th className="text-left font-mono text-[12px] pb-2">{t("pages:benchmarks.llm.table.topics")}</th>
               <th className="text-left font-mono text-[12px] pb-2">
-                intrusion accuracy
+                {t("pages:benchmarks.llm.table.intrusionAccuracy")}
               </th>
-              <th className="text-left font-mono text-[12px] pb-2">model</th>
+              <th className="text-left font-mono text-[12px] pb-2">{t("pages:benchmarks.llm.table.model")}</th>
             </tr>
           </thead>
           <tbody>
@@ -87,17 +91,17 @@ function LlmTeaLeavesSection() {
             }}
           >
             <summary className="cursor-pointer font-mono text-[13px]">
-              {sceneId} — per-topic LLM labels
+              {t("pages:benchmarks.llm.detail.summary", { sceneId })}
             </summary>
             <ul className="mt-2 space-y-1 text-sm">
               {data!.per_topic.map((tt) => (
                 <li key={tt.topic_id} className="font-mono text-[12.5px]">
                   <span style={{ color: "var(--color-text-muted)" }}>
-                    topic {tt.topic_id}
+                    {t("pages:benchmarks.llm.detail.topic", { topicId: tt.topic_id })}
                   </span>{" "}
                   {tt.skipped ? (
                     <span style={{ color: "var(--color-text-muted)" }}>
-                      — skipped ({tt.reason})
+                      {t("pages:benchmarks.llm.detail.skipped", { reason: tt.reason })}
                     </span>
                   ) : (
                     <>
@@ -110,7 +114,7 @@ function LlmTeaLeavesSection() {
                       >
                         [{tt.intrusion_correct ? "✓" : "✗"}]
                       </span>{" "}
-                      {tt.llm_label || "(no label)"}
+                      {tt.llm_label || t("pages:benchmarks.llm.detail.noLabel")}
                     </>
                   )}
                 </li>

--- a/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
+++ b/frontend/src/pages/benchmarks/BenchmarksSummary.tsx
@@ -1,4 +1,5 @@
 import { useQueries } from "@tanstack/react-query";
+import { Trans, useTranslation } from "react-i18next";
 import {
   api,
   type MethodStatistics,
@@ -23,6 +24,7 @@ import { VSweepCoverageMatrix } from "./VSweepCoverageMatrix";
 import { BackboneF7Panel } from "./BackboneF7Panel";
 
 export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
+  const { t } = useTranslation(["pages"]);
   return (
     <div className="space-y-8">
       <ProtocolBox stats={data} />
@@ -30,8 +32,8 @@ export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
       <BackboneF7Panel />
       <Section
         id="forest"
-        title="Forest plot — macro-F1 with CI95 per scene"
-        lead="Each bar is a scene × method; the dot is the mean, the whiskers are the 2.5 and 97.5 percentiles of the bootstrap over the 25 evaluations."
+        title={t("pages:benchmarks.summary.forest_title")}
+        lead={t("pages:benchmarks.summary.forest_lead")}
       >
         <div className="space-y-8 mt-2">
           {data.labeled_scenes.map((s) => (
@@ -41,8 +43,8 @@ export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
       </Section>
       <Section
         id="paired"
-        title="Paired comparisons (Δ macro-F1)"
-        lead="Each pair shows the difference between methods per evaluation; summarised as mean ± std of Δ. Negative = the second method loses."
+        title={t("pages:benchmarks.summary.paired_title")}
+        lead={t("pages:benchmarks.summary.paired_lead")}
       >
         <div className="space-y-6 mt-2">
           {data.labeled_scenes.map((s) => (
@@ -51,7 +53,10 @@ export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
         </div>
       </Section>
       <MultiAxisBatterySection />
-      <Section id="method-defs" title="Method definitions">
+      <Section
+        id="method-defs"
+        title={t("pages:benchmarks.summary.method_defs_title")}
+      >
         <dl
           className="text-[14px] leading-relaxed space-y-3 mt-2"
           style={{ color: "var(--color-fg-subtle)" }}
@@ -81,6 +86,7 @@ export function BenchmarksSummary({ data }: { data: MethodStatistics }) {
 }
 
 function ProtocolBox({ stats }: { stats: MethodStatistics }) {
+  const { t } = useTranslation(["pages"]);
   return (
     <div
       className="rounded-lg border p-5 grid sm:grid-cols-3 gap-4 mt-2"
@@ -91,11 +97,11 @@ function ProtocolBox({ stats }: { stats: MethodStatistics }) {
       }}
     >
       <Stat
-        label="Scenes evaluated"
+        label={t("pages:benchmarks.summary.stat_scenes_evaluated")}
         value={String(stats.labeled_scenes.length)}
       />
       <Stat
-        label="Evaluations per method"
+        label={t("pages:benchmarks.summary.stat_evaluations_per_method")}
         value={
           stats.labeled_scenes.length > 0
             ? String(
@@ -106,7 +112,7 @@ function ProtocolBox({ stats }: { stats: MethodStatistics }) {
         }
       />
       <Stat
-        label="α significance"
+        label={t("pages:benchmarks.summary.stat_alpha_significance")}
         value={stats.alpha_significance.toFixed(2)}
       />
     </div>
@@ -133,6 +139,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 }
 
 function SceneForest({ scene }: { scene: SceneMethodStats }) {
+  const { t } = useTranslation(["pages"]);
   const methodNames = Object.keys(scene.methods);
   const axisMin = 0;
   const axisMax = 1;
@@ -169,7 +176,8 @@ function SceneForest({ scene }: { scene: SceneMethodStats }) {
         >
           K={scene.scene_summary.topic_count} · D=
           {scene.scene_summary.sampled_documents} ·{" "}
-          {scene.scene_summary.class_count} classes
+          {scene.scene_summary.class_count}{" "}
+          {t("pages:benchmarks.summary.classes_suffix")}
         </span>
       </header>
       <svg
@@ -177,7 +185,9 @@ function SceneForest({ scene }: { scene: SceneMethodStats }) {
         viewBox={`0 0 ${w} ${h}`}
         xmlns="http://www.w3.org/2000/svg"
         role="img"
-        aria-label={`Forest plot for ${scene.dataset_name}`}
+        aria-label={t("pages:benchmarks.summary.forest_aria", {
+          scene: scene.dataset_name,
+        })}
         style={{ color: "var(--color-fg)" }}
       >
         <g
@@ -293,6 +303,7 @@ function SceneForest({ scene }: { scene: SceneMethodStats }) {
 }
 
 function PairedTable({ scene }: { scene: SceneMethodStats }) {
+  const { t } = useTranslation(["pages"]);
   const groups = scene.paired_comparisons;
   const macroGroup = Array.isArray(groups[2])
     ? groups[2]
@@ -328,11 +339,21 @@ function PairedTable({ scene }: { scene: SceneMethodStats }) {
               color: "var(--color-fg)",
             }}
           >
-            <th className="text-left py-2 pr-4 font-semibold">A</th>
-            <th className="text-left py-2 pr-4 font-semibold">B</th>
-            <th className="text-right py-2 pr-4 font-semibold">Δ mean</th>
-            <th className="text-right py-2 pr-4 font-semibold">Δ std</th>
-            <th className="text-right py-2 font-semibold">[Δ min, Δ max]</th>
+            <th className="text-left py-2 pr-4 font-semibold">
+              {t("pages:benchmarks.summary.paired_col_a")}
+            </th>
+            <th className="text-left py-2 pr-4 font-semibold">
+              {t("pages:benchmarks.summary.paired_col_b")}
+            </th>
+            <th className="text-right py-2 pr-4 font-semibold">
+              {t("pages:benchmarks.summary.paired_col_delta_mean")}
+            </th>
+            <th className="text-right py-2 pr-4 font-semibold">
+              {t("pages:benchmarks.summary.paired_col_delta_std")}
+            </th>
+            <th className="text-right py-2 font-semibold">
+              {t("pages:benchmarks.summary.paired_col_delta_range")}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -377,6 +398,7 @@ function PairedTable({ scene }: { scene: SceneMethodStats }) {
 }
 
 function MultiAxisBatterySection() {
+  const { t } = useTranslation(["pages"]);
   const probes = useQueries({
     queries: LABELLED_SCENES.map((sc) => ({
       queryKey: ["linear-probe-panel", sc],
@@ -407,11 +429,11 @@ function MultiAxisBatterySection() {
   if (!ready) {
     return (
       <Section
-        title="Multi-Axis Addendum B — battery summary"
-        lead="One row per labelled scene, one column per axis (B-1 fair-baseline F1, B-3 topic-routed F1, B-6 LDA off-diag stability). The three axes load in parallel. See the wiki for the full framework."
+        title={t("pages:benchmarks.summary.battery_title")}
+        lead={t("pages:benchmarks.summary.battery_lead_loading")}
       >
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-          Loading multi-axis battery payloads…
+          {t("pages:benchmarks.summary.battery_loading")}
         </p>
       </Section>
     );
@@ -465,8 +487,8 @@ function MultiAxisBatterySection() {
 
   return (
     <Section
-      title="Multi-Axis Addendum B — battery summary"
-      lead="One row per labelled scene. Columns: theta-as-feature F1 (B-1, naive), ICA-10 F1 (B-1, fair-baseline winner), best CAE-1D F1 across K∈{4..32} (B-1 deep ladder), topic_routed_soft F1 (B-3 the master-plan thesis), raw_logistic F1 (B-3 strong baseline), and LDA off-diagonal stability (B-6, N=7 seeds). The framework is on the wiki Multi-Axis-Addendum-B page."
+      title={t("pages:benchmarks.summary.battery_title")}
+      lead={t("pages:benchmarks.summary.battery_lead")}
     >
       <div className="overflow-x-auto">
         <table
@@ -476,28 +498,28 @@ function MultiAxisBatterySection() {
           <thead>
             <tr style={{ color: "var(--color-text-muted)" }}>
               <th className="text-left font-mono text-[12px] pb-2 pr-3">
-                scene
+                {t("pages:benchmarks.summary.battery_col_scene")}
               </th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">
-                θ flat (B-1)
+                {t("pages:benchmarks.summary.battery_col_theta_flat")}
               </th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">
-                ICA-10 (B-1)
+                {t("pages:benchmarks.summary.battery_col_ica10")}
               </th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">
-                CAE-1D best (B-1)
+                {t("pages:benchmarks.summary.battery_col_cae_best")}
               </th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">
-                θ_logistic (B-3)
+                {t("pages:benchmarks.summary.battery_col_theta_logistic")}
               </th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">
-                routed_soft (B-3)
+                {t("pages:benchmarks.summary.battery_col_routed_soft")}
               </th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">
-                raw_logistic (B-3)
+                {t("pages:benchmarks.summary.battery_col_raw_logistic")}
               </th>
               <th className="text-right font-mono text-[12px] pb-2 pr-3">
-                LDA stability (B-6)
+                {t("pages:benchmarks.summary.battery_col_lda_stability")}
               </th>
             </tr>
           </thead>
@@ -548,13 +570,10 @@ function MultiAxisBatterySection() {
         className="mt-3 text-[12.5px]"
         style={{ color: "var(--color-text-muted)" }}
       >
-        Headlines: ICA-10 wins B-1 fair-baseline on every scene. CAE-1D K=32
-        closes much of the gap (KSC θ=0.021 → CAE-1D K=32=0.710, a 33×
-        recovery). topic_routed_soft matches or beats raw_logistic on every
-        scene; θ_logistic loses by 30-50 points everywhere — the master-plan
-        thesis "θ as a gate, never as a feature" is empirically validated. LDA
-        off-diag stability ≥ 0.954 across all 6 scenes vs CAE-1D 0.74-0.97 and
-        β-VAE 0.18-0.89.
+        <Trans
+          i18nKey="pages:benchmarks.summary.battery_headlines"
+          components={{ strong: <strong /> }}
+        />
       </p>
     </Section>
   );

--- a/frontend/src/pages/benchmarks/VSweepCoverageMatrix.tsx
+++ b/frontend/src/pages/benchmarks/VSweepCoverageMatrix.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { request } from "@/api/_http";
 import { Section } from "@/components/Section";
 
@@ -63,6 +64,7 @@ function valueColor(
 }
 
 export function VSweepCoverageMatrix() {
+  const { t } = useTranslation(["pages"]);
   const [mode, setMode] = useState<ViewMode>("values");
   const { data, isLoading, isError } = useQuery<CoverageMatrix>({
     queryKey: ["v-sweep-coverage"],
@@ -76,8 +78,8 @@ export function VSweepCoverageMatrix() {
   return (
     <Section
       id="v-sweep-coverage"
-      title="V-sweep coverage matrix (10 axes × 19 recipes × 6 scenes)"
-      lead="1140 numeric cells in total — all populated. Toggle between boolean (cells filled?) and value (per-cell numeric, viridis colormap). F-13 SHAP has no scalar value so it stays boolean."
+      title={t("pages:benchmarks.vsweep_coverage.title")}
+      lead={t("pages:benchmarks.vsweep_coverage.lead")}
     >
       <div className="flex gap-2 mb-3">
         <button
@@ -89,7 +91,7 @@ export function VSweepCoverageMatrix() {
             border: "1px solid var(--color-border)",
           }}
         >
-          values
+          {t("pages:benchmarks.vsweep_coverage.toggle.values")}
         </button>
         <button
           onClick={() => setMode("boolean")}
@@ -100,7 +102,7 @@ export function VSweepCoverageMatrix() {
             border: "1px solid var(--color-border)",
           }}
         >
-          boolean
+          {t("pages:benchmarks.vsweep_coverage.toggle.boolean")}
         </button>
       </div>
       <div className="overflow-x-auto">
@@ -111,7 +113,7 @@ export function VSweepCoverageMatrix() {
                 className="text-left px-2 py-1 border font-mono"
                 style={{ borderColor: "var(--color-border)", backgroundColor: "var(--color-panel)" }}
               >
-                axis \ scene·recipe
+                {t("pages:benchmarks.vsweep_coverage.table.axisSceneRecipe")}
               </th>
               {data.scenes.map((sc) =>
                 data.recipes.map((r) => (
@@ -197,10 +199,9 @@ export function VSweepCoverageMatrix() {
         </table>
       </div>
       <p className="mt-2 text-[11.5px]" style={{ color: "var(--color-fg-faint)" }}>
-        Generated {new Date(data.generated_at).toISOString().slice(0, 10)}. F-14 jaccard uses
-        inverted colour (lower = better, mapped to "high" colour band). F-17 cross-scene
-        (portable only) and B-12 / F-15 per-scene LLM-judge records are reported in their
-        dedicated panels.
+        {t("pages:benchmarks.vsweep_coverage.footnote", {
+          date: new Date(data.generated_at).toISOString().slice(0, 10),
+        })}
       </p>
       <RecipeMeansTable axes={data.axes} recipes={data.recipes} />
     </Section>
@@ -208,6 +209,7 @@ export function VSweepCoverageMatrix() {
 }
 
 function RecipeMeansTable({ axes, recipes }: { axes: CoverageAxis[]; recipes: string[] }) {
+  const { t } = useTranslation(["pages"]);
   const axesWithMeans = axes.filter((a) => a.recipe_means && Object.keys(a.recipe_means).length > 0);
   if (axesWithMeans.length === 0) return null;
 
@@ -227,13 +229,13 @@ function RecipeMeansTable({ axes, recipes }: { axes: CoverageAxis[]; recipes: st
   return (
     <div className="mt-4 overflow-x-auto">
       <h3 className="text-[12.5px] uppercase tracking-widest font-semibold mb-2" style={{ color: "var(--color-fg-faint)" }}>
-        Per-axis recipe-mean ranking
+        {t("pages:benchmarks.vsweep_coverage.recipeMeans.heading")}
       </h3>
       <table className="text-[11.5px] border-collapse w-full" style={{ borderColor: "var(--color-border)" }}>
         <thead>
           <tr>
             <th className="text-left px-2 py-1 border font-mono" style={{ borderColor: "var(--color-border)" }}>
-              axis
+              {t("pages:benchmarks.vsweep_coverage.recipeMeans.axis")}
             </th>
             {recipes.map((r) => (
               <th


### PR DESCRIPTION
F4 (i18n): the /benchmarks subtree was hardcoded English — the ES toggle had no effect there. Migrated all 8 components (~180 strings) to pages:benchmarks.* with EN + fluent technical ES. Technical terms, method ids and symbols (macro F1, c_v, R², θ, ARI, NMI, NFINDR, method names…) kept verbatim. Parity 1437/1437, all 183 t() keys resolve, tsc 0, vitest 50/50, build OK.