### PR TITLE
fix: conceptual/equation corrections from deep math review (ETM decoder, NMI, Moran's I, Lloyd-Max, HDP prevalence, MI bound)

### DIFF
--- a/data-pipeline/build_mutual_information.py
+++ b/data-pipeline/build_mutual_information.py
@@ -81,7 +81,11 @@ def total_mi_classif(X: np.ndarray, y: np.ndarray) -> dict:
     per_feat = mutual_info_classif(X, y, random_state=RANDOM_STATE)
     H_y = label_entropy(y)
     sum_mi = float(per_feat.sum())
-    # Joint MI is bounded above by H(Y); per-feature sum overestimates.
+    # I(X;Y) <= H(Y) always, so clip the per-feature MI sum to H(Y). NOTE:
+    # sum_i I(X_i;Y) is only a heuristic for the joint MI — it over-estimates
+    # under feature redundancy but UNDER-estimates under synergy (e.g. XOR,
+    # where each I(X_i;Y)=0 yet I(X;Y)=H(Y)). So this is a proxy, not a bound
+    # from the sum side; only the H(Y) clip guarantees the upper bound.
     joint_proxy = min(sum_mi, H_y)
     return {
         "label_entropy_nats": round(float(H_y), 6),

--- a/data-pipeline/build_v_sweep_hdp.py
+++ b/data-pipeline/build_v_sweep_hdp.py
@@ -104,23 +104,29 @@ def fit_hdp(doc_term: sp.csr_matrix, scene_id: str, recipe: str):
         phi = np.concatenate([phi, pad], axis=1)
     K_inferred = phi.shape[0]
 
-    # Topic prevalence via projecting the corpus through the inferred HDP
-    # and counting topics that hold meaningful posterior mass. gensim's
-    # HdpModel doesn't expose theta directly; we approximate prevalence
-    # by the L1-norm of each topic's word distribution after subtracting
-    # the uniform baseline, then count topics whose prevalence is at
-    # least 5% of the maximum. This better tracks the 'effective' K than
-    # truncation level alone.
-    if phi.shape[1] > 0:
-        uniform = 1.0 / phi.shape[1]
-        deviation = np.abs(phi - uniform).sum(axis=1)  # L1 from uniform
-        if deviation.max() > 0:
-            normalised = deviation / deviation.max()
-            K_effective = int((normalised > 0.05).sum())
-        else:
-            K_effective = 0
+    # Topic prevalence: project the corpus through the inferred HDP and
+    # accumulate per-topic posterior MASS — the token-weighted sum of the
+    # per-document topic proportions theta_d (gensim hdp[doc] returns the
+    # variational document-topic distribution). This is corpus-level topic
+    # USAGE (Teh-Jordan-Beal-Blei 2006 top-level prevalence), NOT the
+    # word-distribution peakedness of phi. We then count topics holding at
+    # least 1% of the total corpus mass, and also report the perplexity-
+    # style effective topic count N_eff = exp(H(pi)).
+    mass = np.zeros(K_inferred, dtype=np.float64)
+    doc_lens = np.asarray(doc_term.sum(axis=1)).ravel().astype(np.float64)
+    for d in range(D):
+        for topic_id, prob in hdp[corpus[d]]:
+            if 0 <= topic_id < K_inferred:
+                mass[topic_id] += doc_lens[d] * prob
+    total_mass = mass.sum()
+    if total_mass > 0:
+        pi = mass / total_mass
+        K_effective = int((pi > 0.01).sum())
+        nz = pi[pi > 0]
+        N_eff_topics = float(np.exp(-(nz * np.log(nz)).sum()))
     else:
         K_effective = 0
+        N_eff_topics = 0.0
 
     n_classes = CLASS_COUNTS.get(scene_id, 0)
     f16 = abs(K_effective - n_classes) if n_classes else None
@@ -176,6 +182,7 @@ def fit_hdp(doc_term: sp.csr_matrix, scene_id: str, recipe: str):
         "backbone": "HDP",
         "T_truncation": 20, "K_inferred_total": int(K_inferred),
         "K_effective": int(K_effective),
+        "N_eff_topics": round(N_eff_topics, 4),
         "K_ground_truth_classes": n_classes,
         "f16_model_selection_adequacy": f16,
         "f2_c_v": round(c_v, 6),

--- a/frontend/src/pages/methodology/Pipeline.tsx
+++ b/frontend/src/pages/methodology/Pipeline.tsx
@@ -243,8 +243,12 @@ export default function MethodologyPipeline() {
           tex="I_k = \frac{N}{S_0} \cdot \frac{\sum_{i} \sum_{j} W_{ij} (\theta_{i,k} - \bar{\theta}_k)(\theta_{j,k} - \bar{\theta}_k)}{\sum_{i} (\theta_{i,k} - \bar{\theta}_k)^2}, \quad S_0 = \sum_{i,j} W_{ij}."
         />
         <p>
-          <Equation tex="I_k \in [-1, 1]" /> measures how strongly the
-          per-pixel topic weight is spatially clustered. A topic that
+          <Equation tex="I_k" /> measures how strongly the
+          per-pixel topic weight is spatially clustered — typically in
+          roughly <Equation tex="[-1, 1]" /> with null expectation{" "}
+          <Equation tex="\mathbb{E}[I_k] = -1/(N-1)" /> (its exact extremes
+          are the min/max eigenvalues of the centred, symmetrised weight
+          matrix and may fall slightly outside this range). A topic that
           captures a contiguous mineral assemblage shows{" "}
           <Equation tex="I_k \approx 0.6\text{–}0.9" /> on HIDSAG MINERAL1;
           a noisy / over-fragmented topic falls below 0.2. The Workspace{" "}

--- a/frontend/src/pages/methodology/Representations.tsx
+++ b/frontend/src/pages/methodology/Representations.tsx
@@ -80,9 +80,9 @@ const METHODS: MethodEntry[] = [
     id: "etm",
     family: "neural-topic",
     equations: [
-      "\\beta_k = \\rho \\cdot \\alpha_k^\\top \\in \\mathbb{R}^V",
+      "\\beta_k = \\text{softmax}(\\rho^\\top \\alpha_k) \\in \\Delta^{V-1}",
       "q_\\phi(\\theta \\mid w) = \\mathcal{N}(\\mu_\\phi(w), \\Sigma_\\phi(w))",
-      "p(w \\mid \\theta, \\rho, \\alpha) = \\text{softmax}(\\theta^\\top \\beta)",
+      "p(w \\mid \\theta, \\rho, \\alpha) = \\sum_k \\theta_k\\, \\beta_k = \\beta\\theta",
     ],
   },
   {
@@ -457,7 +457,7 @@ export default function MethodologyRepresentations() {
             <strong>Quantile (Q)</strong>: empirical-quantile bins so each cell receives 1/Q of the corpus mass. Equalises token frequencies; the variant the project defaults to for V1.
           </li>
           <li>
-            <strong>Lloyd-Max (L)</strong>: K-means in 1D over the corpus values — minimises mean-square quantisation error. Optimal under the 1/(12·Q²) bound (Gersho-Gray 1992) when values are approximately uniform inside each cell.
+            <strong>Lloyd-Max (L)</strong>: K-means in 1D over the corpus values — the MSE-optimal Q-level quantiser for the empirical value density (Lloyd 1957 / Max 1960), satisfying the centroid and nearest-neighbour conditions. Its high-resolution distortion follows the Panter-Dite integral ∝ (∫ f<sup>1/3</sup>)³ / (12·Q²), which is ≤ the uniform-quantiser figure Δ²/12 = 1/(12·Q²) (range normalised to 1) — equality only when values are uniform over the range.
           </li>
         </ul>
         <p

--- a/frontend/src/pages/methodology/Theory.tsx
+++ b/frontend/src/pages/methodology/Theory.tsx
@@ -255,8 +255,8 @@ export default function MethodologyTheory() {
           disagreement. The project's F-3 axis reports ARI(KMeans on θ,
           ground-truth label). Companion measures:{" "}
           <strong>Normalised Mutual Information (NMI)</strong>{" "}
-          <Equation tex="\mathrm{NMI}(U, V) = \mathrm{I}(U; V) / \mathrm{mean}(\mathrm{H}(U), \mathrm{H}(V))" />
-          {" "}(Strehl &amp; Ghosh 2002), and{" "}
+          <Equation tex="\mathrm{NMI}(U, V) = \mathrm{I}(U; V) / \sqrt{\mathrm{H}(U)\,\mathrm{H}(V)}" />
+          {" "}(geometric-mean normalisation, Strehl &amp; Ghosh 2002), and{" "}
           <strong>V-measure</strong>{" "}
           <Equation tex="\mathrm{V} = \frac{2 \cdot h \cdot c}{h + c}" />,
           the harmonic mean of homogeneity{" "}


### PR DESCRIPTION
Deep conceptual review across app methodology pages + data pipeline. Fixes:

**App methodology**
- ETM decoder equation (was missing softmax in beta_k and applied an outer softmax that is ProdLDA's, not ETM's mixture). Now matches canonical Dieng-Ruiz-Blei 2020 and equations/canonical.tex.
- NMI geometric-mean normalisation to match cited Strehl & Ghosh 2002.
- Moran's I range claim softened (null expectation -1/(N-1), eigenvalue extremes).
- Lloyd-Max optimality vs the 1/(12Q^2) uniform-quantiser figure (Panter-Dite).

**Data pipeline**
- HDP K_effective now measures corpus-level topic mass (Teh 2006 prevalence) not phi peakedness; emits N_eff_topics. **F-16 values change → needs sweep re-run + redeploy.**
- MI joint proxy comment: per-feature MI sum is not a one-sided bound (synergy/XOR).

Core math (NPMI, c_v, U-Mass, LDA/Gibbs, NFINDR/NNLS, theta-gate, N_eff, Kraskov MI, ProdLDA decoder) verified correct — 12 suspicions were false alarms.