### PR TITLE
fix(v-sweep-hdp): recompute F-16 with canonical top-level stick prevalence (114 JSON regenerated)

### DIFF
--- a/data-pipeline/build_v_sweep_hdp.py
+++ b/data-pipeline/build_v_sweep_hdp.py
@@ -104,29 +104,32 @@ def fit_hdp(doc_term: sp.csr_matrix, scene_id: str, recipe: str):
         phi = np.concatenate([phi, pad], axis=1)
     K_inferred = phi.shape[0]
 
-    # Topic prevalence: project the corpus through the inferred HDP and
-    # accumulate per-topic posterior MASS — the token-weighted sum of the
-    # per-document topic proportions theta_d (gensim hdp[doc] returns the
-    # variational document-topic distribution). This is corpus-level topic
-    # USAGE (Teh-Jordan-Beal-Blei 2006 top-level prevalence), NOT the
-    # word-distribution peakedness of phi. We then count topics holding at
-    # least 1% of the total corpus mass, and also report the perplexity-
-    # style effective topic count N_eff = exp(H(pi)).
-    mass = np.zeros(K_inferred, dtype=np.float64)
-    doc_lens = np.asarray(doc_term.sum(axis=1)).ravel().astype(np.float64)
-    for d in range(D):
-        for topic_id, prob in hdp[corpus[d]]:
-            if 0 <= topic_id < K_inferred:
-                mass[topic_id] += doc_lens[d] * prob
-    total_mass = mass.sum()
+    # Topic prevalence: the corpus-level expected topic weights are the HDP
+    # top-level stick-breaking proportions (Teh-Jordan-Beal-Blei 2006), which
+    # gensim exposes as the converted-LDA alpha via hdp_to_lda(). This is the
+    # canonical corpus-level topic USAGE, NOT the word-distribution peakedness
+    # of phi (the previous, wrong, L1-from-uniform proxy). We deliberately use
+    # the top-level sticks rather than averaging the per-document __getitem__
+    # projection, whose variational inference is unstable on these corpora and
+    # collapses onto a single topic for several scenes. We count topics holding
+    # >= 1% of corpus mass and report the perplexity-style effective topic
+    # count N_eff = exp(H(pi)).
+    try:
+        lda_alpha, _ = hdp.hdp_to_lda()
+        alpha = np.asarray(lda_alpha, dtype=np.float64)[:K_inferred]
+    except Exception:
+        alpha = np.zeros(K_inferred, dtype=np.float64)
+    total_mass = alpha.sum()
     if total_mass > 0:
-        pi = mass / total_mass
+        pi = alpha / total_mass
         K_effective = int((pi > 0.01).sum())
         nz = pi[pi > 0]
         N_eff_topics = float(np.exp(-(nz * np.log(nz)).sum()))
+        prevalence_top5 = [round(float(x), 6) for x in np.sort(pi)[::-1][:5]]
     else:
         K_effective = 0
         N_eff_topics = 0.0
+        prevalence_top5 = []
 
     n_classes = CLASS_COUNTS.get(scene_id, 0)
     f16 = abs(K_effective - n_classes) if n_classes else None
@@ -189,7 +192,7 @@ def fit_hdp(doc_term: sp.csr_matrix, scene_id: str, recipe: str):
         "f14_mean_pairwise_jaccard": round(mean_jacc, 6),
         "fit_seconds": round(fit_secs, 3),
         "D": int(D), "V": int(V),
-        "topic_deviation_top5": [round(float(x), 6) for x in sorted(deviation)[::-1][:5]] if phi.shape[1] > 0 else [],
+        "topic_prevalence_top5": prevalence_top5,
         "generated_at": datetime.now(timezone.utc)
         .isoformat(timespec="seconds")
         .replace("+00:00", "Z"),

--- a/data/derived/v_sweep/hdp_backbone/botswana_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V10_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.3275,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.288455,
   "f14_mean_pairwise_jaccard": 0.26943,
-  "fit_seconds": 1.165,
+  "fit_seconds": 1.0,
   "D": 2775,
   "V": 24,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.078817,
+    0.078501,
+    0.073516,
+    0.069858,
+    0.052103
   ],
-  "generated_at": "2026-05-27T03:35:16Z",
+  "generated_at": "2026-06-09T06:40:46Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V11_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.941,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.497772,
   "f14_mean_pairwise_jaccard": 0.188933,
-  "fit_seconds": 0.961,
+  "fit_seconds": 0.828,
   "D": 2775,
   "V": 32,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.05828,
+    0.056391,
+    0.055285,
+    0.053414,
+    0.05309
   ],
-  "generated_at": "2026-05-27T03:35:17Z",
+  "generated_at": "2026-06-09T06:40:47Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V12_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 6,
+  "N_eff_topics": 2.2687,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 8,
   "f2_c_v": 0.316877,
   "f14_mean_pairwise_jaccard": 0.006987,
-  "fit_seconds": 1.277,
+  "fit_seconds": 1.155,
   "D": 2775,
   "V": 1160,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.827629,
+    0.058536,
+    0.028894,
+    0.021579,
+    0.020843
   ],
-  "generated_at": "2026-05-27T03:35:18Z",
+  "generated_at": "2026-06-09T06:40:48Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V13_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.6454,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.307426,
   "f14_mean_pairwise_jaccard": 0.045337,
-  "fit_seconds": 1.69,
+  "fit_seconds": 0.981,
   "D": 2775,
   "V": 128,
