### PR TITLE
fix(i18n): qualify F-7 axis help (asymmetric uncertainty coefficient, not symmetric NMI)

### DIFF
--- a/frontend/src/i18n/locales/en/pages.json
+++ b/frontend/src/i18n/locales/en/pages.json
@@ -1043,7 +1043,7 @@
         "picker_axis": "axis",
         "axis_help_f1": "classification macro-F1 (topic-routed soft, per-fold mean) — higher is better",
         "axis_help_f2": "topic-word coherence c_v — higher is better",
-        "axis_help_f7": "topic-to-label normalised mutual information — higher is better",
+        "axis_help_f7": "topic-to-label mutual information normalised by the label entropy, I(Ẑ;Y)/H(Y) — the asymmetric uncertainty coefficient (Rosenberg–Hirschberg completeness), not the symmetric NMI and not chance-corrected; higher is better",
         "axis_help_f14": "mean pairwise top-token Jaccard (repetitiveness) — lower is better",
         "axis_help_f18": "mean seed-matched topic cosine (reliability) — higher is better",
         "axis_help_f22": "counterfactual median L1 to flip argmax topic (robustness) — higher is better",

--- a/frontend/src/i18n/locales/es/pages.json
+++ b/frontend/src/i18n/locales/es/pages.json
@@ -1043,7 +1043,7 @@
         "picker_axis": "eje",
         "axis_help_f1": "macro-F1 de clasificación (topic-routed soft, media por fold) — más alto es mejor",
         "axis_help_f2": "coherencia tópico-palabra c_v — más alto es mejor",
-        "axis_help_f7": "información mutua normalizada tópico-etiqueta — más alto es mejor",
+        "axis_help_f7": "información mutua tópico-etiqueta normalizada por la entropía de la etiqueta, I(Ẑ;Y)/H(Y) — el coeficiente de incertidumbre asimétrico (completeness de Rosenberg–Hirschberg), no la NMI simétrica ni corregida por azar; más alto es mejor",
         "axis_help_f14": "Jaccard medio por pares de top-tokens (repetitividad) — más bajo es mejor",
         "axis_help_f18": "coseno medio de tópicos emparejados por semilla (fiabilidad) — más alto es mejor",
         "axis_help_f22": "L1 mediana contrafactual para cambiar el tópico argmax (robustez) — más alto es mejor",


### PR DESCRIPTION
Aligns the app F-7 axis definition with the manuscript correction: F-7 = I(Zhat;Y)/H(Y), the asymmetric uncertainty coefficient (completeness), not the symmetric NMI / not chance-corrected. Qualified axis_help_f7 EN+ES. Parity 1554/1554, build OK.