### PR TITLE
fix: per-deploy cache-bust on data fetches

### DIFF
--- a/frontend/src/api/_http.ts
+++ b/frontend/src/api/_http.ts
@@ -7,7 +7,23 @@
  * extracted as part of the c261 api-client split (#441 P1 item 2.4).
  */
 
+import { APP_COMMIT_SHA } from "@/lib/version";
+
 const BASE = (import.meta.env.VITE_API_BASE ?? "").replace(/\/$/, "");
+
+// Per-deploy cache-buster. /api and /generated responses carry
+// `Cache-Control: no-cache` (revalidate via ETag), but a client whose cache
+// was poisoned BEFORE that header existed can keep serving a stale body under
+// heuristic freshness. Stamping the build SHA into the query string changes
+// the URL on every deploy, so a new build can never read a previous build's
+// cached payload (this is why a regenerated EDA could still render n=0).
+const CACHE_BUST =
+  APP_COMMIT_SHA && APP_COMMIT_SHA !== "dev" ? APP_COMMIT_SHA.slice(0, 8) : "";
+
+function withVersion(path: string): string {
+  if (!CACHE_BUST) return path;
+  return `${path}${path.includes("?") ? "&" : "?"}v=${CACHE_BUST}`;
+}
 
 export class ApiError extends Error {
   status: number;
@@ -21,7 +37,7 @@ export class ApiError extends Error {
 }
 
 export async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const url = `${BASE}${path}`;
+  const url = `${BASE}${withVersion(path)}`;
   const res = await fetch(url, init);
   if (!res.ok) {
     throw new ApiError(
@@ -37,7 +53,7 @@ export async function requestBuffer(
   path: string,
   init?: RequestInit,
 ): Promise<ArrayBuffer> {
-  const url = `${BASE}${path}`;
+  const url = `${BASE}${withVersion(path)}`;
   const res = await fetch(url, init);
   if (!res.ok) {
     throw new ApiError(


### PR DESCRIPTION
Felipe saw the HIDSAG GEOMET EDA table still showing n=0 even though live data + code are correct — his browser cache (poisoned before the Cache-Control: no-cache header existed) keeps serving the old {n:0} body under heuristic freshness. Append ?v=<build-sha> to every /api + /generated fetch so each deploy uses fresh URLs no stale cache can satisfy. tsc 0, vitest 50/50.