-  "topic_deviation_top5": [
-    0.7883,
-    0.77306,
-    0.754383,
-    0.744506,
-    0.739667
+  "topic_prevalence_top5": [
+    0.069517,
+    0.064561,
+    0.063888,
+    0.060204,
+    0.057683
   ],
-  "generated_at": "2026-05-30T04:59:20Z",
+  "generated_at": "2026-06-09T06:40:49Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V14_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 17.858,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.305481,
   "f14_mean_pairwise_jaccard": 0.004432,
-  "fit_seconds": 0.894,
+  "fit_seconds": 1.299,
   "D": 2775,
   "V": 1024,
-  "topic_deviation_top5": [
-    0.758007,
-    0.7526,
-    0.748483,
-    0.742487,
-    0.738324
+  "topic_prevalence_top5": [
+    0.112002,
+    0.081681,
+    0.076196,
+    0.073437,
+    0.072061
   ],
-  "generated_at": "2026-05-28T11:38:25Z",
+  "generated_at": "2026-06-09T06:40:51Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V15_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.922,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
-  "f2_c_v": 0.368386,
-  "f14_mean_pairwise_jaccard": 0.120075,
-  "fit_seconds": 1.242,
+  "f2_c_v": 0.534707,
+  "f14_mean_pairwise_jaccard": 0.025496,
+  "fit_seconds": 0.979,
   "D": 2775,
-  "V": 48,
-  "topic_deviation_top5": [
-    0.852502,
-    0.829483,
-    0.800472,
-    0.786639,
-    0.77708
+  "V": 192,
+  "topic_prevalence_top5": [
+    0.058115,
+    0.055784,
+    0.055532,
+    0.05502,
+    0.054621
   ],
-  "generated_at": "2026-05-30T04:59:22Z",
+  "generated_at": "2026-06-09T06:40:52Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V17_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9955,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.613028,
   "f14_mean_pairwise_jaccard": 0.010619,
-  "fit_seconds": 1.109,
+  "fit_seconds": 0.815,
   "D": 2775,
   "V": 512,
-  "topic_deviation_top5": [
-    0.754056,
-    0.750481,
-    0.748093,
-    0.745013,
-    0.744456
+  "topic_prevalence_top5": [
+    0.051945,
+    0.051685,
+    0.051396,
+    0.051276,
+    0.050888
   ],
-  "generated_at": "2026-05-30T04:59:23Z",
+  "generated_at": "2026-06-09T06:40:52Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V18_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 17.5135,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.408902,
   "f14_mean_pairwise_jaccard": 0.046235,
-  "fit_seconds": 0.923,
+  "fit_seconds": 1.22,
   "D": 2775,
   "V": 128,
-  "topic_deviation_top5": [
-    0.78398,
-    0.763282,
-    0.747361,
-    0.733642,
-    0.731887
+  "topic_prevalence_top5": [
+    0.11769,
+    0.106534,
+    0.083088,
+    0.068429,
+    0.068418
   ],
-  "generated_at": "2026-05-28T11:38:26Z",
+  "generated_at": "2026-06-09T06:40:54Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V19_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9504,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.496142,
   "f14_mean_pairwise_jaccard": 0.267841,
-  "fit_seconds": 1.212,
+  "fit_seconds": 0.92,
   "D": 2775,
   "V": 24,
-  "topic_deviation_top5": [
-    0.913695,
-    0.84615,
-    0.824721,
-    0.820448,
-    0.799304
+  "topic_prevalence_top5": [
+    0.055875,
+    0.053619,
+    0.053506,
+    0.052402,
+    0.052391
   ],
-  "generated_at": "2026-05-30T04:59:24Z",
+  "generated_at": "2026-06-09T06:40:55Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V1_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 4,
+  "N_eff_topics": 1.6716,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 10,
   "f2_c_v": 0.455689,
   "f14_mean_pairwise_jaccard": 0.035417,
-  "fit_seconds": 0.967,
+  "fit_seconds": 0.874,
   "D": 2775,
   "V": 145,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.884196,
+    0.066529,
+    0.019225,
+    0.017464,
+    0.006398
   ],
-  "generated_at": "2026-05-27T03:35:04Z",
+  "generated_at": "2026-06-09T06:40:34Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V20_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 6,
+  "N_eff_topics": 4.0587,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 8,
   "f2_c_v": 0.439208,
   "f14_mean_pairwise_jaccard": 0.013613,
-  "fit_seconds": 0.707,
+  "fit_seconds": 0.907,
   "D": 2775,
   "V": 1160,
-  "topic_deviation_top5": [
-    1.448366,
-    1.382096,
-    1.183501,
-    0.869218,
-    0.816517
+  "topic_prevalence_top5": [
+    0.378783,
+    0.321761,
+    0.210408,
+    0.042266,
+    0.016454
   ],
-  "generated_at": "2026-05-28T11:38:27Z",
+  "generated_at": "2026-06-09T06:40:56Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V2_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 7,
+  "N_eff_topics": 4.9497,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.353553,
   "f14_mean_pairwise_jaccard": 1.0,
-  "fit_seconds": 2.604,
+  "fit_seconds": 2.401,
   "D": 2775,
   "V": 8,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.370235,
+    0.269144,
+    0.18212,
+    0.072094,
+    0.063237
   ],
-  "generated_at": "2026-05-27T03:35:06Z",
+  "generated_at": "2026-06-09T06:40:37Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V3_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 4,
+  "N_eff_topics": 1.8047,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 10,
   "f2_c_v": 0.290339,
   "f14_mean_pairwise_jaccard": 0.007849,
-  "fit_seconds": 1.628,
+  "fit_seconds": 1.441,
   "D": 2775,
   "V": 1160,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.872892,
+    0.069411,
+    0.015394,
+    0.010004,
+    0.009888
   ],
-  "generated_at": "2026-05-27T03:35:08Z",
+  "generated_at": "2026-06-09T06:40:38Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V4_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.2019,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 12,
   "f2_c_v": 0.316228,
   "f14_mean_pairwise_jaccard": 0.039752,
-  "fit_seconds": 1.012,
+  "fit_seconds": 1.006,
   "D": 2775,
   "V": 145,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.968239,
+    0.021109,
+    0.00412,
+    0.001791,
+    0.001287
   ],
-  "generated_at": "2026-05-27T03:35:09Z",
+  "generated_at": "2026-06-09T06:40:39Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V5_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.2268,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 12,
   "f2_c_v": 0.320288,
   "f14_mean_pairwise_jaccard": 0.037966,
-  "fit_seconds": 0.938,
+  "fit_seconds": 0.905,
   "D": 2775,
   "V": 145,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.966933,
+    0.011164,
+    0.009986,
+    0.004323,
+    0.002987
   ],
-  "generated_at": "2026-05-27T03:35:10Z",
+  "generated_at": "2026-06-09T06:40:40Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V6_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 4,
+  "N_eff_topics": 1.5409,
   "K_ground_truth_classes": 14,
-  "f16_model_selection_adequacy": 6,
+  "f16_model_selection_adequacy": 10,
   "f2_c_v": 0.317808,
   "f14_mean_pairwise_jaccard": 0.030569,
-  "fit_seconds": 1.353,
+  "fit_seconds": 1.359,
   "D": 2775,
   "V": 171,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.923925,
+    0.019381,
+    0.015531,
+    0.01367,
+    0.00568
   ],
-  "generated_at": "2026-05-27T03:35:12Z",
+  "generated_at": "2026-06-09T06:40:42Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V7_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8872,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.622899,
   "f14_mean_pairwise_jaccard": 0.034072,
-  "fit_seconds": 1.029,
+  "fit_seconds": 1.238,
   "D": 2775,
   "V": 178,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.059955,
+    0.058667,
+    0.058053,
+    0.055488,
+    0.055245
   ],
-  "generated_at": "2026-05-27T03:35:13Z",
+  "generated_at": "2026-06-09T06:40:43Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V8_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.1049,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.276873,
   "f14_mean_pairwise_jaccard": 0.716268,
-  "fit_seconds": 1.413,
+  "fit_seconds": 1.356,
   "D": 2775,
   "V": 12,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.139355,
+    0.063678,
+    0.063352,
+    0.063084,
+    0.060091
   ],
-  "generated_at": "2026-05-27T03:35:14Z",
+  "generated_at": "2026-06-09T06:40:44Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/botswana_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/botswana_V9_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9904,
   "K_ground_truth_classes": 14,
   "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.384,
   "f14_mean_pairwise_jaccard": 0.015512,
-  "fit_seconds": 0.738,
+  "fit_seconds": 0.628,
   "D": 2775,
   "V": 424,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.05333,
+    0.053316,
+    0.051954,
+    0.051301,
+    0.051227
   ],
-  "generated_at": "2026-05-27T03:35:15Z",
+  "generated_at": "2026-06-09T06:40:45Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V10_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.589,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.305891,
   "f14_mean_pairwise_jaccard": 0.26943,
-  "fit_seconds": 0.825,
+  "fit_seconds": 0.79,
   "D": 2812,
   "V": 24,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.072576,
+    0.068043,
+    0.067444,
+    0.063897,
+    0.05504
   ],
-  "generated_at": "2026-05-27T03:34:01Z",
+  "generated_at": "2026-06-09T06:38:44Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V11_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9596,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.457913,
   "f14_mean_pairwise_jaccard": 0.1877,
-  "fit_seconds": 1.172,
+  "fit_seconds": 1.175,
   "D": 2812,
   "V": 32,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.054687,
+    0.053372,
+    0.053195,
+    0.053154,
+    0.052706
   ],
-  "generated_at": "2026-05-27T03:34:02Z",
+  "generated_at": "2026-06-09T06:38:46Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V12_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 3,
+  "N_eff_topics": 1.9216,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 13,
   "f2_c_v": 0.298306,
   "f14_mean_pairwise_jaccard": 0.00277,
-  "fit_seconds": 0.857,
+  "fit_seconds": 1.237,
   "D": 2812,
   "V": 1600,
-  "topic_deviation_top5": [
-    1.230715,
-    0.899146,
-    0.759263,
-    0.753067,
-    0.740966
+  "topic_prevalence_top5": [
+    0.821603,
+    0.138026,
+    0.01037,
+    0.009411,
+    0.004598
   ],
-  "generated_at": "2026-05-28T03:06:48Z",
+  "generated_at": "2026-06-09T06:38:47Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V13_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.735,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.291323,
   "f14_mean_pairwise_jaccard": 0.046542,
-  "fit_seconds": 0.845,
+  "fit_seconds": 1.08,
   "D": 2812,
   "V": 128,
-  "topic_deviation_top5": [
-    0.786624,
-    0.773529,
-    0.757871,
-    0.743344,
-    0.739268
+  "topic_prevalence_top5": [
+    0.061426,
+    0.059986,
+    0.059629,
+    0.059153,
+    0.056725
   ],
-  "generated_at": "2026-05-30T04:58:53Z",
+  "generated_at": "2026-06-09T06:38:48Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V14_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 17.0859,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.321147,
   "f14_mean_pairwise_jaccard": 0.004986,
-  "fit_seconds": 1.091,
+  "fit_seconds": 1.553,
   "D": 2812,
   "V": 1024,
-  "topic_deviation_top5": [
-    0.771491,
-    0.755852,
-    0.75496,
-    0.745692,
-    0.740498
+  "topic_prevalence_top5": [
+    0.147402,
+    0.109686,
+    0.078301,
+    0.068062,
+    0.062403
   ],
-  "generated_at": "2026-05-28T11:38:13Z",
+  "generated_at": "2026-06-09T06:38:50Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V15_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8575,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
-  "f2_c_v": 0.324231,
-  "f14_mean_pairwise_jaccard": 0.119466,
-  "fit_seconds": 1.045,
+  "f2_c_v": 0.537252,
+  "f14_mean_pairwise_jaccard": 0.025593,
+  "fit_seconds": 1.293,
   "D": 2812,
-  "V": 48,
-  "topic_deviation_top5": [
-    0.852629,
-    0.829128,
-    0.800942,
-    0.786586,
-    0.776444
+  "V": 192,
+  "topic_prevalence_top5": [
+    0.063354,
+    0.059357,
+    0.057319,
+    0.0553,
+    0.054434
   ],
-  "generated_at": "2026-05-30T04:58:55Z",
+  "generated_at": "2026-06-09T06:38:51Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V17_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9918,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.593915,
   "f14_mean_pairwise_jaccard": 0.010619,
-  "fit_seconds": 0.796,
+  "fit_seconds": 1.051,
   "D": 2812,
   "V": 512,
-  "topic_deviation_top5": [
-    0.753455,
-    0.750209,
-    0.747854,
-    0.744605,
-    0.744161
+  "topic_prevalence_top5": [
+    0.052978,
+    0.052236,
+    0.051804,
+    0.051217,
+    0.050898
   ],
-  "generated_at": "2026-05-30T04:58:55Z",
+  "generated_at": "2026-06-09T06:38:52Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V18_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.5348,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.395004,
   "f14_mean_pairwise_jaccard": 0.045681,
-  "fit_seconds": 0.973,
+  "fit_seconds": 1.349,
   "D": 2812,
   "V": 128,
-  "topic_deviation_top5": [
-    0.774586,
-    0.76587,
-    0.752003,
-    0.734397,
-    0.731412
+  "topic_prevalence_top5": [
+    0.110666,
+    0.083184,
+    0.070397,
+    0.065997,
+    0.054962
   ],
-  "generated_at": "2026-05-28T11:38:14Z",
+  "generated_at": "2026-06-09T06:38:53Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V19_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9103,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.537828,
   "f14_mean_pairwise_jaccard": 0.266886,
-  "fit_seconds": 0.765,
+  "fit_seconds": 0.898,
   "D": 2812,
   "V": 24,
-  "topic_deviation_top5": [
-    0.913184,
-    0.845097,
-    0.824054,
-    0.819344,
-    0.79965
+  "topic_prevalence_top5": [
+    0.059215,
+    0.057729,
+    0.053789,
+    0.053664,
+    0.053539
   ],
-  "generated_at": "2026-05-30T04:58:56Z",
+  "generated_at": "2026-06-09T06:38:54Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V1_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 3,
+  "N_eff_topics": 1.1648,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 13,
   "f2_c_v": 0.353804,
   "f14_mean_pairwise_jaccard": 0.030793,
-  "fit_seconds": 0.649,
+  "fit_seconds": 1.024,
   "D": 2812,
   "V": 200,
-  "topic_deviation_top5": [
-    0.866691,
-    0.781331,
-    0.777506,
-    0.76504,
-    0.75532
+  "topic_prevalence_top5": [
+    0.973139,
+    0.012739,
+    0.01167,
+    0.001086,
+    0.000643
   ],
-  "generated_at": "2026-05-28T03:06:47Z",
+  "generated_at": "2026-06-09T06:38:29Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V20_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 3,
+  "N_eff_topics": 2.1558,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 13,
   "f2_c_v": 0.33251,
   "f14_mean_pairwise_jaccard": 0.003601,
-  "fit_seconds": 0.933,
+  "fit_seconds": 1.129,
   "D": 2812,
   "V": 1600,
-  "topic_deviation_top5": [
-    1.447426,
-    1.428825,
-    0.895903,
-    0.753146,
-    0.748457
+  "topic_prevalence_top5": [
+    0.686699,
+    0.281191,
+    0.019362,
+    0.005292,
+    0.003539
   ],
-  "generated_at": "2026-05-28T11:38:15Z",
+  "generated_at": "2026-06-09T06:38:56Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V2_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 4,
+  "N_eff_topics": 2.4267,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 12,
   "f2_c_v": 0.353531,
   "f14_mean_pairwise_jaccard": 1.0,
-  "fit_seconds": 3.331,
+  "fit_seconds": 4.004,
   "D": 2812,
   "V": 8,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.681731,
+    0.243617,
+    0.041913,
+    0.024461,
+    0.003568
   ],
-  "generated_at": "2026-05-27T03:33:50Z",
+  "generated_at": "2026-06-09T06:38:33Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V3_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 3,
+  "N_eff_topics": 1.3625,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 13,
   "f2_c_v": 0.297789,
   "f14_mean_pairwise_jaccard": 0.002493,
-  "fit_seconds": 1.183,
+  "fit_seconds": 1.169,
   "D": 2812,
   "V": 1600,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.949307,
+    0.014758,
+    0.011426,
+    0.005292,
+    0.004148
   ],
-  "generated_at": "2026-05-27T03:33:51Z",
+  "generated_at": "2026-06-09T06:38:34Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V4_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 1,
+  "N_eff_topics": 1.089,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 15,
   "f2_c_v": 0.318226,
   "f14_mean_pairwise_jaccard": 0.028325,
-  "fit_seconds": 1.142,
+  "fit_seconds": 1.329,
   "D": 2812,
   "V": 200,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.9891,
+    0.003357,
+    0.001395,
+    0.001304,
+    0.000967
   ],
-  "generated_at": "2026-05-27T03:33:52Z",
+  "generated_at": "2026-06-09T06:38:36Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V5_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 1,
+  "N_eff_topics": 1.0658,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 15,
   "f2_c_v": 0.316706,
   "f14_mean_pairwise_jaccard": 0.026694,
-  "fit_seconds": 1.246,
+  "fit_seconds": 1.202,
   "D": 2812,
   "V": 200,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.989562,
+    0.009312,
+    0.000312,
+    0.000306,
+    0.000181
   ],
-  "generated_at": "2026-05-27T03:33:54Z",
+  "generated_at": "2026-06-09T06:38:37Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V6_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 2.2837,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.314634,
   "f14_mean_pairwise_jaccard": 0.022499,
-  "fit_seconds": 2.587,
+  "fit_seconds": 2.961,
   "D": 2812,
   "V": 227,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.570485,
+    0.407371,
+    0.004665,
+    0.004388,
+    0.002866
   ],
-  "generated_at": "2026-05-27T03:33:56Z",
+  "generated_at": "2026-06-09T06:38:40Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V7_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9375,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.625962,
   "f14_mean_pairwise_jaccard": 0.028599,
-  "fit_seconds": 0.712,
+  "fit_seconds": 1.173,
   "D": 2812,
   "V": 171,
-  "topic_deviation_top5": [
-    0.789704,
-    0.781107,
-    0.762018,
-    0.757713,
-    0.741741
+  "topic_prevalence_top5": [
+    0.056901,
+    0.056049,
+    0.053206,
+    0.052815,
+    0.052246
   ],
-  "generated_at": "2026-05-28T03:06:48Z",
+  "generated_at": "2026-06-09T06:38:41Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V8_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.7335,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.277326,
   "f14_mean_pairwise_jaccard": 0.716268,
-  "fit_seconds": 1.557,
+  "fit_seconds": 1.487,
   "D": 2812,
   "V": 12,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.089243,
+    0.077992,
+    0.075342,
+    0.073287,
+    0.072484
   ],
-  "generated_at": "2026-05-27T03:33:59Z",
+  "generated_at": "2026-06-09T06:38:43Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/indian-pines-corrected_V9_uniform_Q8.json
@@ -7,6 +7,7 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9949,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.389174,
@@ -14,13 +15,13 @@
   "fit_seconds": 0.868,
   "D": 2812,
   "V": 536,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.052038,
+    0.051946,
+    0.051839,
+    0.051344,
+    0.050821
   ],
-  "generated_at": "2026-05-27T03:34:00Z",
+  "generated_at": "2026-06-09T06:38:44Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V10_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.6227,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.586446,
   "f14_mean_pairwise_jaccard": 0.266886,
-  "fit_seconds": 0.954,
+  "fit_seconds": 1.133,
   "D": 2686,
   "V": 24,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.07001,
+    0.069247,
+    0.06305,
+    0.058319,
+    0.055223
   ],
-  "generated_at": "2026-05-27T03:35:00Z",
+  "generated_at": "2026-06-09T06:40:24Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V11_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8936,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.494769,
   "f14_mean_pairwise_jaccard": 0.187296,
-  "fit_seconds": 0.984,
+  "fit_seconds": 0.919,
   "D": 2686,
   "V": 32,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.062085,
+    0.057788,
+    0.055526,
+    0.055128,
+    0.054197
   ],
-  "generated_at": "2026-05-27T03:35:01Z",
+  "generated_at": "2026-06-09T06:40:24Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V12_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 6,
+  "N_eff_topics": 4.1179,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.373537,
   "f14_mean_pairwise_jaccard": 0.007485,
-  "fit_seconds": 1.193,
+  "fit_seconds": 1.14,
   "D": 2686,
   "V": 1408,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.508472,
+    0.194253,
+    0.148003,
+    0.09759,
+    0.02288
   ],
-  "generated_at": "2026-05-27T03:35:03Z",
+  "generated_at": "2026-06-09T06:40:26Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V13_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.7565,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.297836,
   "f14_mean_pairwise_jaccard": 0.04506,
-  "fit_seconds": 2.188,
+  "fit_seconds": 1.165,
   "D": 2686,
   "V": 128,
-  "topic_deviation_top5": [
-    0.78723,
-    0.773451,
-    0.755567,
-    0.743337,
-    0.737221
+  "topic_prevalence_top5": [
+    0.061597,
+    0.061131,
+    0.059991,
+    0.058903,
+    0.057952
   ],
-  "generated_at": "2026-05-30T04:59:12Z",
+  "generated_at": "2026-06-09T06:40:27Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V14_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 17.1152,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.299509,
   "f14_mean_pairwise_jaccard": 0.006192,
-  "fit_seconds": 0.974,
+  "fit_seconds": 1.29,
   "D": 2686,
   "V": 1024,
-  "topic_deviation_top5": [
-    0.755034,
-    0.754731,
-    0.746577,
-    0.741946,
-    0.736437
+  "topic_prevalence_top5": [
+    0.139256,
+    0.097416,
+    0.086717,
+    0.076847,
+    0.067575
   ],
-  "generated_at": "2026-05-28T11:38:23Z",
+  "generated_at": "2026-06-09T06:40:28Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V15_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9122,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
-  "f2_c_v": 0.38409,
-  "f14_mean_pairwise_jaccard": 0.120075,
-  "fit_seconds": 1.983,
+  "f2_c_v": 0.469521,
+  "f14_mean_pairwise_jaccard": 0.025773,
+  "fit_seconds": 0.875,
   "D": 2686,
-  "V": 48,
-  "topic_deviation_top5": [
-    0.852622,
-    0.827616,
-    0.799903,
-    0.784104,
-    0.77759
+  "V": 192,
+  "topic_prevalence_top5": [
+    0.062905,
+    0.054685,
+    0.053938,
+    0.053792,
+    0.053656
   ],
-  "generated_at": "2026-05-30T04:59:14Z",
+  "generated_at": "2026-06-09T06:40:29Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V17_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9905,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.558719,
   "f14_mean_pairwise_jaccard": 0.010619,
-  "fit_seconds": 1.978,
+  "fit_seconds": 0.838,
   "D": 2686,
   "V": 512,
-  "topic_deviation_top5": [
-    0.753933,
-    0.75052,
-    0.748307,
-    0.745195,
-    0.744458
+  "topic_prevalence_top5": [
+    0.053077,
+    0.052904,
+    0.052445,
+    0.051436,
+    0.050838
   ],
-  "generated_at": "2026-05-30T04:59:16Z",
+  "generated_at": "2026-06-09T06:40:30Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V18_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.6228,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.389822,
   "f14_mean_pairwise_jaccard": 0.045041,
-  "fit_seconds": 0.935,
+  "fit_seconds": 1.223,
   "D": 2686,
   "V": 128,
-  "topic_deviation_top5": [
-    0.776602,
-    0.762887,
-    0.741743,
-    0.738353,
-    0.731889
+  "topic_prevalence_top5": [
+    0.090303,
+    0.084785,
+    0.082691,
+    0.07057,
+    0.062909
   ],
-  "generated_at": "2026-05-28T11:38:24Z",
+  "generated_at": "2026-06-09T06:40:31Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V19_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8309,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.399349,
   "f14_mean_pairwise_jaccard": 0.26882,
-  "fit_seconds": 2.266,
+  "fit_seconds": 1.026,
   "D": 2686,
   "V": 24,
-  "topic_deviation_top5": [
-    0.913136,
-    0.846468,
-    0.823231,
-    0.8197,
-    0.800115
+  "topic_prevalence_top5": [
+    0.062906,
+    0.060084,
+    0.059259,
+    0.057759,
+    0.056273
   ],
-  "generated_at": "2026-05-30T04:59:19Z",
+  "generated_at": "2026-06-09T06:40:32Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V1_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.6221,
   "K_ground_truth_classes": 13,
-  "f16_model_selection_adequacy": 7,
+  "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.728809,
   "f14_mean_pairwise_jaccard": 0.027471,
-  "fit_seconds": 0.993,
+  "fit_seconds": 1.426,
   "D": 2686,
   "V": 176,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.863274,
+    0.122621,
+    0.001306,
+    0.001301,
+    0.001252
   ],
-  "generated_at": "2026-05-27T03:34:48Z",
+  "generated_at": "2026-06-09T06:40:06Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V20_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 9,
+  "N_eff_topics": 5.7541,
   "K_ground_truth_classes": 13,
-  "f16_model_selection_adequacy": 7,
+  "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.537211,
   "f14_mean_pairwise_jaccard": 0.008826,
-  "fit_seconds": 0.719,
+  "fit_seconds": 0.992,
   "D": 2686,
   "V": 1408,
-  "topic_deviation_top5": [
-    1.485392,
-    1.158504,
-    1.14236,
-    0.993199,
-    0.888524
+  "topic_prevalence_top5": [
+    0.433182,
+    0.200536,
+    0.134516,
+    0.06343,
+    0.05159
   ],
-  "generated_at": "2026-05-28T11:38:24Z",
+  "generated_at": "2026-06-09T06:40:33Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V2_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 11,
+  "N_eff_topics": 6.3421,
   "K_ground_truth_classes": 13,
-  "f16_model_selection_adequacy": 7,
+  "f16_model_selection_adequacy": 2,
   "f2_c_v": 0.763586,
   "f14_mean_pairwise_jaccard": 1.0,
-  "fit_seconds": 2.47,
+  "fit_seconds": 3.452,
   "D": 2686,
   "V": 8,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.399254,
+    0.281774,
+    0.046751,
+    0.04579,
+    0.044938
   ],
-  "generated_at": "2026-05-27T03:34:51Z",
+  "generated_at": "2026-06-09T06:40:09Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V3_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 6,
+  "N_eff_topics": 3.7464,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.35708,
   "f14_mean_pairwise_jaccard": 0.004771,
-  "fit_seconds": 1.357,
+  "fit_seconds": 1.924,
   "D": 2686,
   "V": 1408,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.557124,
+    0.190785,
+    0.169687,
+    0.027397,
+    0.016664
   ],
-  "generated_at": "2026-05-27T03:34:52Z",
+  "generated_at": "2026-06-09T06:40:11Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V4_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.1963,
   "K_ground_truth_classes": 13,
-  "f16_model_selection_adequacy": 7,
+  "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.772501,
   "f14_mean_pairwise_jaccard": 0.027779,
-  "fit_seconds": 1.151,
+  "fit_seconds": 1.521,
   "D": 2686,
   "V": 176,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.963037,
+    0.033238,
+    0.001147,
+    0.000383,
+    0.00028
   ],
-  "generated_at": "2026-05-27T03:34:53Z",
+  "generated_at": "2026-06-09T06:40:13Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V5_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 1,
+  "N_eff_topics": 1.072,
   "K_ground_truth_classes": 13,
-  "f16_model_selection_adequacy": 7,
+  "f16_model_selection_adequacy": 12,
   "f2_c_v": 0.963422,
   "f14_mean_pairwise_jaccard": 0.027779,
-  "fit_seconds": 1.059,
+  "fit_seconds": 1.326,
   "D": 2686,
   "V": 176,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.991118,
+    0.004365,
+    0.000527,
+    0.000374,
+    0.000372
   ],
-  "generated_at": "2026-05-27T03:34:54Z",
+  "generated_at": "2026-06-09T06:40:15Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V6_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 5,
+  "N_eff_topics": 1.9423,
   "K_ground_truth_classes": 13,
-  "f16_model_selection_adequacy": 7,
+  "f16_model_selection_adequacy": 8,
   "f2_c_v": 0.311275,
   "f14_mean_pairwise_jaccard": 0.030261,
-  "fit_seconds": 2.22,
+  "fit_seconds": 4.009,
   "D": 2686,
   "V": 202,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.879704,
+    0.030227,
+    0.01882,
+    0.012809,
+    0.010106
   ],
-  "generated_at": "2026-05-27T03:34:57Z",
+  "generated_at": "2026-06-09T06:40:19Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V7_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8885,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.609697,
   "f14_mean_pairwise_jaccard": 0.019955,
-  "fit_seconds": 1.059,
+  "fit_seconds": 1.378,
   "D": 2686,
   "V": 280,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.062172,
+    0.060902,
+    0.056491,
+    0.053317,
+    0.053184
   ],
-  "generated_at": "2026-05-27T03:34:58Z",
+  "generated_at": "2026-06-09T06:40:20Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V8_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 19,
+  "N_eff_topics": 15.7317,
   "K_ground_truth_classes": 13,
-  "f16_model_selection_adequacy": 7,
+  "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.482148,
   "f14_mean_pairwise_jaccard": 0.71882,
-  "fit_seconds": 1.013,
+  "fit_seconds": 1.306,
   "D": 2686,
   "V": 12,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.158567,
+    0.105462,
+    0.093982,
+    0.076467,
+    0.071601
   ],
-  "generated_at": "2026-05-27T03:34:59Z",
+  "generated_at": "2026-06-09T06:40:21Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/kennedy-space-center_V9_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9968,
   "K_ground_truth_classes": 13,
   "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.298628,
   "f14_mean_pairwise_jaccard": 0.008895,
-  "fit_seconds": 0.716,
+  "fit_seconds": 0.995,
   "D": 2686,
   "V": 528,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.051818,
+    0.051744,
+    0.051424,
+    0.050667,
+    0.050639
   ],
-  "generated_at": "2026-05-27T03:35:00Z",
+  "generated_at": "2026-06-09T06:40:22Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V10_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.7788,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.316228,
   "f14_mean_pairwise_jaccard": 0.266992,
-  "fit_seconds": 0.733,
+  "fit_seconds": 0.691,
   "D": 1980,
   "V": 24,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.06129,
+    0.060563,
+    0.060245,
+    0.05931,
+    0.058389
   ],
-  "generated_at": "2026-05-27T03:34:45Z",
+  "generated_at": "2026-06-09T06:39:54Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V11_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.962,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.485253,
   "f14_mean_pairwise_jaccard": 0.1877,
-  "fit_seconds": 0.737,
+  "fit_seconds": 0.606,
   "D": 1980,
   "V": 32,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.056547,
+    0.05362,
+    0.053504,
+    0.053009,
+    0.052923
   ],
-  "generated_at": "2026-05-27T03:34:46Z",
+  "generated_at": "2026-06-09T06:39:54Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V12_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 8,
+  "N_eff_topics": 6.1523,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 1,
   "f2_c_v": 0.428419,
   "f14_mean_pairwise_jaccard": 0.006746,
-  "fit_seconds": 0.867,
+  "fit_seconds": 1.683,
   "D": 1980,
   "V": 824,
-  "topic_deviation_top5": [
-    0.78102,
-    0.775626,
-    0.763214,
-    0.757975,
-    0.750375
+  "topic_prevalence_top5": [
+    0.350852,
+    0.234134,
+    0.220796,
+    0.050689,
+    0.035226
   ],
-  "generated_at": "2026-05-28T03:06:50Z",
+  "generated_at": "2026-06-09T06:39:56Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V13_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8993,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.35661,
   "f14_mean_pairwise_jaccard": 0.04506,
-  "fit_seconds": 1.531,
+  "fit_seconds": 0.885,
   "D": 1980,
   "V": 128,
-  "topic_deviation_top5": [
-    0.78757,
-    0.775297,
-    0.756742,
-    0.744786,
-    0.739645
+  "topic_prevalence_top5": [
+    0.061195,
+    0.058316,
+    0.057048,
+    0.054852,
+    0.054585
   ],
-  "generated_at": "2026-05-30T04:59:06Z",
+  "generated_at": "2026-06-09T06:39:57Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V14_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.3359,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.301601,
   "f14_mean_pairwise_jaccard": 0.004155,
-  "fit_seconds": 0.682,
+  "fit_seconds": 1.024,
   "D": 1980,
   "V": 1024,
-  "topic_deviation_top5": [
-    0.758078,
-    0.753128,
-    0.751592,
-    0.742679,
-    0.737293
+  "topic_prevalence_top5": [
+    0.131337,
+    0.073762,
+    0.067823,
+    0.067103,
+    0.062152
   ],
-  "generated_at": "2026-05-28T11:38:21Z",
+  "generated_at": "2026-06-09T06:39:58Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V15_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9716,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
-  "f2_c_v": 0.392838,
-  "f14_mean_pairwise_jaccard": 0.26882,
-  "fit_seconds": 1.25,
+  "f2_c_v": 0.600029,
+  "f14_mean_pairwise_jaccard": 0.063539,
+  "fit_seconds": 0.638,
   "D": 1980,
-  "V": 24,
-  "topic_deviation_top5": [
-    0.913562,
-    0.846942,
-    0.823538,
-    0.819568,
-    0.80029
+  "V": 96,
+  "topic_prevalence_top5": [
+    0.057158,
+    0.054268,
+    0.052231,
+    0.051624,
+    0.051546
   ],
-  "generated_at": "2026-05-30T04:59:07Z",
+  "generated_at": "2026-06-09T06:39:59Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V17_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9921,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.608566,
   "f14_mean_pairwise_jaccard": 0.010619,
-  "fit_seconds": 1.607,
+  "fit_seconds": 1.178,
   "D": 1980,
   "V": 512,
-  "topic_deviation_top5": [
-    0.754456,
-    0.751078,
-    0.748769,
-    0.745829,
-    0.744811
+  "topic_prevalence_top5": [
+    0.052583,
+    0.052253,
+    0.052013,
+    0.052,
+    0.051459
   ],
-  "generated_at": "2026-05-30T04:59:08Z",
+  "generated_at": "2026-06-09T06:40:00Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V18_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.9889,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.460215,
   "f14_mean_pairwise_jaccard": 0.046439,
-  "fit_seconds": 0.646,
+  "fit_seconds": 2.212,
   "D": 1980,
   "V": 128,
-  "topic_deviation_top5": [
-    0.781922,
-    0.770461,
-    0.748993,
-    0.73923,
-    0.734028
+  "topic_prevalence_top5": [
+    0.089859,
+    0.079049,
+    0.076996,
+    0.062811,
+    0.057016
   ],
-  "generated_at": "2026-05-28T11:38:21Z",
+  "generated_at": "2026-06-09T06:40:02Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V19_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9692,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.505885,
   "f14_mean_pairwise_jaccard": 0.266886,
-  "fit_seconds": 1.625,
+  "fit_seconds": 0.989,
   "D": 1980,
   "V": 24,
-  "topic_deviation_top5": [
-    0.913875,
-    0.846945,
-    0.824385,
-    0.819588,
-    0.800427
+  "topic_prevalence_top5": [
+    0.0543,
+    0.054007,
+    0.053008,
+    0.052912,
+    0.052672
   ],
-  "generated_at": "2026-05-30T04:59:10Z",
+  "generated_at": "2026-06-09T06:40:03Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V1_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 5,
+  "N_eff_topics": 3.6603,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.692828,
   "f14_mean_pairwise_jaccard": 0.047823,
-  "fit_seconds": 0.49,
+  "fit_seconds": 0.824,
   "D": 1980,
   "V": 103,
-  "topic_deviation_top5": [
-    0.802042,
-    0.7956,
-    0.780744,
-    0.768431,
-    0.768424
+  "topic_prevalence_top5": [
+    0.413336,
+    0.411231,
+    0.108454,
+    0.023057,
+    0.010342
   ],
-  "generated_at": "2026-05-28T03:06:49Z",
+  "generated_at": "2026-06-09T06:39:43Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V20_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 6,
+  "N_eff_topics": 5.7427,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 3,
   "f2_c_v": 0.420069,
   "f14_mean_pairwise_jaccard": 0.008341,
-  "fit_seconds": 0.422,
+  "fit_seconds": 0.951,
   "D": 1980,
   "V": 824,
-  "topic_deviation_top5": [
-    1.057538,
-    1.014297,
-    0.955818,
-    0.827361,
-    0.731905
+  "topic_prevalence_top5": [
+    0.36068,
+    0.271361,
+    0.160057,
+    0.10522,
+    0.018535
   ],
-  "generated_at": "2026-05-28T11:38:22Z",
+  "generated_at": "2026-06-09T06:40:04Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V2_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 13,
+  "N_eff_topics": 10.0418,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.432289,
   "f14_mean_pairwise_jaccard": 1.0,
-  "fit_seconds": 1.984,
+  "fit_seconds": 2.133,
   "D": 1980,
   "V": 8,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.223182,
+    0.210653,
+    0.150045,
+    0.081909,
+    0.072588
   ],
-  "generated_at": "2026-05-27T03:34:37Z",
+  "generated_at": "2026-06-09T06:39:45Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V3_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 10,
+  "N_eff_topics": 7.2213,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 1,
   "f2_c_v": 0.319819,
   "f14_mean_pairwise_jaccard": 0.007818,
-  "fit_seconds": 1.589,
+  "fit_seconds": 1.627,
   "D": 1980,
   "V": 824,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.385946,
+    0.196217,
+    0.111201,
+    0.10617,
+    0.041757
   ],
-  "generated_at": "2026-05-27T03:34:38Z",
+  "generated_at": "2026-06-09T06:39:47Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V4_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 3,
+  "N_eff_topics": 1.5326,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 6,
   "f2_c_v": 0.609879,
   "f14_mean_pairwise_jaccard": 0.048567,
-  "fit_seconds": 0.9,
+  "fit_seconds": 0.881,
   "D": 1980,
   "V": 103,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.929698,
+    0.014589,
+    0.013651,
+    0.008624,
+    0.008164
   ],
-  "generated_at": "2026-05-27T03:34:39Z",
+  "generated_at": "2026-06-09T06:39:48Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V5_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 4,
+  "N_eff_topics": 1.7768,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 5,
   "f2_c_v": 0.395372,
   "f14_mean_pairwise_jaccard": 0.047946,
-  "fit_seconds": 0.905,
+  "fit_seconds": 0.933,
   "D": 1980,
   "V": 103,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.886151,
+    0.046181,
+    0.028496,
+    0.01004,
+    0.004147
   ],
-  "generated_at": "2026-05-27T03:34:40Z",
+  "generated_at": "2026-06-09T06:39:49Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V6_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.2893,
   "K_ground_truth_classes": 9,
-  "f16_model_selection_adequacy": 11,
+  "f16_model_selection_adequacy": 7,
   "f2_c_v": 0.329123,
   "f14_mean_pairwise_jaccard": 0.039105,
-  "fit_seconds": 1.451,
+  "fit_seconds": 1.408,
   "D": 1980,
   "V": 131,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.961808,
+    0.012426,
+    0.004107,
+    0.003689,
+    0.002617
   ],
-  "generated_at": "2026-05-27T03:34:42Z",
+  "generated_at": "2026-06-09T06:39:50Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V7_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9346,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.578618,
   "f14_mean_pairwise_jaccard": 0.030328,
-  "fit_seconds": 0.551,
+  "fit_seconds": 0.867,
   "D": 1980,
   "V": 197,
-  "topic_deviation_top5": [
-    0.773601,
-    0.76828,
-    0.754102,
-    0.753629,
-    0.752043
+  "topic_prevalence_top5": [
+    0.059502,
+    0.057901,
+    0.05527,
+    0.053164,
+    0.05228
   ],
-  "generated_at": "2026-05-28T03:06:50Z",
+  "generated_at": "2026-06-09T06:39:51Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V8_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.0624,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.205501,
   "f14_mean_pairwise_jaccard": 1.0,
-  "fit_seconds": 0.905,
+  "fit_seconds": 0.997,
   "D": 1980,
   "V": 9,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.09751,
+    0.068623,
+    0.062226,
+    0.058343,
+    0.057033
   ],
-  "generated_at": "2026-05-27T03:34:43Z",
+  "generated_at": "2026-06-09T06:39:52Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/pavia-university_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/pavia-university_V9_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9956,
   "K_ground_truth_classes": 9,
   "f16_model_selection_adequacy": 11,
   "f2_c_v": 0.277578,
   "f14_mean_pairwise_jaccard": 0.003601,
-  "fit_seconds": 0.647,
+  "fit_seconds": 0.664,
   "D": 1980,
   "V": 1728,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.051684,
+    0.051541,
+    0.05134,
+    0.051018,
+    0.05096
   ],
-  "generated_at": "2026-05-27T03:34:44Z",
+  "generated_at": "2026-06-09T06:39:53Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V10_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.5778,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.29321,
   "f14_mean_pairwise_jaccard": 0.266992,
-  "fit_seconds": 0.316,
+  "fit_seconds": 0.314,
   "D": 1320,
   "V": 24,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.069577,
+    0.069495,
+    0.069123,
+    0.065376,
+    0.056397
   ],
-  "generated_at": "2026-05-27T03:34:33Z",
+  "generated_at": "2026-06-09T06:39:36Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V11_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9364,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.545508,
   "f14_mean_pairwise_jaccard": 0.1877,
-  "fit_seconds": 0.521,
+  "fit_seconds": 0.525,
   "D": 1320,
   "V": 32,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.058146,
+    0.057522,
+    0.056328,
+    0.052923,
+    0.052051
   ],
-  "generated_at": "2026-05-27T03:34:33Z",
+  "generated_at": "2026-06-09T06:39:37Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V12_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 4,
+  "N_eff_topics": 2.8655,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 2,
   "f2_c_v": 0.326886,
   "f14_mean_pairwise_jaccard": 0.003601,
-  "fit_seconds": 0.645,
+  "fit_seconds": 0.553,
   "D": 1320,
   "V": 1632,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.531617,
+    0.349987,
+    0.086873,
+    0.025822,
+    0.001222
   ],
-  "generated_at": "2026-05-27T03:34:34Z",
+  "generated_at": "2026-06-09T06:39:37Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V13_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.5563,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.301863,
   "f14_mean_pairwise_jaccard": 0.04506,
-  "fit_seconds": 0.4,
+  "fit_seconds": 0.422,
   "D": 1320,
   "V": 128,
-  "topic_deviation_top5": [
-    0.788401,
-    0.776523,
-    0.756678,
-    0.747147,
-    0.741997
+  "topic_prevalence_top5": [
+    0.082881,
+    0.071246,
+    0.060521,
+    0.060204,
+    0.054886
   ],
-  "generated_at": "2026-05-30T04:59:01Z",
+  "generated_at": "2026-06-09T06:39:38Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V14_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 19,
+  "N_eff_topics": 14.2872,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 13,
   "f2_c_v": 0.309095,
   "f14_mean_pairwise_jaccard": 0.005263,
-  "fit_seconds": 0.696,
+  "fit_seconds": 0.967,
   "D": 1320,
   "V": 1024,
-  "topic_deviation_top5": [
-    0.761129,
-    0.758108,
-    0.749326,
-    0.746985,
-    0.745121
+  "topic_prevalence_top5": [
+    0.239956,
+    0.108491,
+    0.074482,
+    0.064716,
+    0.054795
   ],
-  "generated_at": "2026-05-28T11:38:19Z",
+  "generated_at": "2026-06-09T06:39:39Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V15_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8745,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
-  "f2_c_v": 0.408613,
-  "f14_mean_pairwise_jaccard": 0.120075,
-  "fit_seconds": 0.499,
+  "f2_c_v": 0.413571,
+  "f14_mean_pairwise_jaccard": 0.026111,
+  "fit_seconds": 0.798,
   "D": 1320,
-  "V": 48,
-  "topic_deviation_top5": [
-    0.854341,
-    0.832523,
-    0.80326,
-    0.78874,
-    0.779682
+  "V": 192,
+  "topic_prevalence_top5": [
+    0.058829,
+    0.058781,
+    0.057391,
+    0.057139,
+    0.0553
   ],
-  "generated_at": "2026-05-30T04:59:02Z",
+  "generated_at": "2026-06-09T06:39:40Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V17_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9864,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.552889,
   "f14_mean_pairwise_jaccard": 0.010619,
-  "fit_seconds": 0.971,
+  "fit_seconds": 0.687,
   "D": 1320,
   "V": 512,
-  "topic_deviation_top5": [
-    0.755745,
-    0.752208,
-    0.749884,
-    0.746978,
-    0.745983
+  "topic_prevalence_top5": [
+    0.052481,
+    0.052127,
+    0.052027,
+    0.052018,
+    0.051691
   ],
-  "generated_at": "2026-05-30T04:59:03Z",
+  "generated_at": "2026-06-09T06:39:40Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V18_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 17.8602,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.426544,
   "f14_mean_pairwise_jaccard": 0.045577,
-  "fit_seconds": 0.486,
+  "fit_seconds": 0.737,
   "D": 1320,
   "V": 128,
-  "topic_deviation_top5": [
-    0.783032,
-    0.77265,
-    0.749733,
-    0.741555,
-    0.737427
+  "topic_prevalence_top5": [
+    0.097427,
+    0.095906,
+    0.088071,
+    0.087513,
+    0.060771
   ],
-  "generated_at": "2026-05-28T11:38:19Z",
+  "generated_at": "2026-06-09T06:39:41Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V19_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9147,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.50478,
   "f14_mean_pairwise_jaccard": 0.266886,
-  "fit_seconds": 0.933,
+  "fit_seconds": 0.41,
   "D": 1320,
   "V": 24,
-  "topic_deviation_top5": [
-    0.914388,
-    0.847214,
-    0.825058,
-    0.820801,
-    0.801896
+  "topic_prevalence_top5": [
+    0.057912,
+    0.05702,
+    0.05621,
+    0.055262,
+    0.054981
   ],
-  "generated_at": "2026-05-30T04:59:04Z",
+  "generated_at": "2026-06-09T06:39:42Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V1_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.2014,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.566099,
   "f14_mean_pairwise_jaccard": 0.028327,
-  "fit_seconds": 0.5,
+  "fit_seconds": 0.472,
   "D": 1320,
   "V": 204,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.962155,
+    0.033553,
+    0.000863,
+    0.000861,
+    0.000689
   ],
-  "generated_at": "2026-05-27T03:34:26Z",
+  "generated_at": "2026-06-09T06:39:30Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V20_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 4,
+  "N_eff_topics": 3.1151,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 2,
   "f2_c_v": 0.349237,
   "f14_mean_pairwise_jaccard": 0.003416,
-  "fit_seconds": 0.386,
+  "fit_seconds": 0.612,
   "D": 1320,
   "V": 1632,
-  "topic_deviation_top5": [
-    1.44561,
-    1.356849,
-    1.212626,
-    0.898289,
-    0.757507
+  "topic_prevalence_top5": [
+    0.44478,
+    0.420785,
+    0.086384,
+    0.032536,
+    0.008014
   ],
-  "generated_at": "2026-05-28T11:38:20Z",
+  "generated_at": "2026-06-09T06:39:42Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V2_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 6,
+  "N_eff_topics": 4.6004,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 0,
   "f2_c_v": 0.353553,
   "f14_mean_pairwise_jaccard": 1.0,
   "fit_seconds": 1.127,
   "D": 1320,
   "V": 8,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.355571,
+    0.31369,
+    0.178459,
+    0.081649,
+    0.032624
   ],
-  "generated_at": "2026-05-27T03:34:27Z",
+  "generated_at": "2026-06-09T06:39:31Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V3_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 5,
+  "N_eff_topics": 3.1379,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 1,
   "f2_c_v": 0.312749,
   "f14_mean_pairwise_jaccard": 0.003324,
-  "fit_seconds": 0.618,
+  "fit_seconds": 0.647,
   "D": 1320,
   "V": 1632,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.472259,
+    0.41181,
+    0.06284,
+    0.022554,
+    0.014036
   ],
-  "generated_at": "2026-05-27T03:34:28Z",
+  "generated_at": "2026-06-09T06:39:32Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V4_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 1,
+  "N_eff_topics": 1.0866,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 5,
   "f2_c_v": 0.316228,
   "f14_mean_pairwise_jaccard": 0.028851,
-  "fit_seconds": 0.558,
+  "fit_seconds": 0.625,
   "D": 1320,
   "V": 204,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.988587,
+    0.005456,
+    0.001248,
+    0.001044,
+    0.000922
   ],
-  "generated_at": "2026-05-27T03:34:29Z",
+  "generated_at": "2026-06-09T06:39:32Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V5_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.299,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.316228,
   "f14_mean_pairwise_jaccard": 0.029712,
-  "fit_seconds": 0.672,
+  "fit_seconds": 0.572,
   "D": 1320,
   "V": 204,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.930144,
+    0.068571,
+    0.000588,
+    0.000319,
+    0.000173
   ],
-  "generated_at": "2026-05-27T03:34:29Z",
+  "generated_at": "2026-06-09T06:39:33Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V6_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 9,
+  "N_eff_topics": 3.5727,
   "K_ground_truth_classes": 6,
-  "f16_model_selection_adequacy": 14,
+  "f16_model_selection_adequacy": 3,
   "f2_c_v": 0.342234,
   "f14_mean_pairwise_jaccard": 0.019802,
-  "fit_seconds": 1.417,
+  "fit_seconds": 1.213,
   "D": 1320,
   "V": 230,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.731811,
+    0.065808,
+    0.030785,
+    0.023665,
+    0.021624
   ],
-  "generated_at": "2026-05-27T03:34:31Z",
+  "generated_at": "2026-06-09T06:39:34Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V7_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.852,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.624057,
   "f14_mean_pairwise_jaccard": 0.04835,
-  "fit_seconds": 0.641,
+  "fit_seconds": 0.552,
   "D": 1320,
   "V": 116,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.062651,
+    0.061196,
+    0.059757,
+    0.057492,
+    0.055651
   ],
-  "generated_at": "2026-05-27T03:34:31Z",
+  "generated_at": "2026-06-09T06:39:35Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V8_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 16.6519,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.384315,
   "f14_mean_pairwise_jaccard": 1.0,
-  "fit_seconds": 0.478,
+  "fit_seconds": 0.549,
   "D": 1320,
   "V": 6,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.092236,
+    0.091726,
+    0.090116,
+    0.087256,
+    0.083484
   ],
-  "generated_at": "2026-05-27T03:34:32Z",
+  "generated_at": "2026-06-09T06:39:35Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-a-corrected_V9_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9741,
   "K_ground_truth_classes": 6,
   "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.45593,
   "f14_mean_pairwise_jaccard": 0.046977,
-  "fit_seconds": 0.356,
+  "fit_seconds": 0.36,
   "D": 1320,
   "V": 112,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.05407,
+    0.05392,
+    0.053558,
+    0.052937,
+    0.052611
   ],
-  "generated_at": "2026-05-27T03:34:32Z",
+  "generated_at": "2026-06-09T06:39:36Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V10_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V10_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.306,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.298138,
   "f14_mean_pairwise_jaccard": 0.26943,
-  "fit_seconds": 1.743,
+  "fit_seconds": 1.619,
   "D": 3520,
   "V": 24,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.07684,
+    0.076776,
+    0.075595,
+    0.06888,
+    0.057253
   ],
-  "generated_at": "2026-05-27T03:34:22Z",
+  "generated_at": "2026-06-09T06:39:15Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V11_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V11_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9356,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.521944,
   "f14_mean_pairwise_jaccard": 0.1877,
-  "fit_seconds": 1.509,
+  "fit_seconds": 1.475,
   "D": 3520,
   "V": 32,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.057785,
+    0.056378,
+    0.055446,
+    0.053888,
+    0.053578
   ],
-  "generated_at": "2026-05-27T03:34:24Z",
+  "generated_at": "2026-06-09T06:39:17Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V12_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V12_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.2243,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.277461,
   "f14_mean_pairwise_jaccard": 0.003601,
-  "fit_seconds": 1.675,
+  "fit_seconds": 1.608,
   "D": 3520,
   "V": 1632,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.962068,
+    0.024278,
+    0.009743,
+    0.001195,
+    0.000785
   ],
-  "generated_at": "2026-05-27T03:34:26Z",
+  "generated_at": "2026-06-09T06:39:18Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V13_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V13_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8763,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.307551,
   "f14_mean_pairwise_jaccard": 0.044783,
-  "fit_seconds": 1.204,
+  "fit_seconds": 1.485,
   "D": 3520,
   "V": 128,
-  "topic_deviation_top5": [
-    0.787988,
-    0.773016,
-    0.754377,
-    0.744629,
-    0.739061
+  "topic_prevalence_top5": [
+    0.05957,
+    0.059052,
+    0.056481,
+    0.056223,
+    0.052742
   ],
-  "generated_at": "2026-05-30T04:58:57Z",
+  "generated_at": "2026-06-09T06:39:20Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V14_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V14_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 16.7068,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.337438,
   "f14_mean_pairwise_jaccard": 0.006987,
-  "fit_seconds": 1.1,
+  "fit_seconds": 1.61,
   "D": 3520,
   "V": 1024,
-  "topic_deviation_top5": [
-    0.777425,
-    0.754135,
-    0.75365,
-    0.750074,
-    0.742358
+  "topic_prevalence_top5": [
+    0.164496,
+    0.105211,
+    0.081387,
+    0.061171,
+    0.05301
   ],
-  "generated_at": "2026-05-28T11:38:16Z",
+  "generated_at": "2026-06-09T06:39:22Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V15_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V15_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9142,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
-  "f2_c_v": 0.453143,
-  "f14_mean_pairwise_jaccard": 0.120075,
-  "fit_seconds": 1.042,
+  "f2_c_v": 0.568016,
+  "f14_mean_pairwise_jaccard": 0.02587,
+  "fit_seconds": 1.307,
   "D": 3520,
-  "V": 48,
-  "topic_deviation_top5": [
-    0.851243,
-    0.825184,
-    0.795462,
-    0.784416,
-    0.774766
+  "V": 192,
+  "topic_prevalence_top5": [
+    0.063827,
+    0.055853,
+    0.052825,
+    0.052789,
+    0.052694
   ],
-  "generated_at": "2026-05-30T04:58:58Z",
+  "generated_at": "2026-06-09T06:39:23Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V17_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V17_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9948,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.587808,
   "f14_mean_pairwise_jaccard": 0.010619,
-  "fit_seconds": 1.089,
+  "fit_seconds": 1.328,
   "D": 3520,
   "V": 512,
-  "topic_deviation_top5": [
-    0.753677,
-    0.750477,
-    0.748209,
-    0.745176,
-    0.744057
+  "topic_prevalence_top5": [
+    0.052146,
+    0.051332,
+    0.051293,
+    0.051244,
+    0.051063
   ],
-  "generated_at": "2026-05-30T04:59:00Z",
+  "generated_at": "2026-06-09T06:39:24Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V18_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V18_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.0319,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.446411,
   "f14_mean_pairwise_jaccard": 0.047489,
-  "fit_seconds": 1.256,
+  "fit_seconds": 1.78,
   "D": 3520,
   "V": 128,
-  "topic_deviation_top5": [
-    0.777353,
-    0.76217,
-    0.743152,
-    0.734697,
-    0.731376
+  "topic_prevalence_top5": [
+    0.124688,
+    0.074689,
+    0.070199,
+    0.065776,
+    0.065032
   ],
-  "generated_at": "2026-05-28T11:38:17Z",
+  "generated_at": "2026-06-09T06:39:26Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V19_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V19_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.8886,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.552273,
   "f14_mean_pairwise_jaccard": 0.266886,
-  "fit_seconds": 1.533,
+  "fit_seconds": 1.614,
   "D": 3520,
   "V": 24,
-  "topic_deviation_top5": [
-    0.912693,
-    0.845029,
-    0.824522,
-    0.818753,
-    0.800525
+  "topic_prevalence_top5": [
+    0.060541,
+    0.057308,
+    0.05679,
+    0.056237,
+    0.055116
   ],
-  "generated_at": "2026-05-30T04:59:01Z",
+  "generated_at": "2026-06-09T06:39:28Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V1_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V1_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 1,
+  "N_eff_topics": 1.0489,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 15,
   "f2_c_v": 0.443509,
   "f14_mean_pairwise_jaccard": 0.028327,
-  "fit_seconds": 1.34,
+  "fit_seconds": 1.258,
   "D": 3520,
   "V": 204,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.992519,
+    0.006775,
+    0.000193,
+    0.000188,
+    0.000117
   ],
-  "generated_at": "2026-05-27T03:34:05Z",
+  "generated_at": "2026-06-09T06:38:57Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V20_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V20_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 3,
+  "N_eff_topics": 3.0203,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 13,
   "f2_c_v": 0.354543,
   "f14_mean_pairwise_jaccard": 0.004253,
-  "fit_seconds": 1.046,
+  "fit_seconds": 1.423,
   "D": 3520,
   "V": 1632,
-  "topic_deviation_top5": [
-    1.550013,
-    1.540066,
-    1.406446,
-    0.757528,
-    0.747273
+  "topic_prevalence_top5": [
+    0.412881,
+    0.344492,
+    0.23738,
+    0.004202,
+    0.000582
   ],
-  "generated_at": "2026-05-28T11:38:18Z",
+  "generated_at": "2026-06-09T06:39:29Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V2_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V2_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 6,
+  "N_eff_topics": 4.3783,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 10,
   "f2_c_v": 0.353553,
   "f14_mean_pairwise_jaccard": 1.0,
-  "fit_seconds": 3.124,
+  "fit_seconds": 3.006,
   "D": 3520,
   "V": 8,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.387079,
+    0.271494,
+    0.200795,
+    0.081036,
+    0.031564
   ],
-  "generated_at": "2026-05-27T03:34:08Z",
+  "generated_at": "2026-06-09T06:39:00Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V3_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V3_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 2.1266,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.290667,
   "f14_mean_pairwise_jaccard": 0.003047,
-  "fit_seconds": 1.648,
+  "fit_seconds": 1.738,
   "D": 3520,
   "V": 1632,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.685494,
+    0.289631,
+    0.007347,
+    0.007159,
+    0.004355
   ],
-  "generated_at": "2026-05-27T03:34:10Z",
+  "generated_at": "2026-06-09T06:39:02Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V4_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V4_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 1,
+  "N_eff_topics": 1.0669,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 15,
   "f2_c_v": 0.316228,
   "f14_mean_pairwise_jaccard": 0.029466,
-  "fit_seconds": 1.426,
+  "fit_seconds": 1.482,
   "D": 3520,
   "V": 204,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.990258,
+    0.004827,
+    0.004228,
+    0.000237,
+    0.000186
   ],
-  "generated_at": "2026-05-27T03:34:11Z",
+  "generated_at": "2026-06-09T06:39:04Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V5_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V5_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 2,
+  "N_eff_topics": 1.2033,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 14,
   "f2_c_v": 0.316228,
   "f14_mean_pairwise_jaccard": 0.029466,
-  "fit_seconds": 1.669,
+  "fit_seconds": 1.765,
   "D": 3520,
   "V": 204,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.955723,
+    0.043784,
+    0.000141,
+    0.000101,
+    7.4e-05
   ],
-  "generated_at": "2026-05-27T03:34:13Z",
+  "generated_at": "2026-06-09T06:39:06Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V6_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V6_uniform_Q8.json
@@ -6,21 +6,22 @@
   "backbone": "HDP",
   "T_truncation": 20,
   "K_inferred_total": 20,
-  "K_effective": 20,
+  "K_effective": 7,
+  "N_eff_topics": 2.8491,
   "K_ground_truth_classes": 16,
-  "f16_model_selection_adequacy": 4,
+  "f16_model_selection_adequacy": 9,
   "f2_c_v": 0.316251,
   "f14_mean_pairwise_jaccard": 0.021525,
-  "fit_seconds": 3.164,
+  "fit_seconds": 2.838,
   "D": 3520,
   "V": 230,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.759517,
+    0.080674,
+    0.045957,
+    0.033268,
+    0.018851
   ],
-  "generated_at": "2026-05-27T03:34:16Z",
+  "generated_at": "2026-06-09T06:39:09Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V7_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V7_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9375,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.626159,
   "f14_mean_pairwise_jaccard": 0.039572,
-  "fit_seconds": 1.481,
+  "fit_seconds": 1.363,
   "D": 3520,
   "V": 132,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.055781,
+    0.055746,
+    0.055302,
+    0.054733,
+    0.054413
   ],
-  "generated_at": "2026-05-27T03:34:18Z",
+  "generated_at": "2026-06-09T06:39:10Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V8_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V8_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 18.8041,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.21789,
   "f14_mean_pairwise_jaccard": 0.71882,
-  "fit_seconds": 1.75,
+  "fit_seconds": 2.205,
   "D": 3520,
   "V": 12,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.090322,
+    0.079467,
+    0.064495,
+    0.060991,
+    0.060595
   ],
-  "generated_at": "2026-05-27T03:34:19Z",
+  "generated_at": "2026-06-09T06:39:12Z",
   "builder": "build_v_sweep_hdp v0.1"
 }

--- a/data/derived/v_sweep/hdp_backbone/salinas-corrected_V9_uniform_Q8.json
+++ b/data/derived/v_sweep/hdp_backbone/salinas-corrected_V9_uniform_Q8.json
@@ -7,20 +7,21 @@
   "T_truncation": 20,
   "K_inferred_total": 20,
   "K_effective": 20,
+  "N_eff_topics": 19.9931,
   "K_ground_truth_classes": 16,
   "f16_model_selection_adequacy": 4,
   "f2_c_v": 0.315216,
   "f14_mean_pairwise_jaccard": 0.00871,
-  "fit_seconds": 1.138,
+  "fit_seconds": 1.343,
   "D": 3520,
   "V": 552,
-  "topic_mass_top5": [
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
+  "topic_prevalence_top5": [
+    0.051597,
+    0.051542,
+    0.05151,
+    0.051461,
+    0.051341
   ],
-  "generated_at": "2026-05-27T03:34:21Z",
+  "generated_at": "2026-06-09T06:39:14Z",
   "builder": "build_v_sweep_hdp v0.1"
 }


### PR DESCRIPTION
Follow-up to PR #806. The per-document hdp[doc] projection collapsed (degenerate K_eff=1 on several scenes); switched to the canonical HDP top-level stick prevalence (hdp_to_lda, topics >=1% corpus mass). Full sweep re-run 114/114; F-16 now varies 0-15. All derived JSON regenerated and served by the backend. Paired with paper PR #132